### PR TITLE
🔒 Fix information leakage vulnerability in exception handling

### DIFF
--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/util/ConfigManager.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/util/ConfigManager.java
@@ -24,7 +24,7 @@ public class ConfigManager {
             try (FileReader reader = new FileReader(CONFIG_FILE)) {
                 config = GSON.fromJson(reader, ModConfig.class);
             } catch (IOException e) {
-                e.printStackTrace();
+                org.ssoggy.ssoggysouls.SSoggySoulsMod.LOGGER.error("Failed to load config file", e);
                 config = new ModConfig();
                 save();
             }
@@ -38,7 +38,7 @@ public class ConfigManager {
         try (FileWriter writer = new FileWriter(CONFIG_FILE)) {
             GSON.toJson(config, writer);
         } catch (IOException e) {
-            e.printStackTrace();
+            org.ssoggy.ssoggysouls.SSoggySoulsMod.LOGGER.error("Failed to save config file", e);
         }
     }
 

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/util/ConfigManager.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/util/ConfigManager.java
@@ -24,7 +24,7 @@ public class ConfigManager {
             try (FileReader reader = new FileReader(CONFIG_FILE)) {
                 config = GSON.fromJson(reader, ModConfig.class);
             } catch (IOException e) {
-                e.printStackTrace();
+                org.ssoggy.ssoggysouls.SSoggySoulsMod.LOGGER.error("Failed to load config file", e);
                 config = new ModConfig();
                 save();
             }
@@ -38,7 +38,7 @@ public class ConfigManager {
         try (FileWriter writer = new FileWriter(CONFIG_FILE)) {
             GSON.toJson(config, writer);
         } catch (IOException e) {
-            e.printStackTrace();
+            org.ssoggy.ssoggysouls.SSoggySoulsMod.LOGGER.error("Failed to save config file", e);
         }
     }
 

--- a/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPStorage.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPStorage.java
@@ -29,11 +29,13 @@ import java.util.Map;
 
 public class RPStorage {
 
+    private final JavaPlugin plugin;
     private final File file;
     private FileConfiguration config;
 
 
     public RPStorage(JavaPlugin plugin, String fileName) {
+        this.plugin = plugin;
         if (!plugin.getDataFolder().exists()) {
             plugin.getDataFolder().mkdirs();
         }
@@ -46,7 +48,7 @@ public class RPStorage {
                     plugin.getLogger().log(java.util.logging.Level.WARNING, "Storage file already exists or could not be created: {0}", fileName);
                 }
             } catch (IOException e) {
-                e.printStackTrace();
+                plugin.getLogger().log(java.util.logging.Level.SEVERE, "Could not create storage file: " + fileName, e);
             }
         }
 
@@ -61,7 +63,7 @@ public class RPStorage {
         try {
             config.save(file);
         } catch (IOException e) {
-            e.printStackTrace();
+            plugin.getLogger().log(java.util.logging.Level.SEVERE, "Could not save storage file: " + file.getName(), e);
         }
     }
 


### PR DESCRIPTION
🎯 **What:** 
Fixed an Information Leakage vulnerability where exceptions were being printed directly to standard error using `e.printStackTrace()` instead of the standard application logger.

⚠️ **Risk:** 
Using `e.printStackTrace()` directly prints raw execution context. This bypasses the configured logging framework (which may implement filtering or secure log forwarding) and could expose sensitive system internals, paths, or execution state to console logs.

🛡️ **Solution:** 
- In `src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPStorage.java`, passed the `JavaPlugin` instance to a field and updated the catch blocks to use `plugin.getLogger().log(Level.SEVERE, ...)` to securely log exceptions.
- In both the `fabric` and `forge` implementations of `ConfigManager.java`, replaced similar `printStackTrace` usages with `SSoggySoulsMod.LOGGER.error(...)` to integrate cleanly with their respective logging frameworks.

---
*PR created automatically by Jules for task [1435765039944926916](https://jules.google.com/task/1435765039944926916) started by @SSoggyTacoMan*