### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS risk in Admin Log Command

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-06 - [Fix OutOfMemoryError reading admin log]
+**Vulnerability:** `Files.readAllLines()` was used to read the admin log file, which can grow arbitrarily large and cause an OOM error.
+**Learning:** Admin log files should always be read using a streaming approach if only the most recent N lines are needed.
+**Prevention:** Use a `Stream` via `Files.lines()` combined with a `Deque` to store only the last N lines.

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -210,11 +210,10 @@ public class CommandRegistration {
                     }
 
                     try {
-                        java.util.List<String> lines = java.nio.file.Files.readAllLines(logFile.toPath());
+                        java.util.Deque<String> lines = readLastLines(logFile, 15);
                         source.sendMessage(net.minecraft.text.Text.literal("--- Recent Admin Logs ---").styled(s -> s.withColor(net.minecraft.util.Formatting.RED).withBold(true)));
-                        int start = Math.max(0, lines.size() - 15);
-                        for (int i = start; i < lines.size(); i++) {
-                            source.sendMessage(net.minecraft.text.Text.literal(lines.get(i)).styled(s -> s.withColor(net.minecraft.util.Formatting.GRAY)));
+                        for (String line : lines) {
+                            source.sendMessage(net.minecraft.text.Text.literal(line).styled(s -> s.withColor(net.minecraft.util.Formatting.GRAY)));
                         }
                     } catch (Exception e) {
                         source.sendError(net.minecraft.text.Text.literal("Error reading admin log: " + e.getMessage()));
@@ -224,5 +223,18 @@ public class CommandRegistration {
                 return 1;
             })
         );
+    }
+
+    private static java.util.Deque<String> readLastLines(java.io.File file, int maxLines) throws Exception {
+        java.util.Deque<String> lastLines = new java.util.ArrayDeque<>(maxLines);
+        try (java.util.stream.Stream<String> lines = java.nio.file.Files.lines(file.toPath())) {
+            lines.forEach(line -> {
+                if (lastLines.size() >= maxLines) {
+                    lastLines.pollFirst();
+                }
+                lastLines.addLast(line);
+            });
+        }
+        return lastLines;
     }
 }

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -211,12 +211,14 @@ public class CommandRegistration {
 
                     try {
                         java.util.Deque<String> lines = readLastLines(logFile, 15);
-                        source.sendMessage(net.minecraft.text.Text.literal("--- Recent Admin Logs ---").styled(s -> s.withColor(net.minecraft.util.Formatting.RED).withBold(true)));
-                        for (String line : lines) {
-                            source.sendMessage(net.minecraft.text.Text.literal(line).styled(s -> s.withColor(net.minecraft.util.Formatting.GRAY)));
-                        }
-                    } catch (Exception e) {
-                        source.sendError(net.minecraft.text.Text.literal("Error reading admin log: " + e.getMessage()));
+                        source.getServer().execute(() -> {
+                            source.sendMessage(net.minecraft.text.Text.literal("--- Recent Admin Logs ---").styled(s -> s.withColor(net.minecraft.util.Formatting.RED).withBold(true)));
+                            for (String line : lines) {
+                                source.sendMessage(net.minecraft.text.Text.literal(line).styled(s -> s.withColor(net.minecraft.util.Formatting.GRAY)));
+                            }
+                        });
+                    } catch (java.io.IOException e) {
+                        source.getServer().execute(() -> source.sendError(net.minecraft.text.Text.literal("Error reading admin log: " + e.getMessage())));
                     }
                 });
 
@@ -225,7 +227,8 @@ public class CommandRegistration {
         );
     }
 
-    private static java.util.Deque<String> readLastLines(java.io.File file, int maxLines) throws Exception {
+    private static java.util.Deque<String> readLastLines(java.io.File file, int maxLines) throws java.io.IOException {
+        if (maxLines <= 0) return new java.util.ArrayDeque<>();
         java.util.Deque<String> lastLines = new java.util.ArrayDeque<>(maxLines);
         try (java.util.stream.Stream<String> lines = java.nio.file.Files.lines(file.toPath())) {
             lines.forEach(line -> {

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -225,12 +225,11 @@ public class CommandRegistration {
                     }
 
                     try {
-                        List<String> lines = Files.readAllLines(logFile.toPath());
+                        java.util.Deque<String> lines = readLastLines(logFile, 15);
                         source.getServer().execute(() -> {
                             source.sendSystemMessage(Component.literal("--- Recent Admin Logs ---").withStyle(net.minecraft.ChatFormatting.RED, net.minecraft.ChatFormatting.BOLD));
-                            int start = Math.max(0, lines.size() - 15);
-                            for (int i = start; i < lines.size(); i++) {
-                                source.sendSystemMessage(Component.literal(lines.get(i)).withStyle(net.minecraft.ChatFormatting.GRAY));
+                            for (String line : lines) {
+                                source.sendSystemMessage(Component.literal(line).withStyle(net.minecraft.ChatFormatting.GRAY));
                             }
                         });
                     } catch (Exception e) {
@@ -241,5 +240,18 @@ public class CommandRegistration {
                 return 1;
             })
         );
+    }
+
+    private static java.util.Deque<String> readLastLines(File file, int maxLines) throws Exception {
+        java.util.Deque<String> lastLines = new java.util.ArrayDeque<>(maxLines);
+        try (java.util.stream.Stream<String> lines = Files.lines(file.toPath())) {
+            lines.forEach(line -> {
+                if (lastLines.size() >= maxLines) {
+                    lastLines.pollFirst();
+                }
+                lastLines.addLast(line);
+            });
+        }
+        return lastLines;
     }
 }

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -232,7 +232,7 @@ public class CommandRegistration {
                                 source.sendSystemMessage(Component.literal(line).withStyle(net.minecraft.ChatFormatting.GRAY));
                             }
                         });
-                    } catch (Exception e) {
+                    } catch (java.io.IOException e) {
                         source.getServer().execute(() -> source.sendFailure(Component.literal("Error reading admin log: " + e.getMessage())));
                     }
                 });
@@ -242,7 +242,8 @@ public class CommandRegistration {
         );
     }
 
-    private static java.util.Deque<String> readLastLines(File file, int maxLines) throws Exception {
+    private static java.util.Deque<String> readLastLines(File file, int maxLines) throws java.io.IOException {
+        if (maxLines <= 0) return new java.util.ArrayDeque<>();
         java.util.Deque<String> lastLines = new java.util.ArrayDeque<>(maxLines);
         try (java.util.stream.Stream<String> lines = Files.lines(file.toPath())) {
             lines.forEach(line -> {


### PR DESCRIPTION
Fix DoS vulnerability in AdminLogCommand

Replaced `Files.readAllLines()` with a stream-based approach in `CommandRegistration.java` for both Fabric and Forge to prevent OutOfMemoryError when reading large log files. Logged the finding in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [15790538745613665816](https://jules.google.com/task/15790538745613665816) started by @SSoggyTacoMan*