### PR TITLE
fix(forge): restore Bungee payload registration for Limbo transfers

### DIFF
--- a/forge/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
@@ -26,6 +26,7 @@ import org.ssoggy.ssoggysouls.hrm.dlc.listener.GhostModeEvents;
 import org.ssoggy.ssoggysouls.hrm.dlc.listener.GhostBlockEvents;
 import org.ssoggy.ssoggysouls.hrm.dlc.shared.DlcServices;
 import org.ssoggy.ssoggysouls.listener.LimboServerListener;
+import org.ssoggy.ssoggysouls.util.ServerTransferUtil;
 
 @Mod(SSoggySoulsMod.MODID)
 public class SSoggySoulsMod implements PluginContext {
@@ -95,7 +96,7 @@ public class SSoggySoulsMod implements PluginContext {
     }
 
     private void commonSetup(final FMLCommonSetupEvent event) {
-        // Some common setup code
+        ServerTransferUtil.register();
     }
 
     @SubscribeEvent

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/util/ServerTransferUtil.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/util/ServerTransferUtil.java
@@ -5,9 +5,9 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.network.event.RegisterPayloadHandlersEvent;
+import net.minecraftforge.network.ChannelBuilder;
+import net.minecraftforge.network.SimpleChannel;
+import net.minecraftforge.network.Channel;
 import org.ssoggy.ssoggysouls.SSoggySoulsMod;
 
 import java.io.ByteArrayInputStream;
@@ -17,16 +17,20 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
-@Mod.EventBusSubscriber(modid = SSoggySoulsMod.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
 public class ServerTransferUtil {
 
-    @SubscribeEvent
-    public static void registerPayloads(RegisterPayloadHandlersEvent event) {
-        event.registrar(SSoggySoulsMod.MODID).playToClient(
-                BungeeConnectPayload.PAYLOAD_TYPE,
-                BungeeConnectPayload.CODEC,
-                (payload, context) -> {}
-        );
+    private static final int PROTOCOL_VERSION = 1;
+    public static final SimpleChannel CHANNEL = ChannelBuilder
+            .named(ResourceLocation.fromNamespaceAndPath(SSoggySoulsMod.MODID, "bungee_connect"))
+            .networkProtocolVersion(PROTOCOL_VERSION)
+            .acceptedVersions(Channel.VersionTest.exact(PROTOCOL_VERSION))
+            .simpleChannel();
+
+    public static void register() {
+        CHANNEL.messageBuilder(BungeeConnectPayload.class, 1)
+                .codec(BungeeConnectPayload.CODEC)
+                .consumerMainThread((payload, context) -> {}) // No action needed on the client or server side to handle this specific custom payload besides what the proxy does
+                .add();
     }
 
     public static void sendToServer(ServerPlayer player, String serverName) {

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/util/ServerTransferUtil.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/util/ServerTransferUtil.java
@@ -5,6 +5,10 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.network.event.RegisterPayloadHandlersEvent;
+import org.ssoggy.ssoggysouls.SSoggySoulsMod;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -13,7 +17,17 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
+@Mod.EventBusSubscriber(modid = SSoggySoulsMod.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
 public class ServerTransferUtil {
+
+    @SubscribeEvent
+    public static void registerPayloads(RegisterPayloadHandlersEvent event) {
+        event.registrar(SSoggySoulsMod.MODID).playToClient(
+                BungeeConnectPayload.PAYLOAD_TYPE,
+                BungeeConnectPayload.CODEC,
+                (payload, context) -> {}
+        );
+    }
 
     public static void sendToServer(ServerPlayer player, String serverName) {
         player.connection.send(new net.minecraft.network.protocol.common.ClientboundCustomPayloadPacket(


### PR DESCRIPTION
### Motivation
- A previous change removed the Forge-side registration for the custom Bungee transfer payload while `ClientboundCustomPayloadPacket` sends remained, which can break packet serialization and skip the security-critical Limbo confinement path for dead players.
- Restore the minimal registration so the existing `BungeeConnectPayload` codec is known to the Forge networking layer and transfers are reliably serializable.

### Description
- Added Forge imports and annotated `ServerTransferUtil` with `@Mod.EventBusSubscriber` to register on the MOD event bus.
- Added a `@SubscribeEvent` method `registerPayloads(RegisterPayloadHandlersEvent event)` that calls `event.registrar(...).playToClient(...)` with `BungeeConnectPayload.PAYLOAD_TYPE` and `BungeeConnectPayload.CODEC` to register the payload codec.
- Preserved the existing `BungeeConnectPayload` `CODEC` and the `sendToServer/sendToLimbo/sendToMain` behavior so no transfer logic or codec format was changed.
- Change applied to `forge/src/main/java/org/ssoggy/ssoggysouls/util/ServerTransferUtil.java` and committed with message `fix(forge): restore custom payload registration for limbo transfers`.

### Testing
- Attempted to compile the Forge module with `./gradlew --no-daemon :forge:compileJava`, but the repository root lacks a Gradle wrapper so the command failed (no `./gradlew`).
- Attempted `mvn -pl forge -DskipTests compile`, but Maven failed because the reactor layout does not expose a `forge` module in this environment, so compilation/runtime verification could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc2c1c49a4832393fa6e7e619042c1)