### PR TITLE
Gracefully handle HikariCP connection failures with friendly warning

### DIFF
--- a/common/src/main/java/org/ssoggy/ssoggysouls/database/MySQLManager.java
+++ b/common/src/main/java/org/ssoggy/ssoggysouls/database/MySQLManager.java
@@ -93,12 +93,13 @@ public class MySQLManager implements DatabaseManager {
 
             try {
                 hikariDataSource = new HikariDataSource(config);
-            } catch (Exception ex) {
+            } catch (RuntimeException ex) {
                 plugin.getLogger().severe("=====================================================");
-                plugin.getLogger().severe("SEVERE: Could not connect to the MySQL database. The connection was refused.");
-                plugin.getLogger().severe("If you are setting up a multi-server Limbo network, please double-check your IP, port, username, and password in config.yml.");
+                plugin.getLogger().severe("SEVERE: Could not connect to the MySQL database. The plugin will be disabled.");
+                plugin.getLogger().severe("Please check your connection details in config.yml and see the server log for the full error.");
                 plugin.getLogger().severe("NOTICE: If you are only running a single server, you DO NOT need MySQL! The default database is SQLite. Open config.yml and change type: \"mysql\" back to type: \"sqlite\" to fix this instantly.");
                 plugin.getLogger().severe("=====================================================");
+                plugin.getLogger().log(Level.SEVERE, "MySQL connection error:", ex);
                 return false;
             }
 

--- a/common/src/main/java/org/ssoggy/ssoggysouls/database/MySQLManager.java
+++ b/common/src/main/java/org/ssoggy/ssoggysouls/database/MySQLManager.java
@@ -91,7 +91,17 @@ public class MySQLManager implements DatabaseManager {
             config.addDataSourceProperty("prepStmtCacheSize", "64");
             config.addDataSourceProperty("prepStmtCacheSqlLimit", "2048");
 
-            hikariDataSource = new HikariDataSource(config);
+            try {
+                hikariDataSource = new HikariDataSource(config);
+            } catch (Exception ex) {
+                plugin.getLogger().severe("=====================================================");
+                plugin.getLogger().severe("SEVERE: Could not connect to the MySQL database. The connection was refused.");
+                plugin.getLogger().severe("If you are setting up a multi-server Limbo network, please double-check your IP, port, username, and password in config.yml.");
+                plugin.getLogger().severe("NOTICE: If you are only running a single server, you DO NOT need MySQL! The default database is SQLite. Open config.yml and change type: \"mysql\" back to type: \"sqlite\" to fix this instantly.");
+                plugin.getLogger().severe("=====================================================");
+                return false;
+            }
+
             dataSource = hikariDataSource;
             createTable();
 


### PR DESCRIPTION
Fixes an issue where a MySQL connection failure during HikariDataSource initialization would throw a massive console stack trace and potentially crash the server thread. Now, it catches the exception, prints a highly visible and friendly multi-line warning, and gracefully returns `false` to disable the plugin safely.

---
*PR created automatically by Jules for task [9147608557179835449](https://jules.google.com/task/9147608557179835449) started by @SSoggyTacoMan*