### PR TITLE
🎨 Palette: Improve accessibility and UX of documentation site

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-07 - Accessible Navigation Active States
+**Learning:** Using a visual class like `is-active` is insufficient for screen readers to understand which page is currently being viewed in a navigation menu. They require an explicit semantic attribute to indicate the current context.
+**Action:** Always pair visual active classes with `aria-current="page"` on the active navigation link to provide full context to assistive technologies.

--- a/docs/_includes/docs-sidebar.html
+++ b/docs/_includes/docs-sidebar.html
@@ -2,14 +2,14 @@
   <p class="docs-sidebar-title">Documentation</p>
   <nav>
     <ul class="docs-sidebar-list">
-      <li><a class="{% if page.url == '/' or page.url == '/index.html' %}is-active{% endif %}" href="{{ '/' | relative_url }}">Home</a></li>
-      <li><a class="{% if page.url contains 'quick-start' %}is-active{% endif %}" href="{{ '/quick-start' | relative_url }}">Quick Start</a></li>
-      <li><a class="{% if page.url contains 'installation' %}is-active{% endif %}" href="{{ '/installation' | relative_url }}">Installation</a></li>
-      <li><a class="{% if page.url contains 'configuration' %}is-active{% endif %}" href="{{ '/configuration' | relative_url }}">Configuration</a></li>
-      <li><a class="{% if page.url contains 'commands' %}is-active{% endif %}" href="{{ '/commands' | relative_url }}">Commands</a></li>
-      <li><a class="{% if page.url contains 'revival-system' %}is-active{% endif %}" href="{{ '/revival-system' | relative_url }}">Revival System</a></li>
-      <li><a class="{% if page.url contains 'troubleshooting' %}is-active{% endif %}" href="{{ '/troubleshooting' | relative_url }}">Troubleshooting</a></li>
-      <li><a class="{% if page.url contains 'faq' %}is-active{% endif %}" href="{{ '/faq' | relative_url }}">FAQ</a></li>
+      <li><a class="{% if page.url == '/' or page.url == '/index.html' %}is-active{% endif %}" {% if page.url == '/' or page.url == '/index.html' %}aria-current="page"{% endif %} href="{{ '/' | relative_url }}">Home</a></li>
+      <li><a class="{% if page.url contains 'quick-start' %}is-active{% endif %}" {% if page.url contains 'quick-start' %}aria-current="page"{% endif %} href="{{ '/quick-start' | relative_url }}">Quick Start</a></li>
+      <li><a class="{% if page.url contains 'installation' %}is-active{% endif %}" {% if page.url contains 'installation' %}aria-current="page"{% endif %} href="{{ '/installation' | relative_url }}">Installation</a></li>
+      <li><a class="{% if page.url contains 'configuration' %}is-active{% endif %}" {% if page.url contains 'configuration' %}aria-current="page"{% endif %} href="{{ '/configuration' | relative_url }}">Configuration</a></li>
+      <li><a class="{% if page.url contains 'commands' %}is-active{% endif %}" {% if page.url contains 'commands' %}aria-current="page"{% endif %} href="{{ '/commands' | relative_url }}">Commands</a></li>
+      <li><a class="{% if page.url contains 'revival-system' %}is-active{% endif %}" {% if page.url contains 'revival-system' %}aria-current="page"{% endif %} href="{{ '/revival-system' | relative_url }}">Revival System</a></li>
+      <li><a class="{% if page.url contains 'troubleshooting' %}is-active{% endif %}" {% if page.url contains 'troubleshooting' %}aria-current="page"{% endif %} href="{{ '/troubleshooting' | relative_url }}">Troubleshooting</a></li>
+      <li><a class="{% if page.url contains 'faq' %}is-active{% endif %}" {% if page.url contains 'faq' %}aria-current="page"{% endif %} href="{{ '/faq' | relative_url }}">FAQ</a></li>
     </ul>
   </nav>
 </aside>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -21,7 +21,7 @@
       {% if site.github.is_project_page %}
         <a href="{{ site.github.repository_url }}" class="btn">View on GitHub</a>
       {% endif %}
-      <a href="https://modrinth.com/project/Pb03qu6T" class="btn" target="_blank" rel="noopener noreferrer">View on Modrinth</a>
+      <a href="https://modrinth.com/project/Pb03qu6T" class="btn" target="_blank" rel="noopener noreferrer" aria-label="View on Modrinth (opens in a new tab)">View on Modrinth</a>
       {% if site.show_downloads %}
         <a href="{{ site.github.zip_url }}" class="btn">Download .zip</a>
         <a href="{{ site.github.tar_url }}" class="btn">Download .tar.gz</a>

--- a/docs/assets/css/sidebar.css
+++ b/docs/assets/css/sidebar.css
@@ -49,6 +49,12 @@
   text-decoration: none;
 }
 
+.docs-sidebar a:focus-visible {
+  outline: 2px solid #1f4f73;
+  outline-offset: 2px;
+  background: #f1f8f8;
+}
+
 .docs-sidebar a.is-active {
   background: #e8f5f4;
   color: #155e5a;


### PR DESCRIPTION
🎨 Palette: Improve accessibility and UX of documentation site

💡 What: 
- Added `aria-current="page"` to the active documentation sidebar links dynamically based on the Jekyll page URL.
- Added `:focus-visible` CSS styles to the sidebar navigation links.
- Added `aria-label="View on Modrinth (opens in a new tab)"` to the external Modrinth link in the header.
- Created `.jules/palette.md` to record critical UX learnings regarding accessible active states.

🎯 Why: 
- Using only a visual `is-active` class is not sufficient for screen reader users to understand their current context within the navigation.
- Keyboard users require distinct, visible focus indicators to easily navigate interactive elements.
- Screen reader users should be notified when a link they are about to click will open in a new window/tab, rather than the current one.

📸 Before/After: Visual changes apply mainly to the focus state (`outline: 2px solid #1f4f73`) of sidebar links when navigating via keyboard.

♿ Accessibility: Improved screen-reader context for active pages, clearer keyboard focus rings, and clear warnings for links that exit the current browser tab.

---
*PR created automatically by Jules for task [12792778606144331753](https://jules.google.com/task/12792778606144331753) started by @SSoggyTacoMan*