### PR TITLE
fix(ci): pin Modrinth publish action to immutable commit SHA

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -219,7 +219,7 @@ jobs:
 
       - name: Publish to Modrinth
         if: steps.version_math.outputs.skip != 'true' && steps.commit_version.outputs.tag_created == 'true'
-        uses: Kir-Antipov/mc-publish@v3.3
+        uses: Kir-Antipov/mc-publish@995edadc13559a8b28d0b7e6571229f067ec7659
         with:
           modrinth-id: REPLACE_WITH_MODRINTH_ID
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -266,7 +266,7 @@ jobs:
 
       - name: Publish Paper to Modrinth
         if: steps.version_math.outputs.skip != 'true'
-        uses: Kir-Antipov/mc-publish@v3.3
+        uses: Kir-Antipov/mc-publish@995edadc13559a8b28d0b7e6571229f067ec7659
         with:
           modrinth-id: Pb03qu6T
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
@@ -295,7 +295,7 @@ jobs:
 
       - name: Publish Fabric to Modrinth
         if: steps.version_math.outputs.skip != 'true'
-        uses: Kir-Antipov/mc-publish@v3.3
+        uses: Kir-Antipov/mc-publish@995edadc13559a8b28d0b7e6571229f067ec7659
         with:
           modrinth-id: Pb03qu6T
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
@@ -322,7 +322,7 @@ jobs:
 
       - name: Publish Forge to Modrinth
         if: steps.version_math.outputs.skip != 'true'
-        uses: Kir-Antipov/mc-publish@v3.3
+        uses: Kir-Antipov/mc-publish@995edadc13559a8b28d0b7e6571229f067ec7659
         with:
           modrinth-id: Pb03qu6T
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}


### PR DESCRIPTION
### Motivation

- The release workflow used a mutable third-party action tag (`Kir-Antipov/mc-publish@v3.3`) that is executed in a privileged job and received `secrets.MODRINTH_TOKEN`, creating a CI/CD supply-chain risk. 
- Pinning to an immutable commit SHA reduces the chance that a malicious change in the external action could exfiltrate the publishing token or tamper with release artifacts.

### Description

- Replaced `uses: Kir-Antipov/mc-publish@v3.3` with `uses: Kir-Antipov/mc-publish@995edadc13559a8b28d0b7e6571229f067ec7659` in `.github/workflows/auto-release.yml` to pin the action to a full 40-character commit SHA. 
- Preserved all existing workflow inputs and behavior, including the `modrinth-token` and release logic, to keep the fix minimal and non-disruptive. 
- No other workflow permissions or runtime behavior were changed.

### Testing

- Verified workflow contents with `sed -n '1,260p' .github/workflows/auto-release.yml`, which succeeded. 
- Searched for the action reference with `rg -n "Kir-Antipov/mc-publish|mc-publish@" .github/workflows`, which located the prior mutable tag. 
- Performed the replacement using a short `python` script that updated the `uses:` line, and validated the change with `git diff -- .github/workflows/auto-release.yml` and `nl -ba .github/workflows/auto-release.yml | sed -n '210,240p'`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc25b805108323b91d13fd9a7203ff)