### PR TITLE
🧪 [Testing] Add missing tests for CommandUtil.checkPermission

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,20 @@
             <version>2.0.9</version>
             <scope>provided</scope>
         </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/org/ssoggy/ssoggysouls/util/CommandUtilTest.java
+++ b/src/test/java/org/ssoggy/ssoggysouls/util/CommandUtilTest.java
@@ -1,0 +1,59 @@
+package org.ssoggy.ssoggysouls.util;
+
+import org.bukkit.command.CommandSender;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CommandUtilTest {
+
+    @Test
+    void testCheckPermission_hasPermission() {
+        CommandSender sender = mock(CommandSender.class);
+        when(sender.hasPermission("some.permission")).thenReturn(true);
+
+        boolean result = CommandUtil.checkPermission(sender, "some.permission");
+
+        assertTrue(result);
+        verify(sender, never()).sendMessage(anyString());
+    }
+
+    @Test
+    void testCheckPermission_noPermission() {
+        CommandSender sender = mock(CommandSender.class);
+        when(sender.hasPermission("some.permission")).thenReturn(false);
+
+        boolean result = CommandUtil.checkPermission(sender, "some.permission");
+
+        assertFalse(result);
+        verify(sender).sendMessage(MessageUtil.colorize("&cYou don't have permission to use this command."));
+    }
+
+    @Test
+    void testCheckPermissionCustomMessage_hasPermission() {
+        CommandSender sender = mock(CommandSender.class);
+        when(sender.hasPermission("some.permission")).thenReturn(true);
+
+        boolean result = CommandUtil.checkPermission(sender, "some.permission", "&cCustom error!");
+
+        assertTrue(result);
+        verify(sender, never()).sendMessage(anyString());
+    }
+
+    @Test
+    void testCheckPermissionCustomMessage_noPermission() {
+        CommandSender sender = mock(CommandSender.class);
+        when(sender.hasPermission("some.permission")).thenReturn(false);
+
+        boolean result = CommandUtil.checkPermission(sender, "some.permission", "&cCustom error!");
+
+        assertFalse(result);
+        verify(sender).sendMessage(MessageUtil.colorize("&cCustom error!"));
+    }
+}


### PR DESCRIPTION
🎯 **What:** `CommandUtil.checkPermission` was missing unit tests.
📊 **Coverage:** This PR adds tests covering both overloaded `checkPermission` methods, checking happy path behavior as well as failure paths (asserting that custom or default deny messages are dispatched via `CommandSender.sendMessage`).
✨ **Result:** Test coverage for `CommandUtil` has been improved, adding safety for future refactoring and improving overall codebase reliability.

---
*PR created automatically by Jules for task [12339084252529719482](https://jules.google.com/task/12339084252529719482) started by @SSoggyTacoMan*