### PR TITLE
fix(ci): prevent manual_version command injection in auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -58,15 +58,19 @@ jobs:
       # --- VERSION BUMPING LOGIC ---
       - name: Calculate Next Version
         id: version_math
+        env:
+          BUMP_TYPE_INPUT: ${{ inputs.bump_type }}
+          MANUAL_VERSION_INPUT: ${{ inputs.manual_version }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           OLD_VERSION="$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)"
           IFS='.' read -r MAJOR MINOR PATCH <<< "$OLD_VERSION"
           
-          BUMP_TYPE="${{ inputs.bump_type }}"
-          MANUAL_VERSION="${{ inputs.manual_version }}"
+          BUMP_TYPE="$BUMP_TYPE_INPUT"
+          MANUAL_VERSION="$MANUAL_VERSION_INPUT"
           SKIP_RELEASE="false"
           
-          if [[ "${{ github.event_name }}" == "push" ]]; then
+          if [[ "$EVENT_NAME" == "push" ]]; then
             COMMIT_MSG=$(git log -1 --pretty=%B)
             
             # 1. Check for skips first (docs, github actions, tests)
@@ -90,6 +94,10 @@ jobs:
           if [ "$SKIP_RELEASE" == "false" ]; then
             # Priority: Manual Version -> Major -> Minor -> Patch
             if [[ -n "$MANUAL_VERSION" ]]; then
+              if ! [[ "$MANUAL_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.+][A-Za-z0-9.-]+)?$ ]]; then
+                echo "Invalid manual_version input: '$MANUAL_VERSION'. Expected semantic version like 1.2.3 or 1.2.3-rc.1."
+                exit 1
+              fi
               NEW_VERSION="$MANUAL_VERSION"
             elif [ "$BUMP_TYPE" == "major" ]; then
               NEW_VERSION="$((MAJOR + 1)).0.0"


### PR DESCRIPTION
### Motivation
- The `workflow_dispatch` `manual_version` input was interpolated directly into a Bash `run` block, allowing quote-breaking shell injection during privileged release jobs. 
- The goal is to eliminate the injection vector while keeping the existing release/version-bump behavior intact.

### Description
- Moved workflow inputs into step `env` variables and consume them inside the script to avoid pre-runtime GitHub expression interpolation (`BUMP_TYPE_INPUT`, `MANUAL_VERSION_INPUT`, `EVENT_NAME`).
- Replaced direct `${{ inputs.* }}` interpolation with environment-driven assignments (`BUMP_TYPE="$BUMP_TYPE_INPUT"`, `MANUAL_VERSION="$MANUAL_VERSION_INPUT"`) and used `EVENT_NAME` for event checks.
- Added strict semantic-version validation for `manual_version` using the regex `^[0-9]+\.[0-9]+\.[0-9]+([-.+][A-Za-z0-9.-]+)?$` and fail-fast `exit 1` if the input is invalid.
- Change applied to `.github/workflows/auto-release.yml` and preserves manual-version-priority and existing bump logic when inputs are valid.

### Testing
- Applied the patch successfully to `.github/workflows/auto-release.yml` using the automated patch tool and the operation completed without errors.
- Verified the updated file contents with `sed -n '1,240p' .github/workflows/auto-release.yml` and inspected the relevant region with `nl -ba .github/workflows/auto-release.yml | sed -n '52,120p'`, both of which succeeded. 
- Confirmed the repository diff of the workflow with `git diff -- .github/workflows/auto-release.yml && git status --short`, which showed only the intended changes and no unrelated modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc2690a8848323b89ce6f9a96a0a91)