### PR TITLE
Implement head drop functionality and configuration options and auto build workflow

### DIFF
--- a/.github/workflows/build-plugin-release.yml
+++ b/.github/workflows/build-plugin-release.yml
@@ -55,9 +55,10 @@ jobs:
             fi
           fi
 
-          JAR_PATH="$(ls target/*.jar | grep -v 'sources.jar' | grep -v 'javadoc.jar' | grep -v 'original-' | head -n 1)"
+          # Always publish the shaded plugin artifact so runtime deps are bundled.
+          JAR_PATH="$(ls target/*-shaded.jar 2>/dev/null | head -n 1 || true)"
           if [[ -z "${JAR_PATH}" ]]; then
-            echo "No plugin jar found in target/."
+            echo "No shaded plugin jar found in target/ (expected *-shaded.jar)."
             exit 1
           fi
 

--- a/.github/workflows/build-plugin-release.yml
+++ b/.github/workflows/build-plugin-release.yml
@@ -1,0 +1,85 @@
+name: Build Plugin Jar And Tag Release
+
+'on':
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Optional tag name for manual runs (example: v2.1.2). Defaults to pom version tag."
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Build with Maven
+        run: mvn -B clean package
+
+      - name: Select plugin jar
+        id: package
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSION="$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)"
+          EXPECTED_TAG="v${VERSION}"
+
+          if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            TAG_NAME="${GITHUB_REF_NAME}"
+            if [[ "${TAG_NAME}" != "${EXPECTED_TAG}" ]]; then
+              echo "Tag '${TAG_NAME}' does not match pom version '${EXPECTED_TAG}'."
+              echo "Use a matching tag (example: ${EXPECTED_TAG})."
+              exit 1
+            fi
+          else
+            TAG_NAME="${{ inputs.release_tag }}"
+            if [[ -z "${TAG_NAME}" ]]; then
+              TAG_NAME="${EXPECTED_TAG}"
+            fi
+          fi
+
+          JAR_PATH="$(ls target/*.jar | grep -v 'sources.jar' | grep -v 'javadoc.jar' | grep -v 'original-' | head -n 1)"
+          if [[ -z "${JAR_PATH}" ]]; then
+            echo "No plugin jar found in target/."
+            exit 1
+          fi
+
+          JAR_NAME="$(basename "${JAR_PATH}")"
+
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "tag=${TAG_NAME}" >> "${GITHUB_OUTPUT}"
+          echo "jar=${JAR_PATH}" >> "${GITHUB_OUTPUT}"
+          echo "jar_name=${JAR_NAME}" >> "${GITHUB_OUTPUT}"
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugin-jar
+          path: ${{ steps.package.outputs.jar }}
+
+      - name: Create tag release with jar
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.package.outputs.tag }}
+          name: Build ${{ steps.package.outputs.version }} (${{ steps.package.outputs.tag }})
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+          files: ${{ steps.package.outputs.jar }}

--- a/README.md
+++ b/README.md
@@ -67,10 +67,16 @@ All modes work with all revival methods:
 Comes with a full revival system:
 
 ### Player Head Drops
-- When you lose all your lives, your head drops where you died
+- When you lose all your lives, your head spawns where you died
 - You get coords in chat so your team knows where to look
 - Heads are needed for the revival ritual
 - Can disable this in `config.yml` (`hrm.drop-heads: false`)
+
+**Head placement modes** (`hrm.head-place-as-block`):
+- **Block mode (default):** Head is placed as a permanent skull block. Scans upward from the death spot to find the first accessible air pocket above solid ground, so dying in lava places the head *above* the lava surface. Can't burn or despawn. Break the block to pick up the skull item, then use it in the revival structure as normal.
+- **Item entity mode:** Head drops as a normal item. Use `head-no-despawn: true` to prevent the 5-minute despawn and `head-fireproof: true` to make it survive lava/fire.
+
+**On revival** the plugin automatically removes all copies of the head from the world.
 
 ### Revival Ritual Structure
 Build a 3x3x3 beacon-ish structure to bring people back:

--- a/docs/revival-system.md
+++ b/docs/revival-system.md
@@ -376,55 +376,86 @@ Dead players' heads are central to the HRM revival system.
 
 ### Player Head Drops
 
-When a player loses all lives:
+When a player loses all lives, the plugin spawns their head near the death location. There are two modes for how this works, controlled by `hrm.head-place-as-block` in `config.yml`.
 
-1. Their player head **drops at the death location**
-2. The dead player receives a **message with coordinates**
-3. Teammates can collect the head
-4. Head is used in ritual structures or Revive Skull
+---
 
-### Death Location Messages
+#### Block Mode (`head-place-as-block: true`, default)
 
-Example message when you die:
+The head is placed as a **permanent skull block** in the world.
 
+- The plugin scans **upward** from the death Y coordinate to find the first open air block sitting on solid ground. If you die inside lava it emerges above the lava surface — always accessible.
+- The block persists forever. It can't burn, can't despawn, and can't be washed away by water.
+- Teammates **mine/break the block** to pick up the skull item as normal, then carry it to the revival structure.
+- On revival the plugin **removes the block automatically** (see Cleanup below).
+
+**Configuration:**
+```yaml
+hrm:
+  head-place-as-block: true
 ```
-💀 Death Location: X: 1234 Y: 64 Z: -5678
+
+---
+
+#### Item Entity Mode (`head-place-as-block: false`)
+
+The head is dropped as a standard **item entity** on the ground — the traditional Minecraft approach.
+
+Two extra options control its survival:
+
+| Option | What it does |
+|---|---|
+| `head-no-despawn: true` | Cancels the natural 5-minute despawn timer. The item stays until picked up. |
+| `head-fireproof: true` | Marks the item as invulnerable. Fire, lava, and explosions can't destroy it. |
+
+**Configuration:**
+```yaml
+hrm:
+  head-place-as-block: false
+  head-no-despawn: true    # item never despawns
+  head-fireproof: true     # item survives lava/fire
 ```
 
