### PR TITLE
🔒 fix: prevent SQL injection in ensureColumn

### DIFF
--- a/src/main/java/org/ssoggy/ssoggysouls/database/MySQLManager.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/database/MySQLManager.java
@@ -146,7 +146,7 @@ public class MySQLManager implements DatabaseManager {
         if (definition == null || !definition.matches("^[a-zA-Z0-9_ \\(\\),'.\\-]+$")) {
             throw new IllegalArgumentException("Invalid column definition: " + definition);
         }
-        if (definition.contains("--") || definition.contains("/*") || definition.contains("*/")) {
+        if (definition.contains("--")) {
             throw new IllegalArgumentException("SQL comments are not allowed in column definition.");
         }
 

--- a/src/main/java/org/ssoggy/ssoggysouls/database/MySQLManager.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/database/MySQLManager.java
@@ -59,6 +59,9 @@ public class MySQLManager implements DatabaseManager {
             String pass = plugin.getConfig().getString("database.password", "changeme");
             int poolSize = plugin.getConfig().getInt("database.pool-size", 5);
             tableName = plugin.getConfig().getString("database.table-name", "hardcore_players");
+            if (tableName == null || !tableName.matches("^[a-zA-Z0-9_]+$")) {
+                throw new IllegalArgumentException("Invalid table name configuration: " + tableName);
+            }
 
             String jdbcUrl = "jdbc:mysql://" + host + ":" + port + "/" + dbName
                     + "?useSSL=false&allowPublicKeyRetrieval=true&autoReconnect=true"
@@ -137,9 +140,6 @@ public class MySQLManager implements DatabaseManager {
      *                   DEFAULT 0")
      */
     private void ensureColumn(Connection conn, String columnName, String definition) {
-        if (tableName == null || !tableName.matches("^[a-zA-Z0-9_]+$")) {
-            throw new IllegalArgumentException("Invalid table name: " + tableName);
-        }
         if (columnName == null || !columnName.matches("^[a-zA-Z0-9_]+$")) {
             throw new IllegalArgumentException("Invalid column name: " + columnName);
         }

--- a/src/main/java/org/ssoggy/ssoggysouls/database/MySQLManager.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/database/MySQLManager.java
@@ -137,17 +137,17 @@ public class MySQLManager implements DatabaseManager {
      *                   DEFAULT 0")
      */
     private void ensureColumn(Connection conn, String columnName, String definition) {
+        if (tableName == null || !tableName.matches("^[a-zA-Z0-9_]+$")) {
+            throw new IllegalArgumentException("Invalid table name: " + tableName);
+        }
         if (columnName == null || !columnName.matches("^[a-zA-Z0-9_]+$")) {
             throw new IllegalArgumentException("Invalid column name: " + columnName);
         }
-        if (definition == null || !definition.matches("^[a-zA-Z0-9_ \\(\\),'. -]+$")) {
+        if (definition == null || !definition.matches("^[a-zA-Z0-9_ \\(\\),'.\\-]+$")) {
             throw new IllegalArgumentException("Invalid column definition: " + definition);
         }
         if (definition.contains("--") || definition.contains("/*") || definition.contains("*/")) {
-            throw new IllegalArgumentException("Invalid column definition: " + definition);
-        }
-        if (tableName == null || !tableName.matches("^[a-zA-Z0-9_]+$")) {
-            throw new IllegalArgumentException("Invalid table name: " + tableName);
+            throw new IllegalArgumentException("SQL comments are not allowed in column definition.");
         }
 
         String sql = "ALTER TABLE " + tableName + " ADD COLUMN " + columnName + " " + definition;

--- a/src/main/java/org/ssoggy/ssoggysouls/database/MySQLManager.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/database/MySQLManager.java
@@ -140,8 +140,14 @@ public class MySQLManager implements DatabaseManager {
         if (columnName == null || !columnName.matches("^[a-zA-Z0-9_]+$")) {
             throw new IllegalArgumentException("Invalid column name: " + columnName);
         }
-        if (definition == null || !definition.matches("^[a-zA-Z0-9_ \\(\\),']+$")) {
+        if (definition == null || !definition.matches("^[a-zA-Z0-9_ \\(\\),'. -]+$")) {
             throw new IllegalArgumentException("Invalid column definition: " + definition);
+        }
+        if (definition.contains("--") || definition.contains("/*") || definition.contains("*/")) {
+            throw new IllegalArgumentException("Invalid column definition: " + definition);
+        }
+        if (tableName == null || !tableName.matches("^[a-zA-Z0-9_]+$")) {
+            throw new IllegalArgumentException("Invalid table name: " + tableName);
         }
 
         String sql = "ALTER TABLE " + tableName + " ADD COLUMN " + columnName + " " + definition;

--- a/src/main/java/org/ssoggy/ssoggysouls/database/MySQLManager.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/database/MySQLManager.java
@@ -137,6 +137,13 @@ public class MySQLManager implements DatabaseManager {
      *                   DEFAULT 0")
      */
     private void ensureColumn(Connection conn, String columnName, String definition) {
+        if (columnName == null || !columnName.matches("^[a-zA-Z0-9_]+$")) {
+            throw new IllegalArgumentException("Invalid column name: " + columnName);
+        }
+        if (definition == null || !definition.matches("^[a-zA-Z0-9_ \\(\\),']+$")) {
+            throw new IllegalArgumentException("Invalid column definition: " + definition);
+        }
+
         String sql = "ALTER TABLE " + tableName + " ADD COLUMN " + columnName + " " + definition;
         try (Statement stmt = conn.createStatement()) {
             stmt.executeUpdate(sql);

--- a/src/main/java/org/ssoggy/ssoggysouls/database/MySQLManager.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/database/MySQLManager.java
@@ -155,8 +155,11 @@ public class MySQLManager implements DatabaseManager {
         if (!isValidIdentifier(columnName)) {
             throw new IllegalArgumentException("Invalid column name identifier: " + columnName);
         }
-        if (definition == null || !definition.matches("^[a-zA-Z0-9_ \\(\\),'.\\-]+$") || definition.contains("--")) {
-            throw new IllegalArgumentException("Invalid column definition: " + definition);
+        if (definition == null || !definition.matches("^[a-zA-Z0-9_ \\(\\),'.\\-]+$")) {
+            throw new IllegalArgumentException("Invalid column definition characters: " + definition);
+        }
+        if (definition.contains("--")) {
+            throw new IllegalArgumentException("SQL comments are not allowed in column definition: " + definition);
         }
 
         String sql = "ALTER TABLE " + tableName + " ADD COLUMN " + columnName + " " + definition;

--- a/src/main/java/org/ssoggy/ssoggysouls/database/SQLiteManager.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/database/SQLiteManager.java
@@ -124,17 +124,17 @@ public class SQLiteManager implements DatabaseManager {
      *                   DEFAULT 0")
      */
     private void ensureColumn(Connection conn, String columnName, String definition) {
+        if (tableName == null || !tableName.matches("^[a-zA-Z0-9_]+$")) {
+            throw new IllegalArgumentException("Invalid table name: " + tableName);
+        }
         if (columnName == null || !columnName.matches("^[a-zA-Z0-9_]+$")) {
             throw new IllegalArgumentException("Invalid column name: " + columnName);
         }
-        if (definition == null || !definition.matches("^[a-zA-Z0-9_ \\(\\),'. -]+$")) {
+        if (definition == null || !definition.matches("^[a-zA-Z0-9_ \\(\\),'.\\-]+$")) {
             throw new IllegalArgumentException("Invalid column definition: " + definition);
         }
         if (definition.contains("--") || definition.contains("/*") || definition.contains("*/")) {
-            throw new IllegalArgumentException("Invalid column definition: " + definition);
-        }
-        if (tableName == null || !tableName.matches("^[a-zA-Z0-9_]+$")) {
-            throw new IllegalArgumentException("Invalid table name: " + tableName);
+            throw new IllegalArgumentException("SQL comments are not allowed in column definition.");
         }
 
         String sql = "ALTER TABLE " + tableName + " ADD COLUMN " + columnName + " " + definition;

--- a/src/main/java/org/ssoggy/ssoggysouls/database/SQLiteManager.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/database/SQLiteManager.java
@@ -135,8 +135,11 @@ public class SQLiteManager implements DatabaseManager {
         if (!isValidIdentifier(columnName)) {
             throw new IllegalArgumentException("Invalid column name identifier: " + columnName);
         }
-        if (definition == null || !definition.matches("^[a-zA-Z0-9_ \\(\\),'.\\-]+$") || definition.contains("--")) {
-            throw new IllegalArgumentException("Invalid column definition: " + definition);
+        if (definition == null || !definition.matches("^[a-zA-Z0-9_ \\(\\),'.\\-]+$")) {
+            throw new IllegalArgumentException("Invalid column definition characters: " + definition);
+        }
+        if (definition.contains("--")) {
+            throw new IllegalArgumentException("SQL comments are not allowed in column definition: " + definition);
         }
 
         String sql = "ALTER TABLE " + tableName + " ADD COLUMN " + columnName + " " + definition;

--- a/src/main/java/org/ssoggy/ssoggysouls/database/SQLiteManager.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/database/SQLiteManager.java
@@ -127,8 +127,14 @@ public class SQLiteManager implements DatabaseManager {
         if (columnName == null || !columnName.matches("^[a-zA-Z0-9_]+$")) {
             throw new IllegalArgumentException("Invalid column name: " + columnName);
         }
-        if (definition == null || !definition.matches("^[a-zA-Z0-9_ \\(\\),']+$")) {
+        if (definition == null || !definition.matches("^[a-zA-Z0-9_ \\(\\),'. -]+$")) {
             throw new IllegalArgumentException("Invalid column definition: " + definition);
+        }
+        if (definition.contains("--") || definition.contains("/*") || definition.contains("*/")) {
+            throw new IllegalArgumentException("Invalid column definition: " + definition);
+        }
+        if (tableName == null || !tableName.matches("^[a-zA-Z0-9_]+$")) {
+            throw new IllegalArgumentException("Invalid table name: " + tableName);
         }
 
         String sql = "ALTER TABLE " + tableName + " ADD COLUMN " + columnName + " " + definition;

--- a/src/main/java/org/ssoggy/ssoggysouls/database/SQLiteManager.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/database/SQLiteManager.java
@@ -133,7 +133,7 @@ public class SQLiteManager implements DatabaseManager {
         if (definition == null || !definition.matches("^[a-zA-Z0-9_ \\(\\),'.\\-]+$")) {
             throw new IllegalArgumentException("Invalid column definition: " + definition);
         }
-        if (definition.contains("--") || definition.contains("/*") || definition.contains("*/")) {
+        if (definition.contains("--")) {
             throw new IllegalArgumentException("SQL comments are not allowed in column definition.");
         }
 

--- a/src/main/java/org/ssoggy/ssoggysouls/database/SQLiteManager.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/database/SQLiteManager.java
@@ -124,6 +124,13 @@ public class SQLiteManager implements DatabaseManager {
      *                   DEFAULT 0")
      */
     private void ensureColumn(Connection conn, String columnName, String definition) {
+        if (columnName == null || !columnName.matches("^[a-zA-Z0-9_]+$")) {
+            throw new IllegalArgumentException("Invalid column name: " + columnName);
+        }
+        if (definition == null || !definition.matches("^[a-zA-Z0-9_ \\(\\),']+$")) {
+            throw new IllegalArgumentException("Invalid column definition: " + definition);
+        }
+
         String sql = "ALTER TABLE " + tableName + " ADD COLUMN " + columnName + " " + definition;
         try (Statement stmt = conn.createStatement()) {
             stmt.executeUpdate(sql);

--- a/src/main/java/org/ssoggy/ssoggysouls/database/SQLiteManager.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/database/SQLiteManager.java
@@ -52,6 +52,9 @@ public class SQLiteManager implements DatabaseManager {
     public boolean initialize() {
         try {
             tableName = plugin.getConfig().getString("database.table-name", "hardcore_players");
+            if (tableName == null || !tableName.matches("^[a-zA-Z0-9_]+$")) {
+                throw new IllegalArgumentException("Invalid table name configuration: " + tableName);
+            }
 
             java.io.File dataFolder = plugin.getDataFolder();
             if (!dataFolder.exists()) {
@@ -124,9 +127,6 @@ public class SQLiteManager implements DatabaseManager {
      *                   DEFAULT 0")
      */
     private void ensureColumn(Connection conn, String columnName, String definition) {
-        if (tableName == null || !tableName.matches("^[a-zA-Z0-9_]+$")) {
-            throw new IllegalArgumentException("Invalid table name: " + tableName);
-        }
         if (columnName == null || !columnName.matches("^[a-zA-Z0-9_]+$")) {
             throw new IllegalArgumentException("Invalid column name: " + columnName);
         }


### PR DESCRIPTION
🎯 **What:** Fixed an SQL injection vulnerability in the `ensureColumn` method of `MySQLManager.java` and `SQLiteManager.java`.
⚠️ **Risk:** If these internal database management methods are exposed to or modified to accept dynamic input, an attacker could execute arbitrary SQL strings via query stacking, compromising the database payload. 
🛡️ **Solution:** Replaced string concatenation vulnerabilities with strict whitelist-based input validation for the `columnName` and `definition` arguments, throwing an `IllegalArgumentException` before execution if they don't match standard SQL definitions.

---
*PR created automatically by Jules for task [4732318498293102062](https://jules.google.com/task/4732318498293102062) started by @SSoggyTacoMan*