### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent SQL injection risk in metadata table creation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** `Files.readAllLines()` was used to read the admin log file, which can grow arbitrarily large and cause an OOM error.
 **Learning:** Admin log files should always be read using a streaming approach if only the most recent N lines are needed.
 **Prevention:** Use a `Stream` via `Files.lines()` combined with a `Deque` to store only the last N lines.
+## 2024-05-07 - [Prevent potential SQL Injection in schema generation]
+**Vulnerability:** In database managers (`MySQLManager`, `SQLiteManager`), dynamic DDL methods like `createMetadataTableIfNeeded` directly concatenated string arguments (`metaTable`) into `CREATE TABLE` commands. Even though the table name was internally hardcoded, lack of validation poses an SQL injection risk if the method's signature or usage expands.
+**Learning:** Defensive programming requires validating all dynamic identifiers used in non-parameterizable SQL statements (DDL).
+**Prevention:** Apply the existing `isValidIdentifier` (whitelisting regex `^\w+$`) check to table and column name parameters before they are concatenated into SQL queries.

--- a/common/src/main/java/org/ssoggy/ssoggysouls/database/MySQLManager.java
+++ b/common/src/main/java/org/ssoggy/ssoggysouls/database/MySQLManager.java
@@ -498,6 +498,9 @@ public class MySQLManager implements DatabaseManager {
     }
 
     private void createMetadataTableIfNeeded(Connection conn, String metaTable) throws SQLException {
+        if (!isValidIdentifier(metaTable)) {
+            throw new IllegalArgumentException("Invalid metadata table name identifier: " + metaTable);
+        }
         String createTableSql = "CREATE TABLE IF NOT EXISTS " + metaTable + " ("
                 + "key_ VARCHAR(50) PRIMARY KEY,"
                 + "version VARCHAR(50)"

--- a/common/src/main/java/org/ssoggy/ssoggysouls/database/SQLiteManager.java
+++ b/common/src/main/java/org/ssoggy/ssoggysouls/database/SQLiteManager.java
@@ -473,6 +473,9 @@ public class SQLiteManager implements DatabaseManager {
     }
 
     private void createMetadataTableIfNeeded(Connection conn, String metaTable) throws SQLException {
+        if (!isValidIdentifier(metaTable)) {
+            throw new IllegalArgumentException("Invalid metadata table name identifier: " + metaTable);
+        }
         String createTableSql = "CREATE TABLE IF NOT EXISTS " + metaTable + " ("
                 + "key_ VARCHAR(50) PRIMARY KEY,"
                 + "version VARCHAR(50)"


### PR DESCRIPTION
Add validation to `createMetadataTableIfNeeded` to prevent potential SQL injection in database managers by checking the identifier with `isValidIdentifier`.

---
*PR created automatically by Jules for task [17073535652895665637](https://jules.google.com/task/17073535652895665637) started by @SSoggyTacoMan*