-This helps teammates find the dropped head.
+---
+
+### Head Cleanup on Revival
+
+When a player is revived (any method — ritual, skull, command, admin), the plugin **removes all copies of their head** from the world. This runs in two passes:
+
+**Pass 1 — Targeted removal (instant)**
+If the server placed the head as a block, it stored the exact location in memory. On revive it looks up those coordinates directly, force-loads the chunk if it isn't currently loaded, removes the block, and releases the chunk. This is always correct regardless of whether the chunk is loaded or not.
+
+> **Note:** The location map is in-memory only. If the server restarts between a player's death and their revival, Pass 1 has no data and Pass 2 acts as the safety net.
+
+**Pass 2 — Tick-spread scan (fallback)**
+Scans across all worlds to catch anything Pass 1 missed: item entities, item frames, player inventories, ender chests, shulker boxes, and any stale skull blocks left from before location tracking was introduced. Work is spread across multiple server ticks to avoid lag spikes on large servers.
+
+In item-entity mode the chunk block scan is skipped entirely (no skull blocks to find), making cleanup faster.
+
+---
 
 ### Wearing Head Effects
 
 When a living player **wears a dead player's head**, they receive:
 
-- ⚡ **Speed II** effect (faster movement)
-- 👁️ **Night Vision** effect (see in darkness)
-
-This gives a tactical advantage while carrying heads to the revival structure.
+- **Speed II** — faster movement to the revival structure
+- **Night Vision** — see in darkness en route
 
 **Configuration:**
-
 ```yaml
 hrm:
-  head-wearing-effects: true     # Enable/disable effects
+  head-wearing-effects: true
 ```
 
-### Getting Heads Without Death
+### Getting Heads Without a Physical Drop
 
-**Using the Revive Skull:**
+If the original head was lost, burned, or simply too far away, use the **Revive Skull** to get a fresh copy:
 
 1. Right-click a Revive Skull
-2. Select a dead player from the menu
-3. Receive their head
+2. Select the dead player from the menu
+3. Receive their head instantly
 
-This is useful if the original head was lost or destroyed.
-
-### Head Preservation
-
-- ⏱️ Heads stay on ground for 5 minutes by default (Minecraft setting)
-- 💾 Data persists in database permanently
-- Can use Revive Skull to get another copy anytime
-- Same player can be revived multiple times
+The database always holds a permanent record of which players are dead, so a new head can be obtained at any time regardless of what happened to the original.
 
 ---
 
@@ -447,6 +478,9 @@ hrm:
   head-wearing-effects: true    # Speed/night vision on heads
   detect-hrm-revive: true       # Auto-detect completed structures
   leave-structure-base: true    # Keep structure after revival
+  head-place-as-block: true     # Place head as permanent block (recommended)
+  head-no-despawn: true         # (item-entity mode) head item never despawns
+  head-fireproof: true          # (item-entity mode) head item survives fire/lava
 ```
 
 ### Lives on Revival

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.polarnl</groupId>
     <artifactId>PolarSouls</artifactId>
-    <version>2.1.2</version>
+    <version>2.2.1</version>
     <packaging>jar</packaging>
 
     <name>PolarSouls</name>

--- a/src/main/java/org/polarnl/polarsouls/PolarSouls.java
+++ b/src/main/java/org/polarnl/polarsouls/PolarSouls.java
@@ -541,6 +541,18 @@ public final class PolarSouls extends JavaPlugin implements Listener {
         return hrmEnabled && hrmReviveSkullRecipe;
     }
 
+    public boolean isHrmHeadPlaceAsBlock() {
+        return hrmHeadPlaceAsBlock;
+    }
+
+    public boolean isHrmHeadNoDespawn() {
+        return hrmHeadNoDespawn;
+    }
+
+    public boolean isHrmHeadFireproof() {
+        return hrmHeadFireproof;
+    }
+
     public boolean isLimboOpSecurityEnabled() {
         return limboOpSecurityEnabled;
     }

--- a/src/main/java/org/polarnl/polarsouls/PolarSouls.java
+++ b/src/main/java/org/polarnl/polarsouls/PolarSouls.java
@@ -89,6 +89,9 @@ public final class PolarSouls extends JavaPlugin implements Listener {
     private boolean hrmLeaveStructureBase;
     private boolean hrmHeadEffects;
     private boolean hrmReviveSkullRecipe;
+    private boolean hrmHeadPlaceAsBlock;
+    private boolean hrmHeadNoDespawn;
+    private boolean hrmHeadFireproof;
     private boolean hardcoreHearts;
     private boolean limboOpSecurityEnabled;
     private Set<String> limboTrustedAdmins;
@@ -326,6 +329,9 @@ public final class PolarSouls extends JavaPlugin implements Listener {
         hrmLeaveStructureBase = cfg.getBoolean("hrm.leave-structure-base", true);
         hrmHeadEffects        = cfg.getBoolean("hrm.head-wearing-effects", true);
         hrmReviveSkullRecipe  = cfg.getBoolean("hrm.revive-skull-recipe", true);
+        hrmHeadPlaceAsBlock   = cfg.getBoolean("hrm.head-place-as-block", true);
+        hrmHeadNoDespawn      = cfg.getBoolean("hrm.head-no-despawn", true);
+        hrmHeadFireproof      = cfg.getBoolean("hrm.head-fireproof", true);
 
         if (isLimboServer) {
             loadLimboSpawn();

--- a/src/main/java/org/polarnl/polarsouls/command/AdminCommand.java
+++ b/src/main/java/org/polarnl/polarsouls/command/AdminCommand.java
@@ -58,12 +58,13 @@ public class AdminCommand implements CommandExecutor, TabCompleter {
     private final Map<String, PendingGrace> pendingGraceConfirmations = new ConcurrentHashMap<>();
 
     /**
-     * Stores pending grace confirmations so we can ask before overwriting.
-     * @param targetUuid The UUID of the player whose grace is being set
-     * @param targetName The username of the target player
-     * @param requestedMillis The requested grace period duration in milliseconds
-     * @param existingGraceUntil The existing grace_until timestamp (if any)
-     * @param createdAt Timestamp when this pending confirmation was created (for TTL cleanup)
+     * stores pending grace confirmation data used before overwriting an existing grace period.
+     *
+     * @param targetUuid the UUID of the player whose grace is being set
+     * @param targetName the username of the target player
+     * @param requestedMillis the requested grace duration in milliseconds
+     * @param existingGraceUntil the existing grace_until timestamp, if present
+     * @param createdAt when this pending confirmation was created (for TTL cleanup)
      */
     private record PendingGrace(UUID targetUuid, String targetName, long requestedMillis, long existingGraceUntil, long createdAt) {}
 
@@ -75,8 +76,8 @@ public class AdminCommand implements CommandExecutor, TabCompleter {
     }
 
     /**
-     * Generate a consistent key for pending grace confirmations.
-     * Uses a stable identifier to avoid key changes from proxy/plugin wrappers.
+     * generates a stable key for pending grace confirmations.
+     * uses sender UUID for players and name for non-player senders.
      */
     private String getConfirmationKey(CommandSender sender) {
         if (sender instanceof Player player) {
@@ -89,7 +90,7 @@ public class AdminCommand implements CommandExecutor, TabCompleter {
         }
     }
     /**
-     * Remove pending confirmations older than 5 minutes to prevent memory leaks.
+     * removes pending confirmations older than 5 minutes.
      */
     private void cleanupStalePendingConfirmations() {
         long now = System.currentTimeMillis();

--- a/src/main/java/org/polarnl/polarsouls/database/DatabaseManager.java
+++ b/src/main/java/org/polarnl/polarsouls/database/DatabaseManager.java
@@ -129,11 +129,11 @@ public class DatabaseManager {
     }
 
     /**
-     * Ensure a column exists in the table. If it already exists, the error is silently ignored.
+     * ensures a column exists in the table, ignoring duplicate-column errors.
      *
-     * @param conn       Database connection
-     * @param columnName Name of the column to add
-     * @param definition SQL definition of the column (e.g., "BIGINT NOT NULL DEFAULT 0")
+     * @param conn database connection
+     * @param columnName name of the column to add
+     * @param definition SQL definition of the column (for example, "BIGINT NOT NULL DEFAULT 0")
      */
     private void ensureColumn(Connection conn, String columnName, String definition) {
         String sql = "ALTER TABLE " + tableName + " ADD COLUMN " + columnName + " " + definition;
@@ -360,10 +360,8 @@ public class DatabaseManager {
     }
 
     /**
-     * Manually invalidate the death status cache for a player.
-     * This should be called if death status changes through non-standard means
-     * (e.g., direct database manipulation, external tools, etc.).
-     * Note: savePlayer(), revivePlayer(), and setLives() already invalidate the cache.
+     * manually invalidates a player's death status cache entry.
+     * use this when external changes bypass savePlayer(), revivePlayer(), or setLives().
      */
     public void invalidateDeathStatusCache(UUID uuid) {
         deathStatusCache.remove(uuid);

--- a/src/main/java/org/polarnl/polarsouls/hrm/HeadDropListener.java
+++ b/src/main/java/org/polarnl/polarsouls/hrm/HeadDropListener.java
@@ -13,7 +13,9 @@ import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.Tag;
 import org.bukkit.World;
+import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
+import org.bukkit.block.Skull;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.Player;
@@ -84,14 +86,20 @@ public class HeadDropListener implements Listener {
                     }
                     return;
                 }
-                // Drop head on main thread
+                // Place head as a block on main thread so it never burns or despawns
                 Bukkit.getScheduler().runTask(plugin, () -> {
-                    ItemStack head = createPlayerHead(player);
-                    world.dropItemNaturally(deathLoc, head);
-                    if (plugin.isDebugMode()) {
-                        plugin.debug("Dropped " + player.getName() + "'s head at "
-                                + deathLoc.getBlockX() + ", " + deathLoc.getBlockY()
-                                + ", " + deathLoc.getBlockZ());
+                    Block block = findSuitableBlock(world, deathLoc);
+                    if (block != null) {
+                        block.setType(Material.PLAYER_HEAD, false);
+                        Skull skull = (Skull) block.getState();
+                        skull.setOwningPlayer(player);
+                        skull.update(true, false);
+                        if (plugin.isDebugMode()) {
+                            plugin.debug("Placed " + player.getName() + "'s head block at "
+                                    + block.getX() + ", " + block.getY() + ", " + block.getZ());
+                        }
+                    } else if (plugin.isDebugMode()) {
+                        plugin.debug("No suitable block found to place " + player.getName() + "'s head.");
                     }
                 });
             }, 10L); // 0.5s delay because idfk it feels good
@@ -245,6 +253,13 @@ public class HeadDropListener implements Listener {
                                 if (state instanceof InventoryHolder holder) {
                                     removedCount.addAndGet(removeFromInventory(holder.getInventory(), ownerUuid));
                                 }
+                                if (state instanceof Skull skull) {
+                                    OfflinePlayer skullOwner = skull.getOwningPlayer();
+                                    if (skullOwner != null && skullOwner.getUniqueId().equals(ownerUuid)) {
+                                        skull.getBlock().setType(Material.AIR);
+                                        removedCount.incrementAndGet();
+                                    }
+                                }
                             }
                         }
                         chunkIndex++;
@@ -333,6 +348,17 @@ public class HeadDropListener implements Listener {
 
     private static boolean isShulkerBox(Material type) {
         return Tag.SHULKER_BOXES.isTagged(type);
+    }
+
+    private static Block findSuitableBlock(World world, Location loc) {
+        int x = loc.getBlockX(), y = loc.getBlockY(), z = loc.getBlockZ();
+        for (int dy : new int[]{0, 1, -1}) {
+            Block b = world.getBlockAt(x, y + dy, z);
+            if (b.isPassable()) {
+                return b;
+            }
+        }
+        return null;
     }
 
     private static boolean isOwnedHead(ItemStack stack, UUID ownerUuid) {

--- a/src/main/java/org/polarnl/polarsouls/hrm/HeadDropListener.java
+++ b/src/main/java/org/polarnl/polarsouls/hrm/HeadDropListener.java
@@ -162,22 +162,30 @@ public class HeadDropListener implements Listener {
         return head;
     }
 
-    // Removes all of a player's heads from existence across all worlds
-    // This operation is spread across multiple ticks to prevent server lag on large servers
-    // It's only called when a player is revived, not on every death
+    // Removes every copy of a player's head from the world when they are revived.
+    // Called once per revive, never on death.
     //
-    // IMPORTANT: This method schedules work across multiple ticks to avoid lag spikes
-    // Multi-tick approach prevents server freezing on large servers with many chunks/entities/players
+    // Two-pass design:
     //
-    // Performance considerations:
-    // - Processes a limited number of items per tick (configurable via batch sizes)
-    // - Spreads work across multiple server ticks to maintain server responsiveness
-    // - Total cleanup time: ~1-2 seconds on large servers vs single-tick lag spike
-    // - Alternative approaches considered:
-    //   1. Track head locations on drop (memory overhead, complex state management)
-    //   2. Limit cleanup to specific radius (heads could remain far from spawn)
-    //   3. Single-tick scan (causes lag spikes, rejected based on PR feedback)
-    // - Current approach prioritizes server performance and responsiveness
+    //  Pass 1 – Targeted removal (always O(n) with n = number of placed head blocks)
+    //   headBlockLocations stores the Location of every skull block placed at death.
+    //   On revive we look up those exact coords, force-load the chunk if necessary,
+    //   verify the block still belongs to this player, set it to AIR, then release
+    //   the chunk again if we had to load it.  This is instant and chunk-safe.
+    //   Limitation: the map is in-memory only.  If the server restarts between death
+    //   and revival the entries are lost and pass 2 acts as the safety net.
+    //
+    //  Pass 2 – Tick-spread fallback scan
+    //   Catches anything pass 1 missed: item entities (item-entity mode), item frames,
+    //   player/ender-chest inventories, shulker boxes, and stale skull blocks left by
+    //   older plugin versions that lacked location tracking.
+    //   Work is spread across multiple server ticks to avoid lag spikes:
+    //     • Item entities  – 50 per tick
+    //     • Item frames    – 50 per tick
+    //     • Chunks (block scan, block-mode only) – 10 per tick
+    //     • Online players – 5 per tick
+    //   The chunk scan phase is skipped entirely when head-place-as-block is false
+    //   because in item-entity mode there are no skull blocks to find in chunks.
     public void removeDroppedHeads(UUID ownerUuid) {
         // --- Targeted removal for block-mode heads ---
         // Remove known skull block locations first.  We force-load the chunk if
@@ -212,9 +220,12 @@ public class HeadDropListener implements Listener {
             });
         }
 
-        // --- Fallback: tick-spread scan across all loaded chunks/entities ---
-        // Catches anything the targeted removal missed (e.g. heads placed by an
-        // older version, or item entities / item frames placed by players).
+        // --- Pass 2: tick-spread fallback scan ---
+        // In block-mode the chunk scan is necessary as a safety net for stale blocks
+        // (server restart between death and revive loses the tracked location).
+        // In item-entity mode there are never any skull blocks to find, so we skip
+        // the whole chunk phase and save a significant amount of per-tick work.
+        final boolean scanChunksForBlocks = plugin.isHrmHeadPlaceAsBlock();
         new BukkitRunnable() {
             private final List<World> worlds = new ArrayList<>(Bukkit.getWorlds());
             private final List<Player> players = new ArrayList<>(Bukkit.getOnlinePlayers());
@@ -231,7 +242,7 @@ public class HeadDropListener implements Listener {
             private boolean processingChunks = false;
             private boolean processingPlayers = false;
 
-            // Batch sizes to process per tick (tunable for performance)
+            // Batch sizes to process per tick
             private final int ENTITIES_PER_TICK = 50;
             private final int CHUNKS_PER_TICK = 10;
             private final int PLAYERS_PER_TICK = 5;
@@ -276,9 +287,13 @@ public class HeadDropListener implements Listener {
                 // Process item frames from worlds
                 if (processingItemFrames) {
                     if (worldIndex >= worlds.size()) {
-                        // Done with item frames, move to chunks
                         processingItemFrames = false;
-                        processingChunks = true;
+                        // Skip chunk scan entirely in item-entity mode — no skull blocks exist
+                        if (scanChunksForBlocks) {
+                            processingChunks = true;
+                        } else {
+                            processingPlayers = true;
+                        }
                         worldIndex = 0;
                         return;
                     }

--- a/src/main/java/org/polarnl/polarsouls/hrm/HeadDropListener.java
+++ b/src/main/java/org/polarnl/polarsouls/hrm/HeadDropListener.java
@@ -22,6 +22,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.ItemDespawnEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
@@ -86,24 +87,55 @@ public class HeadDropListener implements Listener {
                     }
                     return;
                 }
-                // Place head as a block on main thread so it never burns or despawns
+                // Place / drop the head on the main thread
                 Bukkit.getScheduler().runTask(plugin, () -> {
-                    Block block = findSuitableBlock(world, deathLoc);
-                    if (block != null) {
-                        block.setType(Material.PLAYER_HEAD, false);
-                        Skull skull = (Skull) block.getState();
-                        skull.setOwningPlayer(player);
-                        skull.update(true, false);
-                        if (plugin.isDebugMode()) {
-                            plugin.debug("Placed " + player.getName() + "'s head block at "
-                                    + block.getX() + ", " + block.getY() + ", " + block.getZ());
+                    if (plugin.isHrmHeadPlaceAsBlock()) {
+                        // Place as a permanent block — never burns, never despawns
+                        Block block = findSuitableBlock(world, deathLoc);
+                        if (block != null) {
+                            block.setType(Material.PLAYER_HEAD, false);
+                            Skull skull = (Skull) block.getState();
+                            skull.setOwningPlayer(player);
+                            skull.update(true, false);
+                            if (plugin.isDebugMode()) {
+                                plugin.debug("Placed " + player.getName() + "'s head block at "
+                                        + block.getX() + ", " + block.getY() + ", " + block.getZ());
+                            }
+                        } else if (plugin.isDebugMode()) {
+                            plugin.debug("No suitable block found to place " + player.getName() + "'s head.");
                         }
-                    } else if (plugin.isDebugMode()) {
-                        plugin.debug("No suitable block found to place " + player.getName() + "'s head.");
+                    } else {
+                        // Drop as item entity
+                        ItemStack head = createPlayerHead(player);
+                        Item item = world.dropItemNaturally(deathLoc, head);
+                        if (plugin.isHrmHeadFireproof()) {
+                            item.setInvulnerable(true);
+                        }
+                        if (plugin.isDebugMode()) {
+                            plugin.debug("Dropped " + player.getName() + "'s head at "
+                                    + deathLoc.getBlockX() + ", " + deathLoc.getBlockY()
+                                    + ", " + deathLoc.getBlockZ()
+                                    + (plugin.isHrmHeadFireproof() ? " (fireproof)" : "")
+                                    + (plugin.isHrmHeadNoDespawn() ? " (no-despawn)" : ""));
+                        }
                     }
                 });
             }, 10L); // 0.5s delay because why not it would break otherwise
         }
+    }
+
+    @EventHandler
+    public void onItemDespawn(ItemDespawnEvent event) {
+        if (!plugin.isHrmDropHeads() || plugin.isHrmHeadPlaceAsBlock() || !plugin.isHrmHeadNoDespawn()) return;
+        if (isOwnedPlayerHead(event.getEntity().getItemStack())) {
+            event.setCancelled(true);
+        }
+    }
+
+    private static boolean isOwnedPlayerHead(ItemStack stack) {
+        if (stack == null || stack.getType() != Material.PLAYER_HEAD) return false;
+        if (!(stack.getItemMeta() instanceof SkullMeta skullMeta)) return false;
+        return skullMeta.getOwningPlayer() != null;
     }
 
     public static ItemStack createPlayerHead(Player player) {

--- a/src/main/java/org/polarnl/polarsouls/hrm/HeadDropListener.java
+++ b/src/main/java/org/polarnl/polarsouls/hrm/HeadDropListener.java
@@ -383,14 +383,36 @@ public class HeadDropListener implements Listener {
     }
 
     private static Block findSuitableBlock(World world, Location loc) {
-        int x = loc.getBlockX(), y = loc.getBlockY(), z = loc.getBlockZ();
-        for (int dy : new int[]{0, 1, -1}) {
-            Block b = world.getBlockAt(x, y + dy, z);
-            if (b.isPassable()) {
-                return b;
+        int x = loc.getBlockX();
+        int startY = loc.getBlockY();
+        int z = loc.getBlockZ();
+        int maxY = Math.min(startY + 64, world.getMaxHeight() - 1);
+
+        // Preferred: first air block sitting on top of a solid surface, scanning upward.
+        // This naturally rises above lava/water pools to the nearest accessible floor/surface.
+        for (int y = startY; y <= maxY; y++) {
+            Block candidate = world.getBlockAt(x, y, z);
+            if (!isAirBlock(candidate)) continue;
+            Block below = world.getBlockAt(x, y - 1, z);
+            if (below.getType().isSolid()) {
+                return candidate;
             }
         }
+
+        // Fallback: any air block going upward (e.g. open cave ceiling, or hovering above lava)
+        for (int y = startY; y <= maxY; y++) {
+            Block candidate = world.getBlockAt(x, y, z);
+            if (isAirBlock(candidate)) {
+                return candidate;
+            }
+        }
+
         return null;
+    }
+
+    private static boolean isAirBlock(Block b) {
+        Material t = b.getType();
+        return t == Material.AIR || t == Material.CAVE_AIR || t == Material.VOID_AIR;
     }
 
     private static boolean isOwnedHead(ItemStack stack, UUID ownerUuid) {

--- a/src/main/java/org/polarnl/polarsouls/hrm/HeadDropListener.java
+++ b/src/main/java/org/polarnl/polarsouls/hrm/HeadDropListener.java
@@ -102,7 +102,7 @@ public class HeadDropListener implements Listener {
                         plugin.debug("No suitable block found to place " + player.getName() + "'s head.");
                     }
                 });
-            }, 10L); // 0.5s delay because idfk it feels good
+            }, 10L); // 0.5s delay because why not it would break otherwise
         }
     }
 

--- a/src/main/java/org/polarnl/polarsouls/hrm/HeadDropListener.java
+++ b/src/main/java/org/polarnl/polarsouls/hrm/HeadDropListener.java
@@ -111,23 +111,17 @@ public class HeadDropListener implements Listener {
                                 plugin.debug("Placed " + player.getName() + "'s head block at "
                                         + block.getX() + ", " + block.getY() + ", " + block.getZ());
                             }
-                        } else if (plugin.isDebugMode()) {
-                            plugin.debug("No suitable block found to place " + player.getName() + "'s head.");
+                        } else {
+                            // Fallback so the head is never lost when no block can be placed.
+                            dropHeadItem(world, deathLoc, player);
+                            if (plugin.isDebugMode()) {
+                                plugin.debug("No suitable block found to place " + player.getName()
+                                        + "'s head; fell back to item drop.");
+                            }
                         }
                     } else {
                         // Drop as item entity
-                        ItemStack head = createPlayerHead(player);
-                        Item item = world.dropItemNaturally(deathLoc, head);
-                        if (plugin.isHrmHeadFireproof()) {
-                            item.setInvulnerable(true);
-                        }
-                        if (plugin.isDebugMode()) {
-                            plugin.debug("Dropped " + player.getName() + "'s head at "
-                                    + deathLoc.getBlockX() + ", " + deathLoc.getBlockY()
-                                    + ", " + deathLoc.getBlockZ()
-                                    + (plugin.isHrmHeadFireproof() ? " (fireproof)" : "")
-                                    + (plugin.isHrmHeadNoDespawn() ? " (no-despawn)" : ""));
-                        }
+                        dropHeadItem(world, deathLoc, player);
                     }
                 });
             }, 10L); // 0.5s delay because why not it would break otherwise
@@ -137,15 +131,36 @@ public class HeadDropListener implements Listener {
     @EventHandler
     public void onItemDespawn(ItemDespawnEvent event) {
         if (!plugin.isHrmDropHeads() || plugin.isHrmHeadPlaceAsBlock() || !plugin.isHrmHeadNoDespawn()) return;
-        if (isOwnedPlayerHead(event.getEntity().getItemStack())) {
+        UUID ownerUuid = getHeadOwnerUuid(event.getEntity().getItemStack());
+        if (ownerUuid == null) return;
+
+        PlayerData data = db.getPlayer(ownerUuid);
+        if (data != null && data.isDead()) {
             event.setCancelled(true);
         }
     }
 
-    private static boolean isOwnedPlayerHead(ItemStack stack) {
-        if (stack == null || stack.getType() != Material.PLAYER_HEAD) return false;
-        if (!(stack.getItemMeta() instanceof SkullMeta skullMeta)) return false;
-        return skullMeta.getOwningPlayer() != null;
+    private UUID getHeadOwnerUuid(ItemStack stack) {
+        if (stack == null || stack.getType() != Material.PLAYER_HEAD) return null;
+        if (!(stack.getItemMeta() instanceof SkullMeta skullMeta)) return null;
+        OfflinePlayer owner = skullMeta.getOwningPlayer();
+        if (owner == null) return null;
+        return owner.getUniqueId();
+    }
+
+    private void dropHeadItem(World world, Location deathLoc, Player player) {
+        ItemStack head = createPlayerHead(player);
+        Item item = world.dropItemNaturally(deathLoc, head);
+        if (plugin.isHrmHeadFireproof()) {
+            item.setInvulnerable(true);
+        }
+        if (plugin.isDebugMode()) {
+            plugin.debug("Dropped " + player.getName() + "'s head at "
+                    + deathLoc.getBlockX() + ", " + deathLoc.getBlockY()
+                    + ", " + deathLoc.getBlockZ()
+                    + (plugin.isHrmHeadFireproof() ? " (fireproof)" : "")
+                    + (plugin.isHrmHeadNoDespawn() ? " (no-despawn)" : ""));
+        }
     }
 
     public static ItemStack createPlayerHead(Player player) {

--- a/src/main/java/org/polarnl/polarsouls/hrm/HeadDropListener.java
+++ b/src/main/java/org/polarnl/polarsouls/hrm/HeadDropListener.java
@@ -2,7 +2,9 @@ package org.polarnl.polarsouls.hrm;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.bukkit.Bukkit;
@@ -43,6 +45,9 @@ public class HeadDropListener implements Listener {
 
     private final PolarSouls plugin;
     private final DatabaseManager db;
+    // Tracks locations of skull blocks placed on death so cleanup can remove them
+    // directly, even if their chunk is unloaded at revive time.
+    private final Map<UUID, List<Location>> headBlockLocations = new ConcurrentHashMap<>();
 
     public HeadDropListener(PolarSouls plugin) {
         this.plugin = plugin;
@@ -97,6 +102,11 @@ public class HeadDropListener implements Listener {
                             Skull skull = (Skull) block.getState();
                             skull.setOwningPlayer(player);
                             skull.update(true, false);
+                            // Remember this location so cleanup can find it even
+                            // if the chunk gets unloaded before the player is revived
+                            headBlockLocations
+                                    .computeIfAbsent(player.getUniqueId(), k -> new ArrayList<>())
+                                    .add(block.getLocation());
                             if (plugin.isDebugMode()) {
                                 plugin.debug("Placed " + player.getName() + "'s head block at "
                                         + block.getX() + ", " + block.getY() + ", " + block.getZ());
@@ -169,6 +179,42 @@ public class HeadDropListener implements Listener {
     //   3. Single-tick scan (causes lag spikes, rejected based on PR feedback)
     // - Current approach prioritizes server performance and responsiveness
     public void removeDroppedHeads(UUID ownerUuid) {
+        // --- Targeted removal for block-mode heads ---
+        // Remove known skull block locations first.  We force-load the chunk if
+        // needed so this works even when the chunk is currently unloaded.
+        List<Location> knownLocations = headBlockLocations.remove(ownerUuid);
+        if (knownLocations != null) {
+            Bukkit.getScheduler().runTask(plugin, () -> {
+                for (Location loc : knownLocations) {
+                    World w = loc.getWorld();
+                    if (w == null) continue;
+                    boolean wasLoaded = w.isChunkLoaded(loc.getBlockX() >> 4, loc.getBlockZ() >> 4);
+                    // getBlockAt force-loads the chunk if not already loaded
+                    Block b = w.getBlockAt(loc);
+                    if (b.getType() == Material.PLAYER_HEAD || b.getType() == Material.PLAYER_WALL_HEAD) {
+                        BlockState state = b.getState();
+                        if (state instanceof Skull skull) {
+                            OfflinePlayer owner = skull.getOwningPlayer();
+                            if (owner != null && owner.getUniqueId().equals(ownerUuid)) {
+                                b.setType(Material.AIR);
+                                if (plugin.isDebugMode()) {
+                                    plugin.debug("Removed tracked head block for " + ownerUuid
+                                            + " at " + b.getX() + ", " + b.getY() + ", " + b.getZ());
+                                }
+                            }
+                        }
+                    }
+                    // Unload the chunk again if we loaded it just for cleanup
+                    if (!wasLoaded) {
+                        w.unloadChunkRequest(loc.getBlockX() >> 4, loc.getBlockZ() >> 4);
+                    }
+                }
+            });
+        }
+
+        // --- Fallback: tick-spread scan across all loaded chunks/entities ---
+        // Catches anything the targeted removal missed (e.g. heads placed by an
+        // older version, or item entities / item frames placed by players).
         new BukkitRunnable() {
             private final List<World> worlds = new ArrayList<>(Bukkit.getWorlds());
             private final List<Player> players = new ArrayList<>(Bukkit.getOnlinePlayers());

--- a/src/main/java/org/polarnl/polarsouls/listener/LimboServerListener.java
+++ b/src/main/java/org/polarnl/polarsouls/listener/LimboServerListener.java
@@ -33,7 +33,7 @@ public class LimboServerListener implements Listener {
     }
     
     /**
-     * Refresh cached limbo spawn (call on config reload or spawn change)
+     * refreshes the cached limbo spawn location (call on config reload or spawn change).
      */
     public void refreshLimboSpawnCache() {
         this.cachedLimboSpawn = plugin.getLimboSpawn();

--- a/src/main/java/org/polarnl/polarsouls/listener/MainServerListener.java
+++ b/src/main/java/org/polarnl/polarsouls/listener/MainServerListener.java
@@ -54,7 +54,7 @@ public class MainServerListener implements Listener {
     }
     
     /**
-     * Refresh cached config values (call on config reload)
+     * refreshes cached config values (call on config reload).
      */
     public void refreshConfigCache() {
         this.cachedDeathMode = plugin.getDeathMode();
@@ -458,11 +458,9 @@ public class MainServerListener implements Listener {
     }
 
     /**
-     * Cancel any pending hybrid transfer task for the given player.
-     * This should be called when a player is revived or their death state changes
-     * to prevent them from being unexpectedly sent to Limbo.
+     * cancels any pending hybrid transfer task for the given player.
      *
-     * @param uuid The UUID of the player whose hybrid transfer should be cancelled
+     * @param uuid the UUID of the player
      */
     public void cancelHybridTransfer(UUID uuid) {
         BukkitTask task = hybridPendingTransfers.remove(uuid);
@@ -473,12 +471,10 @@ public class MainServerListener implements Listener {
     }
 
     /**
-     * Register a hybrid transfer task for the given player.
-     * This allows the task to be properly tracked and cancelled if the player
-     * is revived or their death state changes before the timeout expires.
+     * registers a hybrid transfer task for later cancellation or replacement.
      *
-     * @param uuid The UUID of the player
-     * @param task The scheduled task that will send the player to Limbo
+     * @param uuid the UUID of the player
+     * @param task the scheduled transfer task
      */
     public void registerHybridTransfer(UUID uuid, BukkitTask task) {
         // Cancel any existing task first

--- a/src/main/java/org/polarnl/polarsouls/util/CommandUtil.java
+++ b/src/main/java/org/polarnl/polarsouls/util/CommandUtil.java
@@ -2,9 +2,6 @@ package org.polarnl.polarsouls.util;
 
 import org.bukkit.command.CommandSender;
 
-/**
- * Utility class for common command operations.
- */
 public final class CommandUtil {
 
     private CommandUtil() {
@@ -12,11 +9,11 @@ public final class CommandUtil {
     }
 
     /**
-     * Check if sender has the required permission and send error message if not.
+     * checks whether the sender has a permission, sending the default deny message when missing.
      *
-     * @param sender     The command sender
-     * @param permission The permission node to check
-     * @return true if sender has permission, false otherwise
+     * @param sender the command sender
+     * @param permission the permission node to check
+     * @return true when allowed
      */
     public static boolean checkPermission(CommandSender sender, String permission) {
         if (!sender.hasPermission(permission)) {
@@ -27,12 +24,12 @@ public final class CommandUtil {
     }
 
     /**
-     * Check if sender has the required permission and send custom error message if not.
+     * checks whether the sender has a permission, sending a custom deny message when missing.
      *
-     * @param sender     The command sender
-     * @param permission The permission node to check
-     * @param message    The error message to send if permission check fails
-     * @return true if sender has permission, false otherwise
+     * @param sender the command sender
+     * @param permission the permission node to check
+     * @param message the message to send when denied
+     * @return true when allowed
      */
     public static boolean checkPermission(CommandSender sender, String permission, String message) {
         if (!sender.hasPermission(permission)) {

--- a/src/main/java/org/polarnl/polarsouls/util/PermissionUtil.java
+++ b/src/main/java/org/polarnl/polarsouls/util/PermissionUtil.java
@@ -7,9 +7,6 @@ import org.bukkit.entity.Player;
 
 import org.polarnl.polarsouls.PolarSouls;
 
-/**
- * Utility class for permission-related operations.
- */
 public final class PermissionUtil {
 
     private PermissionUtil() {
@@ -17,15 +14,11 @@ public final class PermissionUtil {
     }
 
     /**
-     * Check if a command sender should be blocked from executing admin/revive commands
-     * due to Limbo-only OP security restrictions.
-     * 
-     * This security check prevents users who have OP status only on the Limbo server
-     * from executing privileged commands like /revive and /psadmin.
-     * 
-     * @param sender The command sender to check
-     * @param plugin The plugin instance
-     * @return true if the sender should be blocked, false if allowed
+     * checks whether a sender should be blocked by limbo-only OP security rules.
+     *
+     * @param sender the command sender to check
+     * @param plugin the plugin instance
+     * @return true when the sender should be blocked
      */
     public static boolean isBlockedByLimboOpSecurity(CommandSender sender, PolarSouls plugin) {
         // If security check is disabled, allow all
@@ -72,9 +65,9 @@ public final class PermissionUtil {
     }
 
     /**
-     * Send a security block message to the command sender.
-     * 
-     * @param sender The command sender to send the message to
+     * sends the limbo OP security block message.
+     *
+     * @param sender the command sender
      */
     public static void sendSecurityBlockMessage(CommandSender sender) {
         sender.sendMessage(MessageUtil.colorize("&cSecurity Error: On the Limbo server, OP status cannot be used to execute this command."));

--- a/src/main/java/org/polarnl/polarsouls/util/PlayerRevivalUtil.java
+++ b/src/main/java/org/polarnl/polarsouls/util/PlayerRevivalUtil.java
@@ -6,9 +6,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
 
-/**
- * Utility class for player revival operations.
- */
 public final class PlayerRevivalUtil {
 
     private PlayerRevivalUtil() {
@@ -16,11 +13,10 @@ public final class PlayerRevivalUtil {
     }
 
     /**
-     * Restore an online spectator player to survival mode and optionally transfer to main server.
-     * This method handles the restoration of a dead player back to survival mode.
+     * restores an online spectator to survival and optionally transfers them from limbo.
      *
-     * @param plugin The PolarSouls plugin instance
-     * @param data   The player data containing UUID and other information
+     * @param plugin the PolarSouls plugin instance
+     * @param data the player data
      */
     public static void restoreOnlineSpectator(PolarSouls plugin, PlayerData data) {
         Player target = Bukkit.getPlayer(data.getUuid());

--- a/src/main/java/org/polarnl/polarsouls/util/TabCompleteUtil.java
+++ b/src/main/java/org/polarnl/polarsouls/util/TabCompleteUtil.java
@@ -6,9 +6,6 @@ import org.bukkit.entity.Player;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * Utility class for tab completion functionality across commands.
- */
 public final class TabCompleteUtil {
 
     private TabCompleteUtil() {
@@ -16,10 +13,10 @@ public final class TabCompleteUtil {
     }
 
     /**
-     * Get a list of online player names that start with the given prefix.
+     * gets online player names matching the given prefix.
      *
-     * @param prefix The prefix to filter by (case-insensitive)
-     * @return List of matching player names
+     * @param prefix the prefix to filter by (case-insensitive)
+     * @return list of matching player names
      */
     public static List<String> getOnlinePlayerNames(String prefix) {
         List<String> names = new ArrayList<>();
@@ -33,11 +30,11 @@ public final class TabCompleteUtil {
     }
 
     /**
-     * Filter a list of options by prefix (case-insensitive).
+     * filters options by prefix (case-insensitive).
      *
-     * @param options List of options to filter
-     * @param prefix  The prefix to filter by
-     * @return List of matching options
+     * @param options list of options to filter
+     * @param prefix the prefix to match
+     * @return list of matching options
      */
     public static List<String> filterStartsWith(List<String> options, String prefix) {
         List<String> result = new ArrayList<>();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -286,6 +286,27 @@ hrm:
   # [CONFIG] BOTH
   drop-heads: true
   
+  # Place the death head as a solid block instead of dropping it as an item entity
+  # When true, the head is permanently embedded in the world at the death location.
+  # This is the recommended approach as it inherently solves both despawn and lava-burn
+  # issues without any extra work.
+  # When false, the head is dropped as a normal item entity - see the options below
+  # for controlling its behaviour in that case.
+  # [CONFIG] BOTH
+  head-place-as-block: true
+  
+  # (Only applies when head-place-as-block is false)
+  # Prevent the dropped head item from despawning naturally (normally after 5 minutes)
+  # When true, the item will stay in the world until a player picks it up.
+  # [CONFIG] BOTH
+  head-no-despawn: true
+  
+  # (Only applies when head-place-as-block is false)
+  # Make the dropped head item immune to fire and lava
+  # When true, the item entity cannot be destroyed by fire, lava, or explosions.
+  # [CONFIG] BOTH
+  head-fireproof: true
+  
   # Send death location message when player dies
   # Helps teammates find the revival structure location
   # [CONFIG] BOTH

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -286,12 +286,13 @@ hrm:
   # [CONFIG] BOTH
   drop-heads: true
   
-  # Place the death head as a solid block instead of dropping it as an item entity
-  # When true, the head is permanently embedded in the world at the death location.
-  # This is the recommended approach as it inherently solves both despawn and lava-burn
-  # issues without any extra work.
-  # When false, the head is dropped as a normal item entity - see the options below
-  # for controlling its behaviour in that case.
+  # Place the death head as a solid block instead of dropping it as an item entity.
+  # The plugin scans upward from the death location to find the first air block above
+  # solid ground — so if you die in lava it emerges above the lava surface, always
+  # reachable. Players break the block to pick up the skull item, then carry it to
+  # the revival structure as normal. The block cannot burn or despawn.
+  # When false, the head spawns as an item entity — use head-no-despawn and
+  # head-fireproof below to control its behaviour in that case.
   # [CONFIG] BOTH
   head-place-as-block: true
   


### PR DESCRIPTION
This pull request introduces a configurable system for how dead players' heads are handled in the HRM revival system, allowing server admins to choose between placing heads as permanent skull blocks or dropping them as item entities, with additional options for item survival. The documentation is updated to reflect these new modes and their configuration, and the codebase is modified to support tracking, placing, and cleaning up heads according to the chosen mode. Several methods and fields are added for configuration, and head drop logic is expanded to handle both block and item modes robustly.

**Revival Head Placement Modes (Major Feature):**
- Added support for two modes of head placement on player death: permanent skull block mode (default) and item entity mode, controlled by `hrm.head-place-as-block` in `config.yml`. Block mode scans upward for accessible air and places a permanent, fireproof skull block; item mode drops the head as an item with configurable despawn and fireproof options. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L70-R80) [[2]](diffhunk://#diff-1616190b6d17a14658d151b100c53e02eb36f9cf0595236402b697bc5b54d1a9L379-R458) [[3]](diffhunk://#diff-1616190b6d17a14658d151b100c53e02eb36f9cf0595236402b697bc5b54d1a9R481-R483) [[4]](diffhunk://#diff-981487f32f2ed6043e88cda57cd9950e6f4c17835ccbcc09e59093b98bd21ab2R92-R94) [[5]](diffhunk://#diff-981487f32f2ed6043e88cda57cd9950e6f4c17835ccbcc09e59093b98bd21ab2R332-R334) [[6]](diffhunk://#diff-981487f32f2ed6043e88cda57cd9950e6f4c17835ccbcc09e59093b98bd21ab2R544-R555) [[7]](diffhunk://#diff-166cd363067a9c4460ccc1a76de26240a5049e86e05ed437fb97e3ff9f860742L87-R150)

**Head Cleanup and Tracking:**
- Implemented tracking of skull block locations (`headBlockLocations`) so that all copies can be reliably removed on revival, even if chunks are unloaded. Cleanup logic now includes both block and item modes, with fallback scanning for stale heads. [[1]](diffhunk://#diff-1616190b6d17a14658d151b100c53e02eb36f9cf0595236402b697bc5b54d1a9L379-R458) [[2]](diffhunk://#diff-166cd363067a9c4460ccc1a76de26240a5049e86e05ed437fb97e3ff9f860742R48-R50) [[3]](diffhunk://#diff-166cd363067a9c4460ccc1a76de26240a5049e86e05ed437fb97e3ff9f860742L87-R150)

**Item Entity Survival Options:**
- Added configuration options for item entity mode: `head-no-despawn` prevents the head from despawning, and `head-fireproof` makes the item invulnerable to fire/lava. Integrated these options into the item drop logic and added an event handler to cancel despawn events when enabled. [[1]](diffhunk://#diff-1616190b6d17a14658d151b100c53e02eb36f9cf0595236402b697bc5b54d1a9R481-R483) [[2]](diffhunk://#diff-981487f32f2ed6043e88cda57cd9950e6f4c17835ccbcc09e59093b98bd21ab2R92-R94) [[3]](diffhunk://#diff-981487f32f2ed6043e88cda57cd9950e6f4c17835ccbcc09e59093b98bd21ab2R332-R334) [[4]](diffhunk://#diff-981487f32f2ed6043e88cda57cd9950e6f4c17835ccbcc09e59093b98bd21ab2R544-R555) [[5]](diffhunk://#diff-166cd363067a9c4460ccc1a76de26240a5049e86e05ed437fb97e3ff9f860742L87-R150)

**Documentation Updates:**
- Updated `README.md` and `docs/revival-system.md` to describe the new placement modes, configuration options, head cleanup process, and head survival mechanics. Improved clarity and detail for server admins and players. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L70-R80) [[2]](diffhunk://#diff-1616190b6d17a14658d151b100c53e02eb36f9cf0595236402b697bc5b54d1a9L379-R458) [[3]](diffhunk://#diff-1616190b6d17a14658d151b100c53e02eb36f9cf0595236402b697bc5b54d1a9R481-R483)

**Minor JavaDoc Improvements:**
- Improved JavaDoc comments for clarity and consistency in several classes, including `AdminCommand` and `DatabaseManager`. [[1]](diffhunk://#diff-2f695a4bcbe20e13f8eaf659b414cf39b9dedea0d336a79bd3700598dfb64df2L61-R67) [[2]](diffhunk://#diff-2f695a4bcbe20e13f8eaf659b414cf39b9dedea0d336a79bd3700598dfb64df2L78-R80) [[3]](diffhunk://#diff-2f695a4bcbe20e13f8eaf659b414cf39b9dedea0d336a79bd3700598dfb64df2L92-R93) [[4]](diffhunk://#diff-5763cefeec987b6274794ec3d987b24fa6f13134bbd32e30c0736c19f17c2509L132-R136) [[5]](diffhunk://#diff-5763cefeec987b6274794ec3d987b24fa6f13134bbd32e30c0736c19f17c2509L363-R364)