### PR TITLE
fix: bound RPStorage async save queue to prevent player-triggered backlog DoS

### DIFF
--- a/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPStorage.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPStorage.java
@@ -29,6 +29,7 @@ import java.nio.file.Files;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;

--- a/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPStorage.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPStorage.java
@@ -40,7 +40,7 @@ public class RPStorage {
     private final File file;
     private final Logger logger;
     private FileConfiguration config;
-    private final ThreadPoolExecutor ioExecutor = new ThreadPoolExecutor(
+    private final ExecutorService ioExecutor = new ThreadPoolExecutor(
             1,
             1,
             0L,

--- a/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPStorage.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPStorage.java
@@ -28,8 +28,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -39,7 +39,14 @@ public class RPStorage {
     private final File file;
     private final Logger logger;
     private FileConfiguration config;
-    private final ExecutorService ioExecutor = Executors.newSingleThreadExecutor();
+    private final ThreadPoolExecutor ioExecutor = new ThreadPoolExecutor(
+            1,
+            1,
+            0L,
+            TimeUnit.MILLISECONDS,
+            new ArrayBlockingQueue<>(1),
+            new ThreadPoolExecutor.DiscardOldestPolicy()
+    );
 
 
     public RPStorage(JavaPlugin plugin, String fileName) {


### PR DESCRIPTION
### Motivation
- `RPStorage.saveConfig()` previously snapshot the full YAML and submitted every write to an unbounded single-thread executor, allowing attacker-controlled player commands (e.g., `/trust`) to enqueue unbounded large snapshots and cause memory/I/O exhaustion. 
- The change aims to restore backpressure on asynchronous saves while preserving async disk I/O to avoid blocking caller threads.

### Description
- Replace `Executors.newSingleThreadExecutor()` with a bounded single-thread `ThreadPoolExecutor` using an `ArrayBlockingQueue` of capacity `1` and `ThreadPoolExecutor.DiscardOldestPolicy()` to prevent an unbounded backlog in `src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPStorage.java`.
- Preserve the existing behavior of snapshotting the configuration under `synchronized` (`config.saveToString()`) and performing the actual `Files.writeString(...)` on the single background thread.
- Keep the existing `shutdown()` logic intact so the executor still attempts graceful termination with a forced shutdown fallback.

### Testing
- Attempted an automated build with `mvn -q -DskipTests compile`, which failed due to external dependency resolution (`403 Forbidden` from Maven Central) in the environment and not due to the code change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc280bde288323a77d1604b9eeba8c)