### PR TITLE
chore: bump version to v4.0.2

### DIFF
--- a/MODRINTH.md
+++ b/MODRINTH.md
@@ -2,7 +2,7 @@
 
 <img src="https://cdn.modrinth.com/data/Pb03qu6T/images/70ce5f45786d4716bb6d47d242ee3238a2b4ec4a.jpeg" alt="SSoggySouls Banner">
 
-**Version 3.2.6** | Minecraft 1.21.X | Spigot/Paper/Purpur
+**Version 4.0.2** | Minecraft 1.21.X | Spigot/Paper/Purpur
 
 A hardcore lives system plugin. When you die enough times, you get exiled to a Limbo server (multi-server) or enter spectator mode (single-server) until your teammates revive you.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![SSoggySouls Banner](https://cdn.modrinth.com/data/Pb03qu6T/images/48a03bf24103dde408dbbcad653a3936b5f5255a.png)
 
-**Version 3.2.6** | [Modrinth](https://modrinth.com/project/Pb03qu6T) | [GitHub](https://github.com/SSoggy-Group/SSoggySouls-for-Hardcore)
+**Version 4.0.2** | [Modrinth](https://modrinth.com/project/Pb03qu6T) | [GitHub](https://github.com/SSoggy-Group/SSoggySouls-for-Hardcore)
 
 A hardcore lives system plugin for Minecraft 1.21.X (Spigot/Paper/Purpur). When you die enough times, you get exiled to a Limbo server or stuck in spectator mode until your teammates bring you back.
 
@@ -345,15 +345,15 @@ After setup, test everything:
 
 ### Step 1: Download
 
-Download the latest release (`SSoggySouls-3.2.6.jar`) from the [Releases page](https://github.com/SSoggy-Group/SSoggySouls-for-Hardcore/releases).
+Download the latest release (`SSoggySouls-4.0.2.jar`) from the [Releases page](https://github.com/SSoggy-Group/SSoggySouls-for-Hardcore/releases).
 
 ### Step 2: Install Plugin
 
-Place `SSoggySouls-3.2.6.jar` in the `plugins/` folder of **both** servers:
+Place `SSoggySouls-4.0.2.jar` in the `plugins/` folder of **both** servers:
 
-- Main server: `/plugins/SSoggySouls-3.2.6.jar`
+- Main server: `/plugins/SSoggySouls-4.0.2.jar`
 
-- Limbo server: `/plugins/SSoggySouls-3.2.6.jar`
+- Limbo server: `/plugins/SSoggySouls-4.0.2.jar`
 
 ### Step 3: Generate Config
 
@@ -890,7 +890,7 @@ SSoggySouls includes automatic update checking via Modrinth:
 
 ## Changelog
 
-### v3.2.6
+### v4.0.2
 
 **What's Changed:**
 
@@ -904,7 +904,7 @@ SSoggySouls includes automatic update checking via Modrinth:
 
 - **Rename: PolarSouls to SSoggySouls** - Finished renaming everything internally. No config changes needed.
 
-**Full Changelog:** [v1...v3.2.6](https://github.com/SSoggy-Group/SSoggySouls-for-Hardcore/compare/v1...v3.2.6)
+**Full Changelog:** [v1...v4.0.2](https://github.com/SSoggy-Group/SSoggySouls-for-Hardcore/compare/v1...v4.0.2)
 
 ## Credits
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -553,7 +553,7 @@ Check console logs for:
 
 ### Mistake 6: Different Plugin Versions
 
-**Wrong:** Main server has v4.0.1, Limbo has v4.0.2
+**Wrong:** Main server has v3.2.6, Limbo has v4.0.2
 
 **Right:** Both servers must use the exact same version
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -194,7 +194,7 @@ Get the latest version:
 
 - [Modrinth](https://modrinth.com/project/Pb03qu6T)
 
-Download `SSoggySouls-3.2.6.jar` (or latest version).
+Download `SSoggySouls-4.0.2.jar` (or latest version).
 
 ### Installation Steps
 
@@ -205,14 +205,14 @@ Download `SSoggySouls-3.2.6.jar` (or latest version).
 **For Single Server Setups:**
 
 ```text
-Server: /plugins/SSoggySouls-3.2.6.jar
+Server: /plugins/SSoggySouls-4.0.2.jar
 ```
 
 **For 2-Server Setups (Main + Limbo):**
 
 ```text
-Main Server: /plugins/SSoggySouls-3.2.6.jar
-Limbo Server: /plugins/SSoggySouls-3.2.6.jar
+Main Server: /plugins/SSoggySouls-4.0.2.jar
+Limbo Server: /plugins/SSoggySouls-4.0.2.jar
 ```
 
 1. **Start your server(s)** to generate config files
@@ -553,7 +553,7 @@ Check console logs for:
 
 ### Mistake 6: Different Plugin Versions
 
-**Wrong:** Main server has v3.2.5, Limbo has v3.2.6
+**Wrong:** Main server has v4.0.1, Limbo has v4.0.2
 
 **Right:** Both servers must use the exact same version
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -25,7 +25,7 @@ This guide will help you get SSoggySouls up and running in 8 simple steps. For m
 
 ### Step 1: Download
 
-Download the latest `SSoggySouls-3.2.6.jar` from:
+Download the latest `SSoggySouls-4.0.2.jar` from:
 
 - [GitHub Releases](https://github.com/SSoggy-Group/SSoggySouls-for-Hardcore/releases)
 
@@ -33,12 +33,12 @@ Download the latest `SSoggySouls-3.2.6.jar` from:
 
 ### Step 2: Install Plugin
 
-Place `SSoggySouls-3.2.6.jar` in your server's `plugins/` folder.
+Place `SSoggySouls-4.0.2.jar` in your server's `plugins/` folder.
 
 If using a 2-server setup, install it on **both** backend servers:
 
-- Main server: `/plugins/SSoggySouls-3.2.6.jar`
-- Limbo server: `/plugins/SSoggySouls-3.2.6.jar`
+- Main server: `/plugins/SSoggySouls-4.0.2.jar`
+- Limbo server: `/plugins/SSoggySouls-4.0.2.jar`
 
 > **Important:** If using a proxy, install on backend servers only, NOT on Velocity!
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -382,7 +382,7 @@ Check console logs on both servers:
 
 ```text
 
-[SSoggySouls] Version 3.2.6 enabled
+[SSoggySouls] Version 4.0.2 enabled
 
 ```
 

--- a/fabric/gradle.properties
+++ b/fabric/gradle.properties
@@ -1,7 +1,7 @@
 # Gradle properties for SSoggySouls Fabric Mod
 
 # Mod metadata
-mod_version=3.2.6-fabric
+mod_version=4.0.2-fabric
 maven_group=org.ssoggy
 archives_base_name=SSoggySouls-Fabric
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.ssoggy</groupId>
     <artifactId>SSoggySouls</artifactId>
-    <version>3.2.6</version>
+    <version>4.0.2</version>
     <packaging>jar</packaging>
 
     <name>SSoggySouls</name>


### PR DESCRIPTION
Updates all hardcoded version references from v3.2.6 to v4.0.2 across documentation, metadata, and build files. Tagged the release to trigger the GitHub Action build.

---
*PR created automatically by Jules for task [9182447212763938812](https://jules.google.com/task/9182447212763938812) started by @SSoggyTacoMan*