### PR TITLE
fix: `/revivalconfig` silent failures on invalid arguments

### DIFF
--- a/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/RPConfigCommand.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/RPConfigCommand.java
@@ -110,6 +110,11 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
         Material whoMat;
         String whoName;
         OPTIONEDITENUM action = OPTIONEDITENUM.getEnumFromVal(what);
+        if (!RPStatic.BLOCK_TAGS.containsKey(where)) {
+            result.success = COMMANDOUTPUTENUM.FALSE;
+            result.message = "Invalid structure: " + where;
+            return;
+        }
         if (action == null) {
             result.success = COMMANDOUTPUTENUM.FALSE;
             result.message = "Use add, remove, or reset.";

--- a/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/RPConfigCommand.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/RPConfigCommand.java
@@ -83,9 +83,14 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
     }
 
     private void executeTimerCMD(String who, String where, RPCommandOutput result) {
-        int whoInt = Integer.parseInt(who);
-        result.success = COMMANDOUTPUTENUM.valueOf(RPConfig.setConfigTimer(where, whoInt));
-        result.message = "Set " + where + " to " + whoInt;
+        try {
+            int whoInt = Integer.parseInt(who);
+            result.success = COMMANDOUTPUTENUM.valueOf(RPConfig.setConfigTimer(where, whoInt));
+            result.message = "Set " + where + " to " + whoInt;
+        } catch (NumberFormatException e) {
+            result.success = COMMANDOUTPUTENUM.FALSE;
+            result.message = "Timer value must be a number.";
+        }
     }
 
     private void executeGameruleCMD(String who, String where, RPCommandOutput result) {
@@ -98,9 +103,14 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
         Set<Material> whoSet;
         Material whoMat;
         String whoName;
-        switch(OPTIONEDITENUM.getEnumFromVal(what)) {
-            case null:
-                break;
+        OPTIONEDITENUM action = OPTIONEDITENUM.getEnumFromVal(what);
+        if (action == null) {
+            result.success = COMMANDOUTPUTENUM.FALSE;
+            result.message = "Use add, remove, or reset.";
+            return;
+        }
+
+        switch(action) {
             case OPTIONEDITENUM.ADD: // add
                 if (!Objects.equals(who, "ALL")) {
                     whoMat = Material.getMaterial(who);
@@ -159,7 +169,8 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
 
         OPTIONCONFIGENUM option = OPTIONCONFIGENUM.getEnumFromVal(opt1);
         if (option == null) {
-            // No-op: null option is silently ignored
+            result.success = COMMANDOUTPUTENUM.FALSE;
+            result.message = "Please use /revivalconfig <structure|gamerule|timer|reload>";
         } else {
             switch (option) {
                 case OPTIONCONFIGENUM.STRUCTURE -> handleStructure(args, result);

--- a/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/RPConfigCommand.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/RPConfigCommand.java
@@ -83,10 +83,16 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
     }
 
     private void executeTimerCMD(String who, String where, RPCommandOutput result) {
+        if (!RPStatic.CONFIG_TIMERS.containsKey(where)) {
+            result.success = COMMANDOUTPUTENUM.FALSE;
+            result.message = "Invalid timer: " + where;
+            return;
+        }
         try {
             int whoInt = Integer.parseInt(who);
-            result.success = COMMANDOUTPUTENUM.valueOf(RPConfig.setConfigTimer(where, whoInt));
-            result.message = "Set " + where + " to " + whoInt;
+            byte status = RPConfig.setConfigTimer(where, whoInt);
+            result.success = COMMANDOUTPUTENUM.valueOf(status);
+            result.message = (status == 1) ? "Set " + where + " to " + whoInt : "Failed to update configuration.";
         } catch (NumberFormatException e) {
             result.success = COMMANDOUTPUTENUM.FALSE;
             result.message = "Timer value must be a number.";


### PR DESCRIPTION
* Updated `RPConfigCommand.onCommand` to explicitly set an error output instead of silently ignoring invalid options
* Handled `NumberFormatException` in `executeTimerCMD` to prevent console errors when a non-number is provided to timer configs
* Added a `null` check on the structure edit option enum to instruct the user to use 'add', 'remove', or 'reset' when they make typos

---
*PR created automatically by Jules for task [12289616556526962586](https://jules.google.com/task/12289616556526962586) started by @SSoggyTacoMan*