### PR TITLE
🧪 Add TimeUtil.formatTime test suite

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,13 +73,7 @@
         <!-- JUnit 5 -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>5.10.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <version>5.10.1</version>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,20 @@
             <version>2.0.9</version>
             <scope>provided</scope>
         </dependency>
+
+        <!-- JUnit 5 -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.10.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.10.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/org/ssoggy/ssoggysouls/util/TimeUtilTest.java
+++ b/src/test/java/org/ssoggy/ssoggysouls/util/TimeUtilTest.java
@@ -1,55 +1,25 @@
 package org.ssoggy.ssoggysouls.util;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class TimeUtilTest {
 
-    @Test
-    void testFormatTimeNegativeAndZero() {
-        assertEquals("0s", TimeUtil.formatTime(-1000L));
-        assertEquals("0s", TimeUtil.formatTime(0L));
-    }
-
-    @Test
-    void testFormatTimeUnderOneSecond() {
-        assertEquals("0s", TimeUtil.formatTime(500L));
-    }
-
-    @Test
-    void testFormatTimeSecondsOnly() {
-        assertEquals("45s", TimeUtil.formatTime(45_000L));
-    }
-
-    @Test
-    void testFormatTimeMinutesOnly() {
-        assertEquals("2m", TimeUtil.formatTime(120_000L));
-    }
-
-    @Test
-    void testFormatTimeMinutesAndSeconds() {
-        assertEquals("2m 30s", TimeUtil.formatTime(150_000L));
-    }
-
-    @Test
-    void testFormatTimeHoursOnly() {
-        assertEquals("1h", TimeUtil.formatTime(3600_000L));
-    }
-
-    @Test
-    void testFormatTimeHoursAndMinutes() {
-        assertEquals("1h 30m", TimeUtil.formatTime(5400_000L));
-    }
-
-    @Test
-    void testFormatTimeHoursMinutesAndSeconds() {
-        // Seconds should be omitted when hours > 0
-        assertEquals("1h 30m", TimeUtil.formatTime(5430_000L));
-    }
-
-    @Test
-    void testFormatTimeHoursAndSeconds() {
-        // Seconds should be omitted when hours > 0 even if minutes == 0
-        assertEquals("1h", TimeUtil.formatTime(3630_000L));
+    @ParameterizedTest(name = "formatTime({0}ms) -> {1}")
+    @CsvSource({
+        "-1000,   0s",
+        "0,       0s",
+        "500,     0s",
+        "45000,   45s",
+        "120000,  2m",
+        "150000,  2m 30s",
+        "3600000, 1h",
+        "5400000, 1h 30m",
+        "5430000, 1h 30m",
+        "3630000, 1h"
+    })
+    void testFormatTime(long millis, String expected) {
+        assertEquals(expected, TimeUtil.formatTime(millis));
     }
 }

--- a/src/test/java/org/ssoggy/ssoggysouls/util/TimeUtilTest.java
+++ b/src/test/java/org/ssoggy/ssoggysouls/util/TimeUtilTest.java
@@ -1,0 +1,55 @@
+package org.ssoggy.ssoggysouls.util;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TimeUtilTest {
+
+    @Test
+    void testFormatTimeNegativeAndZero() {
+        assertEquals("0s", TimeUtil.formatTime(-1000L));
+        assertEquals("0s", TimeUtil.formatTime(0L));
+    }
+
+    @Test
+    void testFormatTimeUnderOneSecond() {
+        assertEquals("0s", TimeUtil.formatTime(500L));
+    }
+
+    @Test
+    void testFormatTimeSecondsOnly() {
+        assertEquals("45s", TimeUtil.formatTime(45_000L));
+    }
+
+    @Test
+    void testFormatTimeMinutesOnly() {
+        assertEquals("2m", TimeUtil.formatTime(120_000L));
+    }
+
+    @Test
+    void testFormatTimeMinutesAndSeconds() {
+        assertEquals("2m 30s", TimeUtil.formatTime(150_000L));
+    }
+
+    @Test
+    void testFormatTimeHoursOnly() {
+        assertEquals("1h", TimeUtil.formatTime(3600_000L));
+    }
+
+    @Test
+    void testFormatTimeHoursAndMinutes() {
+        assertEquals("1h 30m", TimeUtil.formatTime(5400_000L));
+    }
+
+    @Test
+    void testFormatTimeHoursMinutesAndSeconds() {
+        // Seconds should be omitted when hours > 0
+        assertEquals("1h 30m", TimeUtil.formatTime(5430_000L));
+    }
+
+    @Test
+    void testFormatTimeHoursAndSeconds() {
+        // Seconds should be omitted when hours > 0 even if minutes == 0
+        assertEquals("1h", TimeUtil.formatTime(3630_000L));
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap in `TimeUtil.formatTime` addressed by adding JUnit 5 tests.
📊 **Coverage:** Covered negative/zero values, seconds only, minutes only, hours only, and combinations of all three, including edge cases where seconds are correctly omitted when hours > 0.
✨ **Result:** Test coverage improved and the code is now confidently verifiable using `mvn test`.

---
*PR created automatically by Jules for task [5987380331966229698](https://jules.google.com/task/5987380331966229698) started by @SSoggyTacoMan*