### PR TITLE
Fix offline revival teleportation for Forge and Paper

### DIFF
--- a/forge/src/main/java/org/ssoggy/ssoggysouls/listener/ServerLifecycleListener.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/listener/ServerLifecycleListener.java
@@ -50,7 +50,14 @@ public class ServerLifecycleListener {
     }
 
     private static void handleJoinSync(ServerPlayer player, PlayerData data) {
-        // Pending revival logic is handled here, omitted complex pending for Phase 3
+        GlobalPos pending = org.ssoggy.ssoggysouls.hrm.RevivalStructureListener.consumePendingRevival(player.getUUID());
+        if (pending != null) {
+            setGhostModeAttributes(player, false);
+            ServerLevel targetWorld = player.server.getLevel(pending.dimension());
+            org.ssoggy.ssoggysouls.hrm.RevivalStructureListener.restoreAtStructure(player, targetWorld != null ? targetWorld : player.serverLevel(), pending.pos());
+            return;
+        }
+
         if (data.isDead()) {
             if (ConfigManager.getConfig().isSendToLimboOnDeath()) {
                 // ServerTransferUtil.sendToLimbo(player); // Ported in Phase 6

--- a/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java
@@ -30,10 +30,18 @@ import org.ssoggy.ssoggysouls.model.PlayerData;
 import org.ssoggy.ssoggysouls.util.MessageUtil;
 
 // detects when player head is placed for HRM strcuture (so cool to short it to HRM i know)
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 public class RevivalStructureListener implements Listener {
 
     private final SSoggySouls plugin;
     private final DatabaseManager db;
+    private static final Map<UUID, Location> PENDING_REVIVALS = new ConcurrentHashMap<>();
+
+    public static Location consumePendingRevival(UUID uuid) {
+        return PENDING_REVIVALS.remove(uuid);
+    }
 
     public RevivalStructureListener(SSoggySouls plugin) {
         this.plugin = plugin;
@@ -110,12 +118,13 @@ public class RevivalStructureListener implements Listener {
         if (revived != null && revived.isOnline()) {
             restoreAtStructure(revived, spawnLoc);
         } else {
+            PENDING_REVIVALS.put(revivedUuid, spawnLoc);
             summoner.sendMessage(MessageUtil.get("revive-from-limbo",
                     "player", revivedName));
         }
     }
 
-    private static void restoreAtStructure(Player revived, Location spawnLoc) {
+    public static void restoreAtStructure(Player revived, Location spawnLoc) {
         revived.teleport(spawnLoc);
         revived.setGameMode(GameMode.SURVIVAL);
         revived.sendMessage(MessageUtil.get("revive-success"));

--- a/src/main/java/org/ssoggy/ssoggysouls/listener/MainServerListener.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/listener/MainServerListener.java
@@ -78,6 +78,9 @@ public class MainServerListener implements Listener {
         if (pendingRevival != null) {
             // Must run synchronous Bukkit API calls on main thread
             Bukkit.getScheduler().runTask(plugin, () -> {
+                if (player == null || !player.isOnline()) {
+                    return;
+                }
                 org.ssoggy.ssoggysouls.hrm.RevivalStructureListener.restoreAtStructure(player, pendingRevival);
             });
         }

--- a/src/main/java/org/ssoggy/ssoggysouls/listener/MainServerListener.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/listener/MainServerListener.java
@@ -80,11 +80,6 @@ public class MainServerListener implements Listener {
             Bukkit.getScheduler().runTask(plugin, () -> {
                 org.ssoggy.ssoggysouls.hrm.RevivalStructureListener.restoreAtStructure(player, pendingRevival);
             });
-            // Update database data to reflect revival if necessary, though it is usually saved prior by RevivalStructureListener
-            PlayerData data = db.getPlayer(player.getUniqueId());
-            if (data != null && data.isDead()) {
-                 db.revivePlayer(player.getUniqueId(), plugin.getLivesOnRevive());
-            }
         }
 
         PlayerData data = db.getPlayer(player.getUniqueId());

--- a/src/main/java/org/ssoggy/ssoggysouls/listener/MainServerListener.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/listener/MainServerListener.java
@@ -76,13 +76,15 @@ public class MainServerListener implements Listener {
     private void handleJoinAsync(Player player) {
         org.bukkit.Location pendingRevival = org.ssoggy.ssoggysouls.hrm.RevivalStructureListener.consumePendingRevival(player.getUniqueId());
         if (pendingRevival != null) {
-            // Must run synchronous Bukkit API calls on main thread
+            // Must run synchronous Bukkit API calls on main thread.
+            // Return early so the normal dead/limbo redirect logic cannot race with the revival.
             Bukkit.getScheduler().runTask(plugin, () -> {
                 if (player == null || !player.isOnline()) {
                     return;
                 }
                 org.ssoggy.ssoggysouls.hrm.RevivalStructureListener.restoreAtStructure(player, pendingRevival);
             });
+            return;
         }
 
         PlayerData data = db.getPlayer(player.getUniqueId());

--- a/src/main/java/org/ssoggy/ssoggysouls/listener/MainServerListener.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/listener/MainServerListener.java
@@ -74,6 +74,19 @@ public class MainServerListener implements Listener {
     }
 
     private void handleJoinAsync(Player player) {
+        org.bukkit.Location pendingRevival = org.ssoggy.ssoggysouls.hrm.RevivalStructureListener.consumePendingRevival(player.getUniqueId());
+        if (pendingRevival != null) {
+            // Must run synchronous Bukkit API calls on main thread
+            Bukkit.getScheduler().runTask(plugin, () -> {
+                org.ssoggy.ssoggysouls.hrm.RevivalStructureListener.restoreAtStructure(player, pendingRevival);
+            });
+            // Update database data to reflect revival if necessary, though it is usually saved prior by RevivalStructureListener
+            PlayerData data = db.getPlayer(player.getUniqueId());
+            if (data != null && data.isDead()) {
+                 db.revivePlayer(player.getUniqueId(), plugin.getLivesOnRevive());
+            }
+        }
+
         PlayerData data = db.getPlayer(player.getUniqueId());
 
         if (data == null) {

--- a/src/main/java/org/ssoggy/ssoggysouls/listener/MainServerListener.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/listener/MainServerListener.java
@@ -76,15 +76,15 @@ public class MainServerListener implements Listener {
     private void handleJoinAsync(Player player) {
         org.bukkit.Location pendingRevival = org.ssoggy.ssoggysouls.hrm.RevivalStructureListener.consumePendingRevival(player.getUniqueId());
         if (pendingRevival != null) {
-            // Must run synchronous Bukkit API calls on main thread.
-            // Return early so the normal dead/limbo redirect logic cannot race with the revival.
+            // Must run synchronous Bukkit API calls on main thread
             Bukkit.getScheduler().runTask(plugin, () -> {
-                if (player == null || !player.isOnline()) {
-                    return;
-                }
                 org.ssoggy.ssoggysouls.hrm.RevivalStructureListener.restoreAtStructure(player, pendingRevival);
             });
-            return;
+            // Update database data to reflect revival if necessary, though it is usually saved prior by RevivalStructureListener
+            PlayerData data = db.getPlayer(player.getUniqueId());
+            if (data != null && data.isDead()) {
+                 db.revivePlayer(player.getUniqueId(), plugin.getLivesOnRevive());
+            }
         }
 
         PlayerData data = db.getPlayer(player.getUniqueId());


### PR DESCRIPTION
Applied the Fabric `PENDING_REVIVALS` map logic to Forge and Paper/Spigot codebase to resolve offline revivals teleportation correctly upon login.

---
*PR created automatically by Jules for task [15428452865296344273](https://jules.google.com/task/15428452865296344273) started by @SSoggyTacoMan*