### PR TITLE
🔒 Fix SQL Injection vulnerability in ensureColumn

### DIFF
--- a/src/main/java/org/ssoggy/ssoggysouls/database/MySQLManager.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/database/MySQLManager.java
@@ -60,6 +60,11 @@ public class MySQLManager implements DatabaseManager {
             int poolSize = plugin.getConfig().getInt("database.pool-size", 5);
             tableName = plugin.getConfig().getString("database.table-name", "hardcore_players");
 
+            if (!isValidIdentifier(tableName)) {
+                plugin.getLogger().log(Level.SEVERE, "MySQL initialization failed: Invalid database.table-name '" + tableName + "'. Table name must consist only of alphanumeric characters and underscores.");
+                return false;
+            }
+
             String jdbcUrl = "jdbc:mysql://" + host + ":" + port + "/" + dbName
                     + "?useSSL=false&allowPublicKeyRetrieval=true&autoReconnect=true"
                     + "&characterEncoding=UTF-8&useUnicode=true";
@@ -128,6 +133,10 @@ public class MySQLManager implements DatabaseManager {
         ensureColumn(conn, "grace_until", "BIGINT NOT NULL DEFAULT 0");
     }
 
+    private boolean isValidIdentifier(String identifier) {
+        return identifier != null && identifier.matches("^[a-zA-Z0-9_]+$");
+    }
+
     /**
      * ensures a column exists in the table, ignoring duplicate-column errors.
      *
@@ -137,6 +146,10 @@ public class MySQLManager implements DatabaseManager {
      *                   DEFAULT 0")
      */
     private void ensureColumn(Connection conn, String columnName, String definition) {
+        if (!isValidIdentifier(columnName)) {
+            throw new IllegalArgumentException("Invalid column name identifier: " + columnName);
+        }
+
         String sql = "ALTER TABLE " + tableName + " ADD COLUMN " + columnName + " " + definition;
         try (Statement stmt = conn.createStatement()) {
             stmt.executeUpdate(sql);

--- a/src/main/java/org/ssoggy/ssoggysouls/database/SQLiteManager.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/database/SQLiteManager.java
@@ -53,6 +53,11 @@ public class SQLiteManager implements DatabaseManager {
         try {
             tableName = plugin.getConfig().getString("database.table-name", "hardcore_players");
 
+            if (!isValidIdentifier(tableName)) {
+                plugin.getLogger().log(Level.SEVERE, "SQLite initialization failed: Invalid database.table-name '" + tableName + "'. Table name must consist only of alphanumeric characters and underscores.");
+                return false;
+            }
+
             java.io.File dataFolder = plugin.getDataFolder();
             if (!dataFolder.exists()) {
                 dataFolder.mkdirs();
@@ -115,6 +120,10 @@ public class SQLiteManager implements DatabaseManager {
         ensureColumn(conn, "grace_until", "BIGINT NOT NULL DEFAULT 0");
     }
 
+    private boolean isValidIdentifier(String identifier) {
+        return identifier != null && identifier.matches("^[a-zA-Z0-9_]+$");
+    }
+
     /**
      * ensures a column exists in the table, ignoring duplicate-column errors.
      *
@@ -124,6 +133,10 @@ public class SQLiteManager implements DatabaseManager {
      *                   DEFAULT 0")
      */
     private void ensureColumn(Connection conn, String columnName, String definition) {
+        if (!isValidIdentifier(columnName)) {
+            throw new IllegalArgumentException("Invalid column name identifier: " + columnName);
+        }
+
         String sql = "ALTER TABLE " + tableName + " ADD COLUMN " + columnName + " " + definition;
         try (Statement stmt = conn.createStatement()) {
             stmt.executeUpdate(sql);


### PR DESCRIPTION
🎯 **What:** Fixed an SQL Injection vulnerability in `ensureColumn` and `initialize`/`createTable`.
⚠️ **Risk:** Although `ensureColumn` currently acts on mostly trusted inputs, without input validation or parameterization, an attacker who controls the database table name through the config (e.g. `database.table-name`) or any future argument string interpolated into DDL strings could execute arbitrary DDL or SQL queries.
🛡️ **Solution:** Added a strict input validation check (`isValidIdentifier(String)`) matching `^[a-zA-Z0-9_]+$` to both `SQLiteManager` and `MySQLManager` and applied this to `tableName` on initialization and `columnName` in `ensureColumn`. If a malicious input is detected, initialization is halted or an exception is thrown, preventing the payload execution.

---
*PR created automatically by Jules for task [8984507584277384661](https://jules.google.com/task/8984507584277384661) started by @SSoggyTacoMan*