### PR TITLE
feat(ci): Add continuous integration workflow for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI Tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run Maven Tests
+        run: mvn -B test
+
+      - name: Run Fabric Tests
+        run: |
+          cd fabric
+          ./gradlew test


### PR DESCRIPTION
Added a new continuous integration GitHub Actions workflow `.github/workflows/ci.yml`. This automatically runs `mvn test` and `./gradlew test` (in the `fabric` folder) using Java 21 on `push` and `pull_request` to `main`. It also sets up caches for Maven and Gradle.

---
*PR created automatically by Jules for task [12011328231028048038](https://jules.google.com/task/12011328231028048038) started by @SSoggyTacoMan*