### PR TITLE
Fix Ghost Mode persistence after admin revive (Bukkit/Spigot)

### DIFF
--- a/src/main/java/org/ssoggy/ssoggysouls/util/PlayerRevivalUtil.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/util/PlayerRevivalUtil.java
@@ -2,6 +2,8 @@ package org.ssoggy.ssoggysouls.util;
 
 import org.ssoggy.ssoggysouls.SSoggySouls;
 import org.ssoggy.ssoggysouls.model.PlayerData;
+import org.ssoggy.ssoggysouls.hrm.dlc.util.RPStatic;
+import org.ssoggy.ssoggysouls.hrm.dlc.enums.GAMEMODESENUM;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
@@ -20,12 +22,29 @@ public final class PlayerRevivalUtil {
      */
     public static void restoreOnlineSpectator(SSoggySouls plugin, PlayerData data) {
         Player target = Bukkit.getPlayer(data.getUuid());
+
+        // Also clean up DLC death state if possible
+        Bukkit.getScheduler().runTask(plugin, () -> {
+            try {
+                if (RPStatic.DEAD_LOCATIONS != null) {
+                    RPStatic.DEAD_LOCATIONS.remove(data.getUuid());
+                }
+                if (RPStatic.DEAD_STORAGE != null) {
+                    RPStatic.DEAD_STORAGE.removeValue(data.getUuid().toString(), "deathpos");
+                    RPStatic.DEAD_STORAGE.removeValue(data.getUuid().toString(), "deathtime");
+                    RPStatic.DEAD_STORAGE.saveConfig();
+                }
+            } catch (Exception e) {
+                plugin.getLogger().warning("Failed to clear DLC death state for " + data.getUsername());
+            }
+        });
+
         if (target != null && target.isOnline()
-                && target.getGameMode() != GameMode.SURVIVAL) {
+                && (target.getGameMode() != GameMode.SURVIVAL || GAMEMODESENUM.getPlayerGameMode(target) == GAMEMODESENUM.GHOSTMODE)) {
             Bukkit.getScheduler().runTask(plugin, () -> {
                 if (target.isOnline()) {
                     plugin.getLimboDeadPlayers().remove(target.getUniqueId());
-                    target.setGameMode(GameMode.SURVIVAL);
+                    GAMEMODESENUM.setPlayerGameMode(target, GAMEMODESENUM.SURVIVAL);
                     target.sendMessage(MessageUtil.get("revive-success"));
 
                     if (plugin.isLimboServer()) {


### PR DESCRIPTION
Fixes an issue where admin revives did not fully transition players out of the RevivalPlus "Ghost Mode" restrictions on the Bukkit/Spigot platform.

---
*PR created automatically by Jules for task [12083552751472943421](https://jules.google.com/task/12083552751472943421) started by @SSoggyTacoMan*