### PR TITLE
Fix performance lag caused by RPStorage file IO

### DIFF
--- a/src/main/java/org/ssoggy/ssoggysouls/SSoggySouls.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/SSoggySouls.java
@@ -206,6 +206,8 @@ public final class SSoggySouls extends JavaPlugin implements Listener {
             databaseManager.shutdown();
         }
 
+        org.ssoggy.ssoggysouls.hrm.dlc.RevivalPlus.disable();
+
         getLogger().info("SSoggySouls disabled.");
         setInstance(null);
     }

--- a/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/RevivalPlus.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/RevivalPlus.java
@@ -51,4 +51,20 @@ public final class RevivalPlus {
         java.util.Objects.requireNonNull(plugin.getCommand("ghostmode")).setExecutor(new GhostModeCommand());
         java.util.Objects.requireNonNull(plugin.getCommand("trust")).setExecutor(new SocialCommand());
     }
+
+    public static void disable() {
+        shutdownStorage(RPStatic.DEAD_STORAGE);
+        shutdownStorage(RPStatic.STATS_STORAGE);
+        shutdownStorage(RPStatic.SOCIAL_STORAGE);
+        shutdownStorage(RPStatic.USERNAME_CACHE);
+    }
+
+    private static void shutdownStorage(RPStorage storage) {
+        if (storage == null) return;
+        try {
+            storage.shutdown();
+        } catch (Exception e) {
+            RPStatic.LOGGER.log(java.util.logging.Level.SEVERE, "Error shutting down RPStorage", e);
+        }
+    }
 }

--- a/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPSocial.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPSocial.java
@@ -30,7 +30,6 @@ public class RPSocial {
     private final UUID storedUuid;
     public RPSocial(UUID uuid) {
         this.storedUuid = uuid;
-        RPStatic.SOCIAL_STORAGE.loadConfig();
     }
 
     public void setRelationTo(UUID uuid, @Nullable SOCIALENUM relationship) {

--- a/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPStatic.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPStatic.java
@@ -47,6 +47,7 @@ public class RPStatic {
     public static Map<String, Boolean> CONFIG_RULES;
     public static Map<String, Integer> CONFIG_TIMERS;
 
+    public static RPStorage STATS_STORAGE;
     public static RPStorage SOCIAL_STORAGE;
     public static RPStorage USERNAME_CACHE;
 
@@ -64,6 +65,7 @@ public class RPStatic {
         RPStatic.CONFIG_RULES = new HashMap<>();
         RPStatic.CONFIG_TIMERS = new HashMap<>();
 
+        RPStatic.STATS_STORAGE = new RPStorage(plugin, "stats.yml");
         RPStatic.SOCIAL_STORAGE = new RPStorage(plugin, "social.yml");
 
         RPStatic.USERNAME_CACHE = new RPStorage(plugin, "usernamecache.yml");

--- a/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPStats.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPStats.java
@@ -28,7 +28,7 @@ public class RPStats {
     private final RPStorage storage;
     private final String table;
     public RPStats(UUID uuid) {
-        this.storage = new RPStorage(RPStatic.CLIENT, "stats.yml");
+        this.storage = RPStatic.STATS_STORAGE;
         this.table = uuid.toString().replace("-", "");
     }
 
@@ -44,7 +44,6 @@ public class RPStats {
     }
 
     public void overrideStat(STATSENUM option, Object value) {
-        storage.loadConfig();
         storage.setValue(this.table, option.name(), value);
         storage.saveConfig();
     }

--- a/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPStorage.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPStorage.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -106,5 +107,19 @@ public class RPStorage {
 
     public synchronized Map<String, Object> getTable(String table) throws NullPointerException {
         return config.getConfigurationSection(table).getValues(false);
+    }
+
+    public synchronized void shutdown() {
+        ioExecutor.shutdown();
+        try {
+            if (!ioExecutor.awaitTermination(30, TimeUnit.SECONDS)) {
+                logger.log(Level.WARNING, "RPStorage executor did not terminate in time for {0}; forcing shutdown", file.getName());
+                ioExecutor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            logger.log(Level.WARNING, "RPStorage shutdown interrupted for {0}; forcing shutdown", file.getName());
+            ioExecutor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
     }
 }

--- a/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPStorage.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPStorage.java
@@ -25,8 +25,11 @@ import org.bukkit.plugin.java.JavaPlugin;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -35,6 +38,7 @@ public class RPStorage {
     private final File file;
     private final Logger logger;
     private FileConfiguration config;
+    private final ExecutorService ioExecutor = Executors.newSingleThreadExecutor();
 
 
     public RPStorage(JavaPlugin plugin, String fileName) {
@@ -58,43 +62,49 @@ public class RPStorage {
         loadConfig();
     }
 
-    public void loadConfig() {
+    public synchronized void loadConfig() {
         config = YamlConfiguration.loadConfiguration(file);
     }
 
     public void saveConfig() {
-        try {
-            config.save(file);
-        } catch (IOException e) {
-            logger.log(Level.SEVERE, "Could not save configuration to " + file.getPath(), e);
+        String data;
+        synchronized (this) {
+            data = config.saveToString();
         }
+        ioExecutor.execute(() -> {
+            try {
+                Files.writeString(file.toPath(), data);
+            } catch (IOException e) {
+                logger.log(Level.SEVERE, "Could not save configuration to " + file.getPath(), e);
+            }
+        });
     }
 
-    public void setValue(String table, String key, Object value) {
+    public synchronized void setValue(String table, String key, Object value) {
         String path = table + "." + key;
         config.set(path, value);
     }
 
-    public void removeValue(String table, String key) {
+    public synchronized void removeValue(String table, String key) {
         String path = table + "." + key;
         config.set(path, null);
     }
 
     @Nullable
-    public String getValue(String table, String key) {
+    public synchronized String getValue(String table, String key) {
         return config.getString(table + "." + key, null);
     }
 
-    public boolean hasValue(String table, String key, Object value) {
+    public synchronized boolean hasValue(String table, String key, Object value) {
         String path = table + "." + key;
         return Objects.equals(config.getString(path, null), value);
     }
 
-    public boolean hasValue(String table, String key) {
+    public synchronized boolean hasValue(String table, String key) {
         return !hasValue(table, key, null);
     }
 
-    public Map<String, Object> getTable(String table) throws NullPointerException {
+    public synchronized Map<String, Object> getTable(String table) throws NullPointerException {
         return config.getConfigurationSection(table).getValues(false);
     }
 }


### PR DESCRIPTION
Fixes issues where storage loads would perform blocking synchronous reads on the main thread, leading to potential lag. Fixes Bukkit YamlConfiguration thread-safety issues via synchronization and single-threaded queuing.

---
*PR created automatically by Jules for task [10071992220545301604](https://jules.google.com/task/10071992220545301604) started by @SSoggyTacoMan*