### PR TITLE
chore: pin dependency submission actions

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -12,7 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          persist-credentials: false
 
       - name: Submit Dependency Snapshot
-        uses: advanced-security/maven-dependency-submission-action@v4.1.1
+        uses: advanced-security/maven-dependency-submission-action@c9934379bc7e8b0d129c85cde6d5df1040f6b5dc


### PR DESCRIPTION
### Motivation
- Address a supply-chain vulnerability where the dependency submission workflow used mutable action tags while the job `GITHUB_TOKEN` had `contents: write` permission.
- Reduce token exposure by preventing the checkout step from persisting credentials into the workspace.

### Description
- Pin `actions/checkout` to the immutable commit SHA `b4ffde65f46336ab88eb53be808477a3936bae11` instead of a mutable tag.
- Pin `advanced-security/maven-dependency-submission-action` to the immutable commit SHA `c9934379bc7e8b0d129c85cde6d5df1040f6b5dc` instead of a mutable tag.
- Add `persist-credentials: false` to the checkout step to avoid leaving the `GITHUB_TOKEN` in the local git config and reduce token exposure.

### Testing
- Printed the updated workflow with `sed -n '1,220p' .github/workflows/dependency-submission.yml` and confirmed the expected lines, which succeeded.
- Verified the local diff with `git diff -- .github/workflows/dependency-submission.yml` and confirmed only the intended changes, which succeeded.
- Committed the change with `git commit` to ensure the repository accepts the patch, which succeeded.
- Displayed the final file with `nl -ba .github/workflows/dependency-submission.yml` to validate exact content and line numbers, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc9017a3cc83239837136d7ff17765)