### PR TITLE
Group DLC features under the HRM block in config

### DIFF
--- a/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/ObituariesCommand.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/ObituariesCommand.java
@@ -42,6 +42,9 @@ import java.util.Map;
 import java.util.UUID;
 
 public class ObituariesCommand implements CommandExecutor, TabCompleter {
+    private static final long DEFAULT_TRUSTED_OBITUARY_DELAY_MINUTES = 60L;
+    private static final long DEFAULT_FRIENDS_OBITUARY_DELAY_MINUTES = 600L;
+    private static final long DEFAULT_PUBLIC_OBITUARY_DELAY_MINUTES = 3600L;
 
     @Override
     public boolean onCommand(@NotNull CommandSender cmdSender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
@@ -51,9 +54,9 @@ public class ObituariesCommand implements CommandExecutor, TabCompleter {
         RPCommandOutput result = new RPCommandOutput();
         FileConfiguration config = RPStatic.CLIENT.getConfig();
 
-        long trustedAfterMin = getObituaryDelayMinutes(config, "trusted-obituary-after", 60L);
-        long friendsAfterMin = getObituaryDelayMinutes(config, "friends-obituary-after", 600L);
-        long publicAfterMin = getObituaryDelayMinutes(config, "public-obituary-after", 3600L);
+        long trustedAfterMin = getObituaryDelayMinutes(config, "trusted-obituary-after", DEFAULT_TRUSTED_OBITUARY_DELAY_MINUTES);
+        long friendsAfterMin = getObituaryDelayMinutes(config, "friends-obituary-after", DEFAULT_FRIENDS_OBITUARY_DELAY_MINUTES);
+        long publicAfterMin = getObituaryDelayMinutes(config, "public-obituary-after", DEFAULT_PUBLIC_OBITUARY_DELAY_MINUTES);
 
         String headerText = "Here is a list of all the current public deaths";
         StringBuilder deathListBuilder = new StringBuilder(headerText);

--- a/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/ObituariesCommand.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/ObituariesCommand.java
@@ -51,9 +51,9 @@ public class ObituariesCommand implements CommandExecutor, TabCompleter {
         RPCommandOutput result = new RPCommandOutput();
         FileConfiguration config = RPStatic.CLIENT.getConfig();
 
-        long trustedAfterMin = config.getLong("trusted-obituary-after");
-        long friendsAfterMin = config.getLong("friends-obituary-after");
-        long publicAfterMin = config.getLong("public-obituary-after");
+        long trustedAfterMin = getObituaryDelayMinutes(config, "trusted-obituary-after", 60L);
+        long friendsAfterMin = getObituaryDelayMinutes(config, "friends-obituary-after", 600L);
+        long publicAfterMin = getObituaryDelayMinutes(config, "public-obituary-after", 3600L);
 
         String headerText = "Here is a list of all the current public deaths";
         StringBuilder deathListBuilder = new StringBuilder(headerText);
@@ -94,5 +94,13 @@ public class ObituariesCommand implements CommandExecutor, TabCompleter {
     @Override
     public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args) {
         return Bukkit.getOnlinePlayers().stream().map(Player::getName).toList();
+    }
+
+    private static long getObituaryDelayMinutes(FileConfiguration config, String key, long fallback) {
+        String hrmPath = "hrm." + key;
+        if (config.contains(hrmPath)) {
+            return config.getLong(hrmPath);
+        }
+        return config.getLong(key, fallback);
     }
 }

--- a/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPConfig.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPConfig.java
@@ -72,9 +72,9 @@ public class RPConfig {
         RPStatic.CLIENT.saveDefaultConfig();
         RPStatic.CLIENT.reloadConfig();
         FileConfiguration fileConfiguration = RPStatic.CLIENT.getConfig();
-        RPStatic.BLOCK_TAGS.forEach((key, value) -> RPStatic.BLOCK_TAGS.put(key, fileConfiguration.getStringList(key).stream().map(Material::getMaterial).collect(Collectors.toSet())));
-        RPStatic.CONFIG_RULES.forEach((key, value) -> RPStatic.CONFIG_RULES.put(key, fileConfiguration.getBoolean(key, value)));
-        RPStatic.CONFIG_TIMERS.forEach((key, value) -> RPStatic.CONFIG_TIMERS.put(key, fileConfiguration.getInt(key, value)));
+        RPStatic.BLOCK_TAGS.forEach((key, value) -> RPStatic.BLOCK_TAGS.put(key, fileConfiguration.getStringList("hrm." + key).stream().map(Material::getMaterial).collect(Collectors.toSet())));
+        RPStatic.CONFIG_RULES.forEach((key, value) -> RPStatic.CONFIG_RULES.put(key, fileConfiguration.getBoolean("hrm." + key, value)));
+        RPStatic.CONFIG_TIMERS.forEach((key, value) -> RPStatic.CONFIG_TIMERS.put(key, fileConfiguration.getInt("hrm." + key, value)));
     }
 
     public static byte resetBlockTag(String where) {
@@ -84,7 +84,7 @@ public class RPConfig {
     public static byte setBlockTag(String where, Set<Material> who) {
         try {
             JavaPlugin instance = RPStatic.CLIENT;
-            instance.getConfig().set(where, who.stream().map(Enum::name).toList());
+            instance.getConfig().set("hrm." + where, who.stream().map(Enum::name).toList());
             instance.saveConfig();
             instance.reloadConfig();
             RPStatic.BLOCK_TAGS.put(where, who);
@@ -98,7 +98,7 @@ public class RPConfig {
     public static byte setConfigRule(String where, boolean who) {
         try {
             JavaPlugin instance = RPStatic.CLIENT;
-            instance.getConfig().set(where, who);
+            instance.getConfig().set("hrm." + where, who);
             instance.saveConfig();
             instance.reloadConfig();
             RPStatic.CONFIG_RULES.put(where, who);
@@ -112,7 +112,7 @@ public class RPConfig {
     public static byte setConfigTimer(String where, int who) {
         try {
             JavaPlugin instance = RPStatic.CLIENT;
-            instance.getConfig().set(where, who);
+            instance.getConfig().set("hrm." + where, who);
             instance.saveConfig();
             instance.reloadConfig();
             RPStatic.CONFIG_TIMERS.put(where, who);

--- a/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPConfig.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPConfig.java
@@ -19,7 +19,9 @@ along with RevivePlus.  If not, see <https://www.gnu.org/licenses/>
 package org.ssoggy.ssoggysouls.hrm.dlc.util;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -75,16 +77,10 @@ public class RPConfig {
         RPStatic.BLOCK_TAGS.replaceAll((key, value) -> {
             String hrmPath = "hrm." + key;
             if (fileConfiguration.contains(hrmPath)) {
-                return fileConfiguration.getStringList(hrmPath).stream()
-                        .map(Material::matchMaterial)
-                        .filter(m -> m != null)
-                        .collect(Collectors.toSet());
+                return parseMaterials(fileConfiguration.getStringList(hrmPath));
             }
             if (fileConfiguration.contains(key)) {
-                return fileConfiguration.getStringList(key).stream()
-                        .map(Material::matchMaterial)
-                        .filter(m -> m != null)
-                        .collect(Collectors.toSet());
+                return parseMaterials(fileConfiguration.getStringList(key));
             }
             return value;
         });
@@ -137,5 +133,9 @@ public class RPConfig {
             RPStatic.LOGGER.severe(e.getMessage());
             return 0;
         }
+    }
+
+    private static Set<Material> parseMaterials(List<String> values) {
+        return values.stream().map(Material::matchMaterial).filter(Objects::nonNull).collect(Collectors.toSet());
     }
 }

--- a/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPConfig.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPConfig.java
@@ -72,9 +72,9 @@ public class RPConfig {
         RPStatic.CLIENT.saveDefaultConfig();
         RPStatic.CLIENT.reloadConfig();
         FileConfiguration fileConfiguration = RPStatic.CLIENT.getConfig();
-        RPStatic.BLOCK_TAGS.forEach((key, value) -> RPStatic.BLOCK_TAGS.put(key, fileConfiguration.getStringList("hrm." + key).stream().map(Material::getMaterial).collect(Collectors.toSet())));
-        RPStatic.CONFIG_RULES.forEach((key, value) -> RPStatic.CONFIG_RULES.put(key, fileConfiguration.getBoolean("hrm." + key, value)));
-        RPStatic.CONFIG_TIMERS.forEach((key, value) -> RPStatic.CONFIG_TIMERS.put(key, fileConfiguration.getInt("hrm." + key, value)));
+        RPStatic.BLOCK_TAGS.replaceAll((key, value) -> fileConfiguration.contains("hrm." + key) ? fileConfiguration.getStringList("hrm." + key).stream().map(Material::matchMaterial).filter(m -> m != null).collect(Collectors.toSet()) : value);
+        RPStatic.CONFIG_RULES.replaceAll((key, value) -> fileConfiguration.getBoolean("hrm." + key, value));
+        RPStatic.CONFIG_TIMERS.replaceAll((key, value) -> fileConfiguration.getInt("hrm." + key, value));
     }
 
     public static byte resetBlockTag(String where) {

--- a/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPConfig.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPConfig.java
@@ -72,9 +72,28 @@ public class RPConfig {
         RPStatic.CLIENT.saveDefaultConfig();
         RPStatic.CLIENT.reloadConfig();
         FileConfiguration fileConfiguration = RPStatic.CLIENT.getConfig();
-        RPStatic.BLOCK_TAGS.replaceAll((key, value) -> fileConfiguration.contains("hrm." + key) ? fileConfiguration.getStringList("hrm." + key).stream().map(Material::matchMaterial).filter(m -> m != null).collect(Collectors.toSet()) : value);
-        RPStatic.CONFIG_RULES.replaceAll((key, value) -> fileConfiguration.getBoolean("hrm." + key, value));
-        RPStatic.CONFIG_TIMERS.replaceAll((key, value) -> fileConfiguration.getInt("hrm." + key, value));
+        RPStatic.BLOCK_TAGS.replaceAll((key, value) -> {
+            String hrmPath = "hrm." + key;
+            if (fileConfiguration.contains(hrmPath)) {
+                return fileConfiguration.getStringList(hrmPath).stream()
+                        .map(Material::matchMaterial)
+                        .filter(m -> m != null)
+                        .collect(Collectors.toSet());
+            }
+            if (fileConfiguration.contains(key)) {
+                return fileConfiguration.getStringList(key).stream()
+                        .map(Material::matchMaterial)
+                        .filter(m -> m != null)
+                        .collect(Collectors.toSet());
+            }
+            return value;
+        });
+        RPStatic.CONFIG_RULES.replaceAll((key, value) -> fileConfiguration.contains("hrm." + key)
+                ? fileConfiguration.getBoolean("hrm." + key, value)
+                : fileConfiguration.getBoolean(key, value));
+        RPStatic.CONFIG_TIMERS.replaceAll((key, value) -> fileConfiguration.contains("hrm." + key)
+                ? fileConfiguration.getInt("hrm." + key, value)
+                : fileConfiguration.getInt(key, value));
     }
 
     public static byte resetBlockTag(String where) {
@@ -86,7 +105,6 @@ public class RPConfig {
             JavaPlugin instance = RPStatic.CLIENT;
             instance.getConfig().set("hrm." + where, who.stream().map(Enum::name).toList());
             instance.saveConfig();
-            instance.reloadConfig();
             RPStatic.BLOCK_TAGS.put(where, who);
             return 1;
         } catch (Exception e) {
@@ -100,7 +118,6 @@ public class RPConfig {
             JavaPlugin instance = RPStatic.CLIENT;
             instance.getConfig().set("hrm." + where, who);
             instance.saveConfig();
-            instance.reloadConfig();
             RPStatic.CONFIG_RULES.put(where, who);
             return 1;
         } catch (Exception e) {
@@ -114,7 +131,6 @@ public class RPConfig {
             JavaPlugin instance = RPStatic.CLIENT;
             instance.getConfig().set("hrm." + where, who);
             instance.saveConfig();
-            instance.reloadConfig();
             RPStatic.CONFIG_TIMERS.put(where, who);
             return 1;
         } catch (Exception e) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -371,6 +371,86 @@ hrm:
   # [CONFIG] BOTH
   revive-skull-recipe: true
 
+
+  # Hardcore Revive DLC (RevivalPlus) Settings
+  # ───────────────────────────────────────────────────────────────────────────────
+  # These settings control the advanced mechanics ported from the RevivalPlus DLC
+  # created by Cera and Jakeccz. You can also edit these in-game using /revivalconfig.
+  #
+  # -- GAMERULES --
+  # Do players drop their entire inventory upon hardcore death?
+  lose-inventory: false
+
+  # Can ghosts (dead players) open menus and inventories?
+  restrict-menu-access: true
+
+  # Do creative mode players drop heads when killed?
+  creative-players-drop-heads: false
+
+  # Does the base of the revival structure remain after a successful ritual?
+  keep-structure-base: true
+
+  # Do players get Speed and Night Vision when wearing a player head?
+  head-effects: true
+
+  # Do dropped player heads burn in lava? (If false, they are placed as blocks instead)
+  head-burns-in-lava: false
+
+  # Does lightning strike the structure when a player is revived?
+  ritual-lightning-strike: true
+
+  # Does the Totem of Undying animation play on the revived player's screen?
+  ritual-totem-effect: true
+
+  # Do dead players (ghosts) emit Dragon Breath particles so others can see them?
+  ghost-mode-particles: false
+
+  # -- TIMERS --
+  # Minutes until a death is visible to 'trusted' players in /deathlist
+  trusted-obituary-after: 60
+
+  # Minutes until a death is visible to 'friends' in /deathlist
+  friends-obituary-after: 600
+
+  # Minutes until a death is visible to everyone in /deathlist
+  public-obituary-after: 3600
+
+  # Max block radius ghosts can travel from their death point without a head
+  spectator-headrestrict-radius: 16
+
+  # Ticks of Resistance given to a revived player (20 ticks = 1 second)
+  revive-resistance-ticks: 100
+
+  # Ticks of Glowing given to a revived player
+  revive-glowing-ticks: 100
+
+  # -- STRUCTURE BLOCK TAGS --
+  # The blocks required for different parts of the revival structure.
+  soul-sand-blocktag:
+    - "CRYING_OBSIDIAN"
+    - "OBSIDIAN"
+  flower-blocktag:
+    - "SOUL_TORCH"
+    - "REDSTONE_TORCH"
+  ore-blocktag:
+    - "ENCHANTING_TABLE"
+  fence-blocktag:
+    - "OAK_FENCE"
+    - "SPRUCE_FENCE"
+    - "BIRCH_FENCE"
+    - "JUNGLE_FENCE"
+    - "ACACIA_FENCE"
+    - "DARK_OAK_FENCE"
+    - "MANGROVE_FENCE"
+    - "CHERRY_FENCE"
+    - "BAMBOO_FENCE"
+    - "CRIMSON_FENCE"
+    - "WARPED_FENCE"
+    - "NETHER_BRICK_FENCE"
+  stair-blocktag:
+    - "MAGMA_BLOCK"
+
+
 # ───────────────────────────────────────────────────────────────────────────────
 # Extra Life Item Settings
 # Players can craft/find items that grant them an extra life when used
@@ -504,81 +584,3 @@ messages:
 # Only enable for troubleshooting - disable for production!
 debug: false
 
-# ───────────────────────────────────────────────────────────────────────────────
-# Hardcore Revive DLC (RevivalPlus) Settings
-# ───────────────────────────────────────────────────────────────────────────────
-# These settings control the advanced mechanics ported from the RevivalPlus DLC
-# created by Cera and Jakeccz. You can also edit these in-game using /revivalconfig.
-#
-# -- GAMERULES --
-# Do players drop their entire inventory upon hardcore death?
-lose-inventory: false
-
-# Can ghosts (dead players) open menus and inventories?
-restrict-menu-access: true
-
-# Do creative mode players drop heads when killed?
-creative-players-drop-heads: false
-
-# Does the base of the revival structure remain after a successful ritual?
-keep-structure-base: true
-
-# Do players get Speed and Night Vision when wearing a player head?
-head-effects: true
-
-# Do dropped player heads burn in lava? (If false, they are placed as blocks instead)
-head-burns-in-lava: false
-
-# Does lightning strike the structure when a player is revived?
-ritual-lightning-strike: true
-
-# Does the Totem of Undying animation play on the revived player's screen?
-ritual-totem-effect: true
-
-# Do dead players (ghosts) emit Dragon Breath particles so others can see them?
-ghost-mode-particles: false
-
-# -- TIMERS --
-# Minutes until a death is visible to 'trusted' players in /deathlist
-trusted-obituary-after: 60
-
-# Minutes until a death is visible to 'friends' in /deathlist
-friends-obituary-after: 600
-
-# Minutes until a death is visible to everyone in /deathlist
-public-obituary-after: 3600
-
-# Max block radius ghosts can travel from their death point without a head
-spectator-headrestrict-radius: 16
-
-# Ticks of Resistance given to a revived player (20 ticks = 1 second)
-revive-resistance-ticks: 100
-
-# Ticks of Glowing given to a revived player
-revive-glowing-ticks: 100
-
-# -- STRUCTURE BLOCK TAGS --
-# The blocks required for different parts of the revival structure.
-soul-sand-blocktag:
-  - "CRYING_OBSIDIAN"
-  - "OBSIDIAN"
-flower-blocktag:
-  - "SOUL_TORCH"
-  - "REDSTONE_TORCH"
-ore-blocktag:
-  - "ENCHANTING_TABLE"
-fence-blocktag:
-  - "OAK_FENCE"
-  - "SPRUCE_FENCE"
-  - "BIRCH_FENCE"
-  - "JUNGLE_FENCE"
-  - "ACACIA_FENCE"
-  - "DARK_OAK_FENCE"
-  - "MANGROVE_FENCE"
-  - "CHERRY_FENCE"
-  - "BAMBOO_FENCE"
-  - "CRIMSON_FENCE"
-  - "WARPED_FENCE"
-  - "NETHER_BRICK_FENCE"
-stair-blocktag:
-  - "MAGMA_BLOCK"


### PR DESCRIPTION
Groups the RevivalPlus DLC features together with the Hardcore Revive Mode (HRM) features under the `hrm:` block in `config.yml` as requested. Also updates `RPConfig.java` to prepend the `hrm.` path prefix for config loading/saving.

---
*PR created automatically by Jules for task [8801253232516585837](https://jules.google.com/task/8801253232516585837) started by @SSoggyTacoMan*