### PR TITLE
Update Forge mod constructor injection and pin Forge to 61.1.5

### DIFF
--- a/forge/gradle.properties
+++ b/forge/gradle.properties
@@ -15,9 +15,9 @@ minecraft_version_range=[1.21.1,1.22)
 # The Forge version must agree with the Minecraft version to get a valid artifact
 forge_version=52.1.0
 # The Forge version range can use any version of Forge as bounds or match the loader version range
-forge_version_range=[0,)
+forge_version_range=[52,53)
 # The loader version range can only use the major version of Forge/FML as bounds
-loader_version_range=[0,)
+loader_version_range=[52,)
 # The mapping channel to use for mappings.
 # The default set of supported mapping channels are ["official", "snapshot", "snapshot_nodoc", "stable", "stable_nodoc"].
 # Additional mapping channels can be registered through the "channelProviders" extension in a Gradle plugin.

--- a/forge/gradle.properties
+++ b/forge/gradle.properties
@@ -13,11 +13,11 @@ minecraft_version=1.21.1
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[1.21.1,1.22)
 # The Forge version must agree with the Minecraft version to get a valid artifact
-forge_version=61.1.5
+forge_version=52.1.0
 # The Forge version range can use any version of Forge as bounds or match the loader version range
-forge_version_range=[61.1.5,)
+forge_version_range=[0,)
 # The loader version range can only use the major version of Forge/FML as bounds
-loader_version_range=[61,)
+loader_version_range=[0,)
 # The mapping channel to use for mappings.
 # The default set of supported mapping channels are ["official", "snapshot", "snapshot_nodoc", "stable", "stable_nodoc"].
 # Additional mapping channels can be registered through the "channelProviders" extension in a Gradle plugin.

--- a/forge/gradle.properties
+++ b/forge/gradle.properties
@@ -13,11 +13,11 @@ minecraft_version=1.21.1
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[1.21.1,1.22)
 # The Forge version must agree with the Minecraft version to get a valid artifact
-forge_version=52.1.0
+forge_version=61.1.5
 # The Forge version range can use any version of Forge as bounds or match the loader version range
-forge_version_range=[0,)
+forge_version_range=[61.1.5,)
 # The loader version range can only use the major version of Forge/FML as bounds
-loader_version_range=[0,)
+loader_version_range=[61,)
 # The mapping channel to use for mappings.
 # The default set of supported mapping channels are ["official", "snapshot", "snapshot_nodoc", "stable", "stable_nodoc"].
 # Additional mapping channels can be registered through the "channelProviders" extension in a Gradle plugin.

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
@@ -7,7 +7,6 @@ import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.slf4j.Logger;
 import net.minecraftforge.fml.loading.FMLPaths;
 import org.ssoggy.ssoggysouls.util.ConfigManager;
@@ -34,8 +33,7 @@ public class SSoggySoulsMod implements PluginContext {
     public static final Logger LOGGER = LogUtils.getLogger();
     private static final java.util.logging.Logger JUL_LOGGER = java.util.logging.Logger.getLogger(MODID);
 
-    public SSoggySoulsMod(FMLJavaModLoadingContext context) {
-        IEventBus modEventBus = context.getModEventBus();
+    public SSoggySoulsMod(IEventBus modEventBus) {
 
         // Register the commonSetup method for modloading
         modEventBus.addListener(this::commonSetup);

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
@@ -7,6 +7,7 @@ import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.slf4j.Logger;
 import net.minecraftforge.fml.loading.FMLPaths;
 import org.ssoggy.ssoggysouls.util.ConfigManager;
@@ -33,7 +34,8 @@ public class SSoggySoulsMod implements PluginContext {
     public static final Logger LOGGER = LogUtils.getLogger();
     private static final java.util.logging.Logger JUL_LOGGER = java.util.logging.Logger.getLogger(MODID);
 
-    public SSoggySoulsMod(IEventBus modEventBus) {
+    public SSoggySoulsMod(FMLJavaModLoadingContext context) {
+        IEventBus modEventBus = context.getModEventBus();
 
         // Register the commonSetup method for modloading
         modEventBus.addListener(this::commonSetup);


### PR DESCRIPTION
### Motivation
- Align the mod entrypoint with modern Forge (v61+) constructor injection which provides the `IEventBus` directly to avoid API/compatibility mismatches.
- Prevent future compile-time desyncs by pinning the Forge and loader version variables to a matching `61.1.5` API in `forge/gradle.properties`.

### Description
- Changed the main mod constructor from `public SSoggySoulsMod(FMLJavaModLoadingContext context)` to `public SSoggySoulsMod(IEventBus modEventBus)` in `forge/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java`.
- Removed the internal `IEventBus modEventBus = context.getModEventBus();` usage and deleted the `net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext` import.
- Updated `forge/gradle.properties` to `forge_version=61.1.5`, `forge_version_range=[61.1.5,)`, and `loader_version_range=[61,)` to match the Forge 61.1.5 API.

### Testing
- Verified the file diffs to confirm the constructor signature, import removal, and `gradle.properties` changes were applied.
- No compilation or unit test suite was run as part of this change; please run a full build (`./gradlew build`) against Forge `61.1.5` to validate compile-time compatibility.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc660a952483239f2ba6eaf4376e70)