### PR TITLE
Use 'main' entrypoint in fabric.mod.json to register ModInitializer

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
   "icon": "assets/ssoggysouls/icon.png",
   "environment": "*",
   "entrypoints": {
-    "server": [
+    "main": [
       "org.ssoggy.ssoggysouls.SSoggySoulsMod"
     ],
     "modmenu": [


### PR DESCRIPTION
### Motivation
- Fix the `DedicatedServerModInitializer` casting crash by registering the mod class as a `ModInitializer` using the correct Fabric entrypoint key.

### Description
- Replace `"server"` with `"main"` in `fabric/src/main/resources/fabric.mod.json` under `entrypoints` while keeping `org.ssoggy.ssoggysouls.SSoggySoulsMod` exactly the same.

### Testing
- Verified the JSON change via diff and file inspection of `fabric/src/main/resources/fabric.mod.json`, confirming the entrypoint now reads `"main": ["org.ssoggy.ssoggysouls.SSoggySoulsMod"]`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc6621caac83238bf69f8528e740de)