### PR TITLE
Fix Java compilation errors

### DIFF
--- a/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/RevivalPlus.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/RevivalPlus.java
@@ -25,6 +25,7 @@ import org.ssoggy.ssoggysouls.hrm.dlc.commands.SocialCommand;
 import org.ssoggy.ssoggysouls.hrm.dlc.listener.*;
 import org.ssoggy.ssoggysouls.hrm.dlc.util.RPConfig;
 import org.ssoggy.ssoggysouls.hrm.dlc.util.RPStatic;
+import org.ssoggy.ssoggysouls.hrm.dlc.util.RPStorage;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 

--- a/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPStatic.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPStatic.java
@@ -50,7 +50,6 @@ public class RPStatic {
     public static RPStorage STATS_STORAGE;
     public static RPStorage SOCIAL_STORAGE;
     public static RPStorage USERNAME_CACHE;
-    public static RPStorage STATS_STORAGE;
 
     public static void init(JavaPlugin plugin) {
         RPStatic.PLUGIN_ID = "revivalplus"; // DO NOT CHANGE
@@ -70,6 +69,5 @@ public class RPStatic {
         RPStatic.SOCIAL_STORAGE = new RPStorage(plugin, "social.yml");
 
         RPStatic.USERNAME_CACHE = new RPStorage(plugin, "usernamecache.yml");
-        RPStatic.STATS_STORAGE = new RPStorage(plugin, "stats.yml");
     }
 }


### PR DESCRIPTION
Fixes the two Java compilation errors specified by the user:
1. `cannot find symbol: class RPStorage` at line 62 in `RevivalPlus.java` - fixed by adding the missing import.
2. `variable STATS_STORAGE is already defined` at line 53 in `RPStatic.java` - fixed by removing the duplicate variable declaration and duplicate initialization.

---
*PR created automatically by Jules for task [13483957952636774718](https://jules.google.com/task/13483957952636774718) started by @SSoggyTacoMan*