### PR TITLE
Fix DLC, HRM, and Souls mechanics overlapping

### DIFF
--- a/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/BlockEvents.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/BlockEvents.java
@@ -90,11 +90,11 @@ public class BlockEvents implements Listener {
             World world = location.getWorld();
             UUID uuid = skullOwner.getUniqueId();
             Instant now = Instant.now();
-            Player target = skullOwner.getPlayer();
+            Player ownerPlayer = skullOwner.getPlayer();
 
             world.spawnParticle(Particle.SOUL, event.getBlock().getLocation().add(0.5, 0.5, 0.5), 1, 0, 0, 0, 0.005);
 
-            if (target == null || GAMEMODESENUM.getPlayerGameMode(target) != GAMEMODESENUM.GHOSTMODE) {
+            if (ownerPlayer == null || GAMEMODESENUM.getPlayerGameMode(ownerPlayer) != GAMEMODESENUM.GHOSTMODE) {
                 return;
             }
 
@@ -102,7 +102,7 @@ public class BlockEvents implements Listener {
             Bukkit.getScheduler().runTaskLater(RPStatic.CLIENT, () -> {
                 String uuidString = uuid.toString();
 
-                if (!target.isOnline() || GAMEMODESENUM.getPlayerGameMode(target) != GAMEMODESENUM.GHOSTMODE) {
+                if (!ownerPlayer.isOnline() || GAMEMODESENUM.getPlayerGameMode(ownerPlayer) != GAMEMODESENUM.GHOSTMODE) {
                     RPStatic.DEAD_LOCATIONS.remove(uuid);
                     RPStatic.DEAD_HOLDERS.remove(uuid);
                     RPStatic.DEAD_STORAGE.removeValue(uuidString, KEY_DEATHHOLDER);

--- a/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/BlockEvents.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/BlockEvents.java
@@ -90,17 +90,35 @@ public class BlockEvents implements Listener {
             World world = location.getWorld();
             UUID uuid = skullOwner.getUniqueId();
             Instant now = Instant.now();
+            Player target = skullOwner.getPlayer();
 
             world.spawnParticle(Particle.SOUL, event.getBlock().getLocation().add(0.5, 0.5, 0.5), 1, 0, 0, 0, 0.005);
 
-            RPStatic.DEAD_STORAGE.removeValue(uuid.toString(), KEY_DEATHHOLDER);
-            RPStatic.DEAD_HOLDERS.remove(uuid);
+            if (target == null || GAMEMODESENUM.getPlayerGameMode(target) != GAMEMODESENUM.GHOSTMODE) {
+                return;
+            }
 
-            RPStatic.DEAD_LOCATIONS.put(uuid, Pair.of(location, now));
-            RPStatic.DEAD_STORAGE.setValue(uuid.toString(), KEY_DEATHPOS,
-                    location.getBlockX() + "$" + location.getBlockY() + "$" + location.getBlockZ() + "$" + world.getName());
-            RPStatic.DEAD_STORAGE.setValue(uuid.toString(), KEY_DEATHTIME, now.toString());
-            RPStatic.DEAD_STORAGE.saveConfig();
+            Bukkit.getScheduler().runTaskLater(RPStatic.CLIENT, () -> {
+                String uuidString = uuid.toString();
+
+                if (!target.isOnline() || GAMEMODESENUM.getPlayerGameMode(target) != GAMEMODESENUM.GHOSTMODE) {
+                    RPStatic.DEAD_LOCATIONS.remove(uuid);
+                    RPStatic.DEAD_HOLDERS.remove(uuid);
+                    RPStatic.DEAD_STORAGE.removeValue(uuidString, KEY_DEATHHOLDER);
+                    RPStatic.DEAD_STORAGE.removeValue(uuidString, KEY_DEATHPOS);
+                    RPStatic.DEAD_STORAGE.removeValue(uuidString, KEY_DEATHTIME);
+                    RPStatic.DEAD_STORAGE.saveConfig();
+                    return;
+                }
+
+                RPStatic.DEAD_STORAGE.removeValue(uuidString, KEY_DEATHHOLDER);
+                RPStatic.DEAD_HOLDERS.remove(uuid);
+                RPStatic.DEAD_LOCATIONS.put(uuid, Pair.of(location, now));
+                RPStatic.DEAD_STORAGE.setValue(uuidString, KEY_DEATHPOS,
+                        location.getBlockX() + "$" + location.getBlockY() + "$" + location.getBlockZ() + "$" + world.getName());
+                RPStatic.DEAD_STORAGE.setValue(uuidString, KEY_DEATHTIME, now.toString());
+                RPStatic.DEAD_STORAGE.saveConfig();
+            }, 1L);
 
         }
     }

--- a/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/BlockEvents.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/BlockEvents.java
@@ -98,6 +98,7 @@ public class BlockEvents implements Listener {
                 return;
             }
 
+            // Run after MONITOR listeners so successful ritual revives can update gamemode first.
             Bukkit.getScheduler().runTaskLater(RPStatic.CLIENT, () -> {
                 String uuidString = uuid.toString();
 

--- a/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/BlockEvents.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/BlockEvents.java
@@ -95,18 +95,11 @@ public class BlockEvents implements Listener {
 
             RPStatic.DEAD_STORAGE.removeValue(uuid.toString(), KEY_DEATHHOLDER);
             RPStatic.DEAD_HOLDERS.remove(uuid);
-            boolean isRevived = ReviveHelper.tryRevivePlayer(world, location, skullOwner.getPlayer(), event.getPlayer());
 
-            if (isRevived) {
-                RPStatic.DEAD_LOCATIONS.remove(uuid);
-                RPStatic.DEAD_STORAGE.removeValue(uuid.toString(), KEY_DEATHPOS);
-                RPStatic.DEAD_STORAGE.removeValue(uuid.toString(), KEY_DEATHTIME);
-            } else {
-                RPStatic.DEAD_LOCATIONS.put(uuid, Pair.of(location, now));
-                RPStatic.DEAD_STORAGE.setValue(uuid.toString(), KEY_DEATHPOS,
-                        location.getBlockX() + "$" + location.getBlockY() + "$" + location.getBlockZ() + "$" + world.getName());
-                RPStatic.DEAD_STORAGE.setValue(uuid.toString(), KEY_DEATHTIME, now.toString());
-            }
+            RPStatic.DEAD_LOCATIONS.put(uuid, Pair.of(location, now));
+            RPStatic.DEAD_STORAGE.setValue(uuid.toString(), KEY_DEATHPOS,
+                    location.getBlockX() + "$" + location.getBlockY() + "$" + location.getBlockZ() + "$" + world.getName());
+            RPStatic.DEAD_STORAGE.setValue(uuid.toString(), KEY_DEATHTIME, now.toString());
             RPStatic.DEAD_STORAGE.saveConfig();
 
         }

--- a/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/PlayerStateEvents.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/PlayerStateEvents.java
@@ -93,7 +93,6 @@ public class PlayerStateEvents implements Listener {
                 deathPos.getBlockX() + "$" + deathPos.getBlockY() + "$" + deathPos.getBlockZ() + "$" + deathPos.getWorld().getName());
         RPStatic.DEAD_STORAGE.setValue(uuid.toString(), KEY_DEATHTIME, now.toString());
         RPStatic.DEAD_STORAGE.saveConfig();
-        GAMEMODESENUM.setPlayerGameMode(player, GAMEMODESENUM.GHOSTMODE);
 
         RPStats stats = new RPStats(uuid);
         stats.incrementStat(STATSENUM.DEATHS, 1);
@@ -103,29 +102,6 @@ public class PlayerStateEvents implements Listener {
             RPStats killerStats = new RPStats(killer.getUniqueId());
             killerStats.incrementStat(STATSENUM.KILLS, 1);
         }
-
-        placeOrDropHead(world, player, deathPos, skull, minHeight, maxHeight);
-    }
-
-    private void placeOrDropHead(World world, Player player, Location deathPos, ItemStack skull, int minHeight, int maxHeight) {
-        if (!Boolean.TRUE.equals(RPStatic.CONFIG_RULES.getOrDefault("head-burns-in-lava", true))) {
-            for (byte i = 0; deathPos.getY() < (maxHeight - 1) && !deathPos.getBlock().getType().isAir() && i < 127; i++) { // After 128 Blocks it force places the block
-                deathPos.add(0, 1, 0);
-            }
-            if (deathPos.getY() == minHeight) {deathPos.add(0, 1, 0);}
-            Block blockA = deathPos.getBlock();
-            Block blockB = deathPos.clone().add(0, -1, 0).getBlock();
-
-            if (blockA.getType() != Material.BEDROCK) { // Does not replace bedrock "e.g. The Nether Roof"
-                RPUtil.createSkullBlockWithName(player.getName(), deathPos);
-                if (blockB.getType().isAir()) {
-                    blockB.setType(Material.OBSIDIAN);
-                }
-            }
-            return;
-        }
-
-        world.dropItem(deathPos, skull);
     }
 
     @EventHandler(priority = EventPriority.HIGH)
@@ -134,19 +110,8 @@ public class PlayerStateEvents implements Listener {
         World world = player.getWorld();
         Location deathPos = RPStatic.DEAD_LOCATIONS.getOrDefault(player.getUniqueId(), Pair.of(world.getSpawnLocation(), Instant.now())).getLeft();
         event.setRespawnLocation(deathPos);
-        if (deathPos.getBlock().getState() instanceof Skull skullBlock) {
-            OfflinePlayer skullOwner = skullBlock.getOwningPlayer();
-            if (skullOwner == null || !skullOwner.getUniqueId().equals(player.getUniqueId())) return;
-            GAMEMODESENUM.setPlayerGameMode(player, GAMEMODESENUM.GHOSTMODE);
-            boolean isRevived = ReviveHelper.tryRevivePlayer(world, deathPos, player, player);
-            if (isRevived) {
-                RPStatic.DEAD_LOCATIONS.remove(player.getUniqueId());
-                RPStatic.DEAD_STORAGE.removeValue(player.getUniqueId().toString(), KEY_DEATHPOS);
-                RPStatic.DEAD_STORAGE.removeValue(player.getUniqueId().toString(), KEY_DEATHTIME);
-                RPStatic.DEAD_STORAGE.saveConfig();
-            }
-        }
     }
+
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();

--- a/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/PlayerStateEvents.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/PlayerStateEvents.java
@@ -144,10 +144,6 @@ public class PlayerStateEvents implements Listener {
         }
 
         Player player = event.getPlayer();
-        if (GAMEMODESENUM.getPlayerGameMode(player) != GAMEMODESENUM.GHOSTMODE) {
-            return;
-        }
-
         // Run next tick so the SURVIVAL transition is fully applied before clearing DLC ghost state.
         Bukkit.getScheduler().runTask(RPStatic.CLIENT, () -> {
             if (!player.isOnline() || player.getGameMode() != GameMode.SURVIVAL) {

--- a/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/PlayerStateEvents.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/PlayerStateEvents.java
@@ -136,4 +136,33 @@ public class PlayerStateEvents implements Listener {
                 break;
         }
     }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPlayerRevived(PlayerGameModeChangeEvent event) {
+        if (event.getNewGameMode() != GameMode.SURVIVAL) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+        if (GAMEMODESENUM.getPlayerGameMode(player) != GAMEMODESENUM.GHOSTMODE) {
+            return;
+        }
+
+        Bukkit.getScheduler().runTask(RPStatic.CLIENT, () -> {
+            if (!player.isOnline() || player.getGameMode() != GameMode.SURVIVAL) {
+                return;
+            }
+            if (GAMEMODESENUM.getPlayerGameMode(player) != GAMEMODESENUM.GHOSTMODE) {
+                return;
+            }
+
+            UUID uuid = player.getUniqueId();
+            GAMEMODESENUM.setPlayerGameMode(player, GAMEMODESENUM.SURVIVAL);
+            RPStatic.DEAD_LOCATIONS.remove(uuid);
+            RPStatic.DEAD_HOLDERS.remove(uuid);
+            RPStatic.DEAD_STORAGE.removeValue(uuid.toString(), KEY_DEATHPOS);
+            RPStatic.DEAD_STORAGE.removeValue(uuid.toString(), KEY_DEATHTIME);
+            RPStatic.DEAD_STORAGE.saveConfig();
+        });
+    }
 }

--- a/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/PlayerStateEvents.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/PlayerStateEvents.java
@@ -148,6 +148,7 @@ public class PlayerStateEvents implements Listener {
             return;
         }
 
+        // Run next tick so the SURVIVAL transition is fully applied before clearing DLC ghost state.
         Bukkit.getScheduler().runTask(RPStatic.CLIENT, () -> {
             if (!player.isOnline() || player.getGameMode() != GameMode.SURVIVAL) {
                 return;


### PR DESCRIPTION
This PR resolves an issue in the Bukkit module where the core Souls/HRM mechanics conflicted with the DLC (`RevivalPlus`) features. The DLC was erroneously duplicating logic:
- Dropping two player heads on death instead of relying on the configured `HeadDropListener`.
- Forcing players into `GHOSTMODE` immediately on death, ignoring the `MainServerListener`'s lives system.
- Calling a redundant `tryRevivePlayer` method in `BlockEvents.java` when skulls were placed, which raced/conflicted with `RevivalStructureListener`.
- Applying buggy self-revival mechanics when players respawned.

This update removes the duplicative logic from the DLC, deferring these core actions to the base plugin managers while retaining the necessary ghost state tracking. Fabric and Forge modules already handled this cleanly, so only the Bukkit logic was modified. All tests pass successfully across all platforms.

---
*PR created automatically by Jules for task [15181449912878578336](https://jules.google.com/task/15181449912878578336) started by @SSoggyTacoMan*