### PR TITLE
Add test dependencies and missing MessageUtilTest to Forge

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -74,3 +74,6 @@ jar {
         rename { "${it}_${project.base.archivesName.get()}" }
     }
 }
+dependencies {
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.10.1'
+}

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -217,3 +217,15 @@ sourceSets.each {
     it.output.resourcesDir = dir
     it.java.destinationDirectory = dir
 }
+
+dependencies {
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.1'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.1'
+}
+
+test {
+    useJUnitPlatform()
+}
+dependencies {
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.10.1'
+}

--- a/forge/src/test/java/org/ssoggy/ssoggysouls/util/MessageUtilTest.java
+++ b/forge/src/test/java/org/ssoggy/ssoggysouls/util/MessageUtilTest.java
@@ -1,0 +1,58 @@
+package org.ssoggy.ssoggysouls.util;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MessageUtilTest {
+
+    @BeforeEach
+    void setUp() throws Exception {
+        // Use reflection to bypass config loading since we only want to test substitution logic
+        Field messagesField = MessageUtil.class.getDeclaredField("messages");
+        messagesField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<String, String> messages = (Map<String, String>) messagesField.get(null);
+        messages.clear();
+        messages.put("test_msg", "Hello %player%!");
+        messages.put("multi_replace", "%prefix% You have %amount% %item%.");
+
+        Field prefixField = MessageUtil.class.getDeclaredField("prefix");
+        prefixField.setAccessible(true);
+        prefixField.set(null, "§8[§4☠§8] §r");
+    }
+
+    @Test
+    void testGetRawString_ExistingKey() {
+        String result = MessageUtil.getRawString("test_msg", "player", "SSoggy");
+        assertEquals("Hello SSoggy!", result);
+    }
+
+    @Test
+    void testGetRawString_MissingKey() {
+        String result = MessageUtil.getRawString("missing_key", "player", "SSoggy");
+        assertEquals("§cMissing message: missing_key", result);
+    }
+
+    @Test
+    void testGetRawString_MultipleReplacements() {
+        String result = MessageUtil.getRawString("multi_replace", "prefix", "§a[Info]", "amount", 5, "item", "apples");
+        assertEquals("§a[Info] You have 5 apples.", result);
+    }
+
+    @Test
+    void testGetRawString_NoReplacements() {
+        String result = MessageUtil.getRawString("test_msg");
+        assertEquals("Hello %player%!", result);
+    }
+
+    @Test
+    void testGetRawString_MissingReplacementValue() {
+        String result = MessageUtil.getRawString("test_msg", "player");
+        assertEquals("Hello %player%!", result);
+    }
+}


### PR DESCRIPTION
Fixes an issue where `MessageUtilTest` was completely missing in the Forge module compared to the Paper codebase. Added `MessageUtilTest.java` to Forge (matching Fabric's reflection-based logic for substituting `%...%` strings). Also added missing junit-jupiter test dependencies in `forge/build.gradle` and `fabric/build.gradle` so that tests compile.

---
*PR created automatically by Jules for task [6690740964328123362](https://jules.google.com/task/6690740964328123362) started by @SSoggyTacoMan*