### PR TITLE
fix: run forge update checks on startup

### DIFF
--- a/forge/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
@@ -18,6 +18,7 @@ import org.ssoggy.ssoggysouls.database.SQLiteManager;
 import org.ssoggy.ssoggysouls.command.CommandRegistration;
 import org.ssoggy.ssoggysouls.listener.ServerLifecycleListener;
 import org.ssoggy.ssoggysouls.util.MessageUtil;
+import org.ssoggy.ssoggysouls.util.UpdateChecker;
 import org.ssoggy.ssoggysouls.hrm.ExtraLifeManager;
 import org.ssoggy.ssoggysouls.hrm.ReviveSkullManager;
 import org.ssoggy.ssoggysouls.hrm.HeadEffectsTask;
@@ -91,6 +92,10 @@ public class SSoggySoulsMod implements PluginContext {
 
             MinecraftForge.EVENT_BUS.register(GhostBlockEvents.class);
             GhostBlockEvents.register(databaseManager);
+        }
+
+        if (ConfigManager.getConfig().isCheckForUpdates()) {
+            new UpdateChecker().checkForUpdates();
         }
     }
 

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/util/ConfigManager.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/util/ConfigManager.java
@@ -136,6 +136,7 @@ public class ConfigManager {
 
         // --- Debug ---
         private boolean debug = false;
+        private boolean checkForUpdates = true;
 
         public ModConfig() {
             // Default messages
@@ -215,6 +216,7 @@ public class ConfigManager {
         public java.util.List<String> getFenceBlocktag() { return fenceBlocktag; }
         public java.util.List<String> getStairBlocktag() { return stairBlocktag; }
         public boolean isDebug() { return debug; }
+        public boolean isCheckForUpdates() { return checkForUpdates; }
 
         public String getConfigString(String path, String defaultValue) {
             return switch (path) {
@@ -286,6 +288,7 @@ public class ConfigManager {
         public void setFenceBlocktag(java.util.Collection<String> blocks) { fenceBlocktag = normalizeBlockList(blocks); }
         public void setStairBlocktag(java.util.Collection<String> blocks) { stairBlocktag = normalizeBlockList(blocks); }
         public void setDebug(boolean d) { debug = d; }
+        public void setCheckForUpdates(boolean check) { checkForUpdates = check; }
 
         private static java.util.List<String> normalizeBlockList(java.util.Collection<String> blocks) {
             java.util.List<String> normalized = new java.util.ArrayList<>();


### PR DESCRIPTION
### Motivation
- Ensure loader parity by running the same startup update check on Forge that Fabric and Paper already perform, while respecting the existing `check-for-updates` configuration.

### Description
- Import and invoke `UpdateChecker` in `forge/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java`, gated by `ConfigManager.getConfig().isCheckForUpdates()`, to align Forge startup behavior with Fabric and Paper.

### Testing
- Executed `./forge/gradlew -p forge build` (failed due to Java toolchain: Unsupported class file major version 69), `./fabric/gradlew -p fabric build` (failed for the same toolchain mismatch), and `mvn -q test` (failed resolving `build-helper-maven-plugin` from Maven Central with HTTP 403), so automated CI builds could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc674b63e483238f28dacb650857e4)