### PR TITLE
thingy with versions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -19,45 +19,23 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.1'
-          bundler-cache: true
-          cache-version: 0
-          working-directory: docs
-
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v4
-
-      - name: Build with Jekyll
-        working-directory: docs
-        run: |
-          gem install bundler
-          bundle install
-          bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
-        env:
-          JEKYLL_ENV: production
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: docs/_site
-
   deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,39 +1,18 @@
 # PolarSouls Documentation
 
-This directory contains the source files for the PolarSouls documentation website, built with Jekyll and hosted on GitHub Pages.
+This directory contains the source files for the PolarSouls documentation website, hosted on GitHub Pages.
 
 ## Documentation Structure
 
-- **index.md** - Home page with overview and navigation
-- **quick-start.md** - 8-step quick start guide
-- **installation.md** - Comprehensive installation guide
-- **configuration.md** - Complete configuration reference
-- **commands.md** - All commands with examples
-- **revival-system.md** - HRM features and revival mechanics
-- **troubleshooting.md** - Solutions to common issues
-- **faq.md** - Frequently asked questions
+The documentation is a **single-page HTML site** (`index.html`) with all content and navigation in one file.
 
-## Building Locally
+- **index.html** - Complete documentation (overview, quick start, installation, configuration, commands, revival system, troubleshooting, FAQ)
+- **styles.css** - All styling for the documentation site
+- **assets/** - SVG icons and other static assets
 
-To preview the documentation locally:
+## Viewing Locally
 
-1. Install Ruby and Bundler:
-   ```bash
-   gem install bundler
-   ```
-
-2. Install dependencies:
-   ```bash
-   cd docs
-   bundle install
-   ```
-
-3. Serve the site locally:
-   ```bash
-   bundle exec jekyll serve
-   ```
-
-4. Open your browser to `http://localhost:4000/PolarSouls-for-Hardcore/`
+To preview the documentation locally, simply open `docs/index.html` in any browser — no build step required.
 
 ## Deployment
 
@@ -41,52 +20,18 @@ The documentation is automatically deployed to GitHub Pages when changes are pus
 
 **Live URL:** https://polarmc-technologies.github.io/PolarSouls-for-Hardcore/
 
-## Theme
-
-The documentation uses the [Cayman theme](https://github.com/pages-themes/cayman) for GitHub Pages with the following plugins:
-- jekyll-seo-tag
-- jekyll-sitemap
-
 ## Contributing
 
 To contribute to the documentation:
 
-1. Edit the relevant `.md` files in this directory
-2. Test your changes locally using `bundle exec jekyll serve`
+1. Edit `index.html` (content) or `styles.css` (styling) directly
+2. Open `index.html` in a browser to verify your changes
 3. Submit a pull request with your changes
 
 Please ensure:
-- All pages have proper YAML front matter
-- Navigation links are updated if adding new pages
+- Navigation anchors stay in sync with section IDs in `index.html`
 - Code examples are properly formatted
-- Internal links work correctly
-
-## File Organization
-
-```
-docs/
-├── _config.yml           # Jekyll configuration
-├── Gemfile              # Ruby dependencies
-├── index.md             # Home page
-├── quick-start.md       # Quick start guide
-├── installation.md      # Installation guide
-├── configuration.md     # Configuration reference
-├── commands.md          # Commands reference
-├── revival-system.md    # Revival system guide
-├── troubleshooting.md   # Troubleshooting guide
-└── faq.md              # FAQ page
-```
-
-## Updating Documentation
-
-When updating the documentation:
-
-1. Keep the language clear and concise
-2. Use code blocks for configuration examples
-3. Include navigation links at the bottom of pages
-4. Update the table of contents if structure changes
-5. Test all code examples to ensure they work
-6. Maintain consistency with existing formatting
+- Both light and dark themes look correct (use the theme toggle button)
 
 ## Questions?
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,29 +4,6 @@ description: Comprehensive hardcore lives system plugin for Minecraft 1.21.X
 baseurl: "/PolarSouls-for-Hardcore"
 url: "https://polarmc-technologies.github.io"
 
-# Theme
-theme: jekyll-theme-cayman
-plugins:
-  - jekyll-seo-tag
-  - jekyll-sitemap
-
-# Navigation
-header_pages:
-  - index.md
-  - quick-start.md
-  - installation.md
-  - configuration.md
-  - commands.md
-  - revival-system.md
-  - troubleshooting.md
-  - faq.md
-
-# Settings
-markdown: kramdown
-kramdown:
-  input: GFM
-  syntax_highlighter: rouge
-
 # Exclude from processing
 exclude:
   - README.md


### PR DESCRIPTION
This pull request migrates the documentation site from a Jekyll-based, multi-file setup to a simplified, single-page static HTML site. The workflow for deploying documentation has been streamlined to remove Ruby/Jekyll dependencies, and documentation contribution instructions have been updated to reflect the new approach.

**Documentation structure and workflow simplification:**

* Converted documentation from multiple Markdown files and Jekyll configuration to a single `index.html` file with supporting `styles.css` and static assets, eliminating the need for Ruby, Bundler, and Jekyll. (`docs/README.md`, `docs/_config.yml`) [[1]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L3-R34) [[2]](diffhunk://#diff-f64371f310bcd3bbf6ead5827d929a4eb13b7516806d6658485a996e39eb2556L7-L29)
* Updated contribution guidelines to instruct editing `index.html` and previewing changes directly in a browser, removing all references to Jekyll build steps. (`docs/README.md`)
* Removed Jekyll theme, plugins, and navigation configuration from `_config.yml`, as they are no longer needed. (`docs/_config.yml`)

**Deployment workflow updates:**

* Simplified the GitHub Actions workflow by removing the Ruby/Jekyll build step and related dependencies, uploading the `docs` directory directly for deployment to GitHub Pages. (`.github/workflows/deploy-docs.yml`)