### PR TITLE
🧪 Add test coverage for TabCompleteUtil.filterStartsWith

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,13 +73,7 @@
         <!-- JUnit -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>5.10.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <version>5.10.1</version>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,13 @@
         <!-- JUnit -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.10.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <version>5.10.1</version>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,20 @@
             <version>2.0.9</version>
             <scope>provided</scope>
         </dependency>
+
+        <!-- JUnit -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.10.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.10.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/org/ssoggy/ssoggysouls/util/TabCompleteUtilTest.java
+++ b/src/test/java/org/ssoggy/ssoggysouls/util/TabCompleteUtilTest.java
@@ -11,9 +11,9 @@ class TabCompleteUtilTest {
 
     @Test
     void testFilterStartsWith_StandardMatch() {
-        List<String> options = List.of("Apple", "Banana", "Apricot", "Cherry");
+        List<String> options = Arrays.asList("Apple", "Banana", "Apricot", "Cherry");
         List<String> result = TabCompleteUtil.filterStartsWith(options, "Ap");
-        assertEquals(List.of("Apple", "Apricot"), result);
+        assertEquals(Arrays.asList("Apple", "Apricot"), result);
     }
 
     @Test

--- a/src/test/java/org/ssoggy/ssoggysouls/util/TabCompleteUtilTest.java
+++ b/src/test/java/org/ssoggy/ssoggysouls/util/TabCompleteUtilTest.java
@@ -11,9 +11,9 @@ class TabCompleteUtilTest {
 
     @Test
     void testFilterStartsWith_StandardMatch() {
-        List<String> options = Arrays.asList("Apple", "Banana", "Apricot", "Cherry");
+        List<String> options = List.of("Apple", "Banana", "Apricot", "Cherry");
         List<String> result = TabCompleteUtil.filterStartsWith(options, "Ap");
-        assertEquals(Arrays.asList("Apple", "Apricot"), result);
+        assertEquals(List.of("Apple", "Apricot"), result);
     }
 
     @Test

--- a/src/test/java/org/ssoggy/ssoggysouls/util/TabCompleteUtilTest.java
+++ b/src/test/java/org/ssoggy/ssoggysouls/util/TabCompleteUtilTest.java
@@ -1,0 +1,53 @@
+package org.ssoggy.ssoggysouls.util;
+
+import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TabCompleteUtilTest {
+
+    @Test
+    void testFilterStartsWith_StandardMatch() {
+        List<String> options = Arrays.asList("Apple", "Banana", "Apricot", "Cherry");
+        List<String> result = TabCompleteUtil.filterStartsWith(options, "Ap");
+        assertEquals(Arrays.asList("Apple", "Apricot"), result);
+    }
+
+    @Test
+    void testFilterStartsWith_CaseInsensitive() {
+        List<String> options = Arrays.asList("apple", "Banana", "APRICOT", "Cherry");
+        List<String> result = TabCompleteUtil.filterStartsWith(options, "ap");
+        assertEquals(Arrays.asList("apple", "APRICOT"), result);
+    }
+
+    @Test
+    void testFilterStartsWith_NoMatch() {
+        List<String> options = Arrays.asList("Apple", "Banana", "Apricot", "Cherry");
+        List<String> result = TabCompleteUtil.filterStartsWith(options, "Zebra");
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testFilterStartsWith_EmptyOptions() {
+        List<String> options = Collections.emptyList();
+        List<String> result = TabCompleteUtil.filterStartsWith(options, "Ap");
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testFilterStartsWith_EmptyPrefix() {
+        List<String> options = Arrays.asList("Apple", "Banana");
+        List<String> result = TabCompleteUtil.filterStartsWith(options, "");
+        assertEquals(Arrays.asList("Apple", "Banana"), result);
+    }
+
+    @Test
+    void testFilterStartsWith_ExactMatch() {
+        List<String> options = Arrays.asList("Apple", "Banana");
+        List<String> result = TabCompleteUtil.filterStartsWith(options, "Apple");
+        assertEquals(Collections.singletonList("Apple"), result);
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added tests to cover the `TabCompleteUtil.filterStartsWith` utility method, including empty list edge cases.
📊 **Coverage:** Tested standard matching, case-insensitivity, non-matching prefix, empty options list, empty prefix, and exact prefix matching.
✨ **Result:** Improved test coverage for `TabCompleteUtil` and added JUnit dependencies to `pom.xml` enabling further unit testing. Both Maven and Fabric Gradle test suites pass successfully.

---
*PR created automatically by Jules for task [15430915887118481609](https://jules.google.com/task/15430915887118481609) started by @SSoggyTacoMan*