### PR TITLE
📦 Porter: Head No-Despawn and Fireproof ported to Fabric and Forge

### DIFF
--- a/.jules/porter.md
+++ b/.jules/porter.md
@@ -1,0 +1,3 @@
+## 2026-05-06 - [Head No-Despawn Parity]
+**Learning:** To prevent item entities from despawning across platforms, the APIs differ significantly: Bukkit/Spigot requires cancelling the `ItemDespawnEvent`, Fabric provides the explicit `ItemEntity.setNeverDespawn()` method, and Forge uses `ItemEntity.setUnlimitedLifetime()`.
+**Action:** Always verify the specific item entity lifecycle methods provided by the target mod loader when porting despawn logic, rather than assuming standard mappings.

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/HeadDropListener.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/HeadDropListener.java
@@ -57,7 +57,14 @@ public class HeadDropListener {
 
             // Spawn item entity
             ItemEntity itemEntity = new ItemEntity(world, pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5, head);
-            itemEntity.setInvulnerable(true);
+
+            if (ConfigManager.getConfig().isHeadFireproof()) {
+                itemEntity.setInvulnerable(true);
+            }
+            if (ConfigManager.getConfig().isHeadNoDespawn()) {
+                itemEntity.setNeverDespawn();
+            }
+
             world.spawnEntity(itemEntity);
             SSoggySoulsMod.LOGGER.info("Dropped {}'s head at {} {} {}", player.getName().getString(), pos.getX(), pos.getY(), pos.getZ());
         }

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/util/ConfigManager.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/util/ConfigManager.java
@@ -103,6 +103,8 @@ public class ConfigManager {
         private boolean hrmEnabled = true;
         private boolean dropHeads = true;
         private boolean headPlaceAsBlock = true;
+        private boolean headNoDespawn = true;
+        private boolean headFireproof = true;
         private boolean headWearingEffects = true;
         private boolean ritualLightningStrike = true;
         private boolean ritualTotemEffect = true;
@@ -181,6 +183,8 @@ public class ConfigManager {
         public boolean isHrmEnabled() { return hrmEnabled; }
         public boolean isDropHeads() { return dropHeads; }
         public boolean isHeadPlaceAsBlock() { return headPlaceAsBlock; }
+        public boolean isHeadNoDespawn() { return headNoDespawn; }
+        public boolean isHeadFireproof() { return headFireproof; }
         public boolean isHeadWearingEffects() { return headWearingEffects; }
         public boolean isRitualLightningStrike() { return ritualLightningStrike; }
         public boolean isRitualTotemEffect() { return ritualTotemEffect; }
@@ -225,6 +229,8 @@ public class ConfigManager {
         public void setHrmEnabled(boolean enabled) { hrmEnabled = enabled; }
         public void setDropHeads(boolean drop) { dropHeads = drop; }
         public void setHeadPlaceAsBlock(boolean place) { headPlaceAsBlock = place; }
+        public void setHeadNoDespawn(boolean noDespawn) { headNoDespawn = noDespawn; }
+        public void setHeadFireproof(boolean fireproof) { headFireproof = fireproof; }
         public void setHeadWearingEffects(boolean effects) { headWearingEffects = effects; }
         public void setRitualLightningStrike(boolean strike) { ritualLightningStrike = strike; }
         public void setRitualTotemEffect(boolean effect) { ritualTotemEffect = effect; }

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/HeadDropListener.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/HeadDropListener.java
@@ -51,7 +51,14 @@ public class HeadDropListener {
                     .withStyle(net.minecraft.ChatFormatting.YELLOW));
 
             ItemEntity itemEntity = new ItemEntity(world, pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5, head);
-            itemEntity.setInvulnerable(true);
+
+            if (ConfigManager.getConfig().isHeadFireproof()) {
+                itemEntity.setInvulnerable(true);
+            }
+            if (ConfigManager.getConfig().isHeadNoDespawn()) {
+                itemEntity.setUnlimitedLifetime();
+            }
+
             world.addFreshEntity(itemEntity);
             SSoggySoulsMod.LOGGER.info("Dropped {}'s head at {} {} {}", player.getScoreboardName(), pos.getX(), pos.getY(), pos.getZ());
         }

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/util/ConfigManager.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/util/ConfigManager.java
@@ -103,6 +103,8 @@ public class ConfigManager {
         private boolean hrmEnabled = true;
         private boolean dropHeads = true;
         private boolean headPlaceAsBlock = true;
+        private boolean headNoDespawn = true;
+        private boolean headFireproof = true;
         private boolean headWearingEffects = true;
         private boolean ritualLightningStrike = true;
         private boolean ritualTotemEffect = true;
@@ -181,6 +183,8 @@ public class ConfigManager {
         public boolean isHrmEnabled() { return hrmEnabled; }
         public boolean isDropHeads() { return dropHeads; }
         public boolean isHeadPlaceAsBlock() { return headPlaceAsBlock; }
+        public boolean isHeadNoDespawn() { return headNoDespawn; }
+        public boolean isHeadFireproof() { return headFireproof; }
         public boolean isHeadWearingEffects() { return headWearingEffects; }
         public boolean isRitualLightningStrike() { return ritualLightningStrike; }
         public boolean isRitualTotemEffect() { return ritualTotemEffect; }
@@ -225,6 +229,8 @@ public class ConfigManager {
         public void setHrmEnabled(boolean enabled) { hrmEnabled = enabled; }
         public void setDropHeads(boolean drop) { dropHeads = drop; }
         public void setHeadPlaceAsBlock(boolean place) { headPlaceAsBlock = place; }
+        public void setHeadNoDespawn(boolean noDespawn) { headNoDespawn = noDespawn; }
+        public void setHeadFireproof(boolean fireproof) { headFireproof = fireproof; }
         public void setHeadWearingEffects(boolean effects) { headWearingEffects = effects; }
         public void setRitualLightningStrike(boolean strike) { ritualLightningStrike = strike; }
         public void setRitualTotemEffect(boolean effect) { ritualTotemEffect = effect; }


### PR DESCRIPTION
💡 What: Ported the `head-no-despawn` and `head-fireproof` config options (introduced in Spigot PR 34) to Fabric and Forge when `head-place-as-block` is false.
🔗 Origin: Commit e77db86 (Merge pull request #34 from PolarMC-Technologies/no-head-despawn)
🛠️ Translation: Added `headNoDespawn` and `headFireproof` to `ConfigManager`. Updated `HeadDropListener` using `setNeverDespawn()` for Fabric and `setUnlimitedLifetime()` for Forge, and conditionally setting `setInvulnerable(true)`.
🔬 Verification: Successfully built and ran `./gradlew test` on both `fabric` and `forge` modules locally.

---
*PR created automatically by Jules for task [6384919261011078144](https://jules.google.com/task/6384919261011078144) started by @SSoggyTacoMan*