### PR TITLE
Rename admin_abuse.log to admin.log

### DIFF
--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -226,7 +226,7 @@ public class CommandRegistration {
                 ServerCommandSource source = context.getSource();
 
                 CompletableFuture.runAsync(() -> {
-                    java.io.File logFile = new java.io.File(plugin.getDataFolder(), "admin_abuse.log");
+                    java.io.File logFile = new java.io.File(plugin.getDataFolder(), "admin.log");
                     if (!logFile.exists()) {
                         source.sendError(net.minecraft.text.Text.literal("No admin logs found."));
                         return;

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -226,7 +226,7 @@ public class CommandRegistration {
                 ServerCommandSource source = context.getSource();
 
                 CompletableFuture.runAsync(() -> {
-                    java.io.File logFile = new java.io.File(plugin.getDataFolder(), "admin.log");
+                    java.io.File logFile = new java.io.File(plugin.getDataFolder(), AdminLogger.LOG_FILE_NAME);
                     if (!logFile.exists()) {
                         source.sendError(net.minecraft.text.Text.literal("No admin logs found."));
                         return;

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/util/AdminLogger.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/util/AdminLogger.java
@@ -12,7 +12,7 @@ import java.time.format.DateTimeFormatter;
 
 public class AdminLogger {
 
-    private static final String LOG_FILE_NAME = "admin_abuse.log";
+    private static final String LOG_FILE_NAME = "admin.log";
     private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private static final Object WRITE_LOCK = new Object();
 

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/util/AdminLogger.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/util/AdminLogger.java
@@ -12,7 +12,7 @@ import java.time.format.DateTimeFormatter;
 
 public class AdminLogger {
 
-    private static final String LOG_FILE_NAME = "admin.log";
+    public static final String LOG_FILE_NAME = "admin.log";
     private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private static final Object WRITE_LOCK = new Object();
 

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -243,7 +243,7 @@ public class CommandRegistration {
                 CommandSourceStack source = context.getSource();
 
                 CompletableFuture.runAsync(() -> {
-                    File logFile = net.minecraftforge.fml.loading.FMLPaths.CONFIGDIR.get().resolve(SSoggySoulsMod.MODID).resolve("admin.log").toFile();
+                    File logFile = net.minecraftforge.fml.loading.FMLPaths.CONFIGDIR.get().resolve(SSoggySoulsMod.MODID).resolve(AdminLogger.LOG_FILE_NAME).toFile();
                     if (!logFile.exists()) {
                         source.sendFailure(Component.literal("No admin logs found."));
                         return;

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -243,7 +243,7 @@ public class CommandRegistration {
                 CommandSourceStack source = context.getSource();
 
                 CompletableFuture.runAsync(() -> {
-                    File logFile = net.minecraftforge.fml.loading.FMLPaths.CONFIGDIR.get().resolve(SSoggySoulsMod.MODID).resolve("admin_abuse.log").toFile();
+                    File logFile = net.minecraftforge.fml.loading.FMLPaths.CONFIGDIR.get().resolve(SSoggySoulsMod.MODID).resolve("admin.log").toFile();
                     if (!logFile.exists()) {
                         source.sendFailure(Component.literal("No admin logs found."));
                         return;

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/util/AdminLogger.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/util/AdminLogger.java
@@ -12,7 +12,7 @@ import java.time.format.DateTimeFormatter;
 
 public class AdminLogger {
 
-    private static final String LOG_FILE_NAME = "admin_abuse.log";
+    private static final String LOG_FILE_NAME = "admin.log";
     private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private static final Object WRITE_LOCK = new Object();
 

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/util/AdminLogger.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/util/AdminLogger.java
@@ -12,7 +12,7 @@ import java.time.format.DateTimeFormatter;
 
 public class AdminLogger {
 
-    private static final String LOG_FILE_NAME = "admin.log";
+    public static final String LOG_FILE_NAME = "admin.log";
     private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private static final Object WRITE_LOCK = new Object();
 

--- a/src/main/java/org/ssoggy/ssoggysouls/command/AdminLogCommand.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/command/AdminLogCommand.java
@@ -34,7 +34,7 @@ public class AdminLogCommand implements CommandExecutor {
         int linesToRead = parseLineCount(sender, args);
         if (linesToRead < 0) return true; // error already sent
 
-        File logFile = new File(plugin.getDataFolder(), "admin.log");
+        File logFile = new File(plugin.getDataFolder(), org.ssoggy.ssoggysouls.util.AdminLogger.LOG_FILE_NAME);
         if (!logFile.exists()) {
             sender.sendMessage(MessageUtil.colorize("&eNo admin log file found. No admin actions have been recorded yet."));
             return true;

--- a/src/main/java/org/ssoggy/ssoggysouls/command/AdminLogCommand.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/command/AdminLogCommand.java
@@ -34,7 +34,7 @@ public class AdminLogCommand implements CommandExecutor {
         int linesToRead = parseLineCount(sender, args);
         if (linesToRead < 0) return true; // error already sent
 
-        File logFile = new File(plugin.getDataFolder(), "admin_abuse.log");
+        File logFile = new File(plugin.getDataFolder(), "admin.log");
         if (!logFile.exists()) {
             sender.sendMessage(MessageUtil.colorize("&eNo admin log file found. No admin actions have been recorded yet."));
             return true;

--- a/src/main/java/org/ssoggy/ssoggysouls/util/AdminLogger.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/util/AdminLogger.java
@@ -11,7 +11,7 @@ import java.util.logging.Level;
 
 public class AdminLogger {
 
-    private static final String LOG_FILE_NAME = "admin_abuse.log";
+    private static final String LOG_FILE_NAME = "admin.log";
     private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private static final Object WRITE_LOCK = new Object();
 

--- a/src/main/java/org/ssoggy/ssoggysouls/util/AdminLogger.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/util/AdminLogger.java
@@ -11,7 +11,7 @@ import java.util.logging.Level;
 
 public class AdminLogger {
 
-    private static final String LOG_FILE_NAME = "admin.log";
+    public static final String LOG_FILE_NAME = "admin.log";
     private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private static final Object WRITE_LOCK = new Object();
 


### PR DESCRIPTION
Renames the `admin_abuse.log` file to `admin.log` as requested by the user. Made changes across the Bukkit/Spigot base project, the Forge module, and the Fabric module. All tests passed.

---
*PR created automatically by Jules for task [12070999832999139942](https://jules.google.com/task/12070999832999139942) started by @SSoggyTacoMan*