### PR TITLE
Add Maven Dependency Submission Action

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,18 @@
+name: Dependency Submission
+
+on:
+  push:
+    branches: [ "main" ]
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Submit Dependency Snapshot
+        uses: advanced-security/maven-dependency-submission-action@v4.1.1


### PR DESCRIPTION
Added a dedicated workflow file `.github/workflows/dependency-submission.yml` to automatically submit the Maven dependency graph to GitHub Security using `advanced-security/maven-dependency-submission-action`.

---
*PR created automatically by Jules for task [8349091531644397057](https://jules.google.com/task/8349091531644397057) started by @SSoggyTacoMan*