### PR TITLE
Make SQLite default database and add first-setup prompt for MySQL

### DIFF
--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/util/ConfigManager.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/util/ConfigManager.java
@@ -31,6 +31,18 @@ public class ConfigManager {
         } else {
             config = new ModConfig();
             save();
+            org.ssoggy.ssoggysouls.SSoggySoulsMod.LOGGER.info("\n" +
+                    "===============================================================\n" +
+                    "                       SSOGGY SOULS\n" +
+                    "===============================================================\n" +
+                    " The mod is using SQLite (single-server mode) by default.\n" +
+                    " \n" +
+                    " If you are setting up a Dual-Server Network (Main + Limbo),\n" +
+                    " you MUST stop the server, open ssoggysouls.json, and change the\n" +
+                    " 'databaseType' to 'mysql', then fill in your DB details.\n" +
+                    " \n" +
+                    " If you are using a single server, you can ignore this message.\n" +
+                    "===============================================================\n");
         }
     }
 

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/util/ConfigManager.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/util/ConfigManager.java
@@ -31,6 +31,18 @@ public class ConfigManager {
         } else {
             config = new ModConfig();
             save();
+            org.ssoggy.ssoggysouls.SSoggySoulsMod.LOGGER.info("\n" +
+                    "===============================================================\n" +
+                    "                       SSOGGY SOULS\n" +
+                    "===============================================================\n" +
+                    " The mod is using SQLite (single-server mode) by default.\n" +
+                    " \n" +
+                    " If you are setting up a Dual-Server Network (Main + Limbo),\n" +
+                    " you MUST stop the server, open ssoggysouls.json, and change the\n" +
+                    " 'databaseType' to 'mysql', then fill in your DB details.\n" +
+                    " \n" +
+                    " If you are using a single server, you can ignore this message.\n" +
+                    "===============================================================\n");
         }
     }
 

--- a/src/main/java/org/ssoggy/ssoggysouls/SSoggySouls.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/SSoggySouls.java
@@ -113,7 +113,25 @@ public final class SSoggySouls extends JavaPlugin implements Listener, PluginCon
     @Override
     public void onEnable() {
         setInstance(this);
-        saveDefaultConfig();
+
+        java.io.File configFile = new java.io.File(getDataFolder(), "config.yml");
+        if (!configFile.exists()) {
+            saveDefaultConfig();
+            getLogger().info("\n" +
+                    "===============================================================\n" +
+                    "                       SSOGGY SOULS\n" +
+                    "===============================================================\n" +
+                    " The plugin is using SQLite (single-server mode) by default.\n" +
+                    " \n" +
+                    " If you are setting up a Dual-Server Network (Main + Limbo),\n" +
+                    " you MUST stop the server, open config.yml, and change the\n" +
+                    " 'database.type' to 'mysql', then fill in your DB details.\n" +
+                    " \n" +
+                    " If you are using a single server, you can ignore this message.\n" +
+                    "===============================================================\n");
+        } else {
+            saveDefaultConfig();
+        }
 
         for (World world : getServer().getWorlds()) {
             originalWorldHardcore.put(world.getName(), world.isHardcore());
@@ -124,7 +142,7 @@ public final class SSoggySouls extends JavaPlugin implements Listener, PluginCon
         getServer().getMessenger().registerOutgoingPluginChannel(this, "BungeeCord");
         getServer().getPluginManager().registerEvents(this, this);
 
-        String dbType = getConfig().getString("database.type", "mysql").toLowerCase();
+        String dbType = getConfig().getString("database.type", "sqlite").toLowerCase();
 
         if (dbType.equals("sqlite") || dbType.equals("local")) {
             databaseManager = new org.ssoggy.ssoggysouls.database.SQLiteManager(this);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -73,7 +73,7 @@ hardcore-hearts: true
 database:
   # Options: "sqlite" or "mysql"
   # If you pick "sqlite", you can ignore everything below this line in this section.
-  type: "mysql"
+  type: "sqlite"
 
   # ── MySQL connection details (ignored when type is "sqlite") ──
 


### PR DESCRIPTION
This PR changes the default database engine across Spigot, Fabric, and Forge from MySQL to SQLite. It also updates the respective configuration managers to check if the main configuration file is missing at startup (indicating a first-time setup). If missing, it generates the default config and logs a prominent ASCII banner to the console notifying users that SQLite is active by default, and providing instructions to switch to MySQL for dual-server setups. All platform tests pass correctly.

---
*PR created automatically by Jules for task [3079512419557499363](https://jules.google.com/task/3079512419557499363) started by @SSoggyTacoMan*