### PR TITLE
fix(forge): adapt payload registration to LexForge 1.21.1

### DIFF
--- a/forge/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
@@ -26,6 +26,7 @@ import org.ssoggy.ssoggysouls.hrm.dlc.listener.GhostModeEvents;
 import org.ssoggy.ssoggysouls.hrm.dlc.listener.GhostBlockEvents;
 import org.ssoggy.ssoggysouls.hrm.dlc.shared.DlcServices;
 import org.ssoggy.ssoggysouls.listener.LimboServerListener;
+import org.ssoggy.ssoggysouls.util.ServerTransferUtil;
 
 @Mod(SSoggySoulsMod.MODID)
 public class SSoggySoulsMod implements PluginContext {
@@ -95,7 +96,7 @@ public class SSoggySoulsMod implements PluginContext {
     }
 
     private void commonSetup(final FMLCommonSetupEvent event) {
-        // Some common setup code
+        ServerTransferUtil.register();
     }
 
     @SubscribeEvent

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/util/ServerTransferUtil.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/util/ServerTransferUtil.java
@@ -5,9 +5,9 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.network.event.RegisterPayloadHandlersEvent;
+import net.minecraftforge.network.ChannelBuilder;
+import net.minecraftforge.network.SimpleChannel;
+import net.minecraftforge.network.Channel;
 import org.ssoggy.ssoggysouls.SSoggySoulsMod;
 
 import java.io.ByteArrayInputStream;
@@ -17,16 +17,20 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
-@Mod.EventBusSubscriber(modid = SSoggySoulsMod.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
 public class ServerTransferUtil {
 
-    @SubscribeEvent
-    public static void registerPayloads(RegisterPayloadHandlersEvent event) {
-        event.registrar(SSoggySoulsMod.MODID).playToClient(
-                BungeeConnectPayload.PAYLOAD_TYPE,
-                BungeeConnectPayload.CODEC,
-                (payload, context) -> {}
-        );
+    private static final int PROTOCOL_VERSION = 1;
+    public static final SimpleChannel CHANNEL = ChannelBuilder
+            .named(ResourceLocation.fromNamespaceAndPath(SSoggySoulsMod.MODID, "bungee_connect"))
+            .networkProtocolVersion(PROTOCOL_VERSION)
+            .acceptedVersions(Channel.VersionTest.exact(PROTOCOL_VERSION))
+            .simpleChannel();
+
+    public static void register() {
+        CHANNEL.messageBuilder(BungeeConnectPayload.class, 1)
+                .codec(BungeeConnectPayload.CODEC)
+                .consumerMainThread((payload, context) -> {}) // No action needed on the client or server side to handle this specific custom payload besides what the proxy does
+                .add();
     }
 
     public static void sendToServer(ServerPlayer player, String serverName) {


### PR DESCRIPTION
Adapts the Forge module's custom payload registration to correctly target LexForge (MinecraftForge 61.1.5) on Minecraft 1.21.1. The code previously attempted to use `RegisterPayloadHandlersEvent`, which is exclusive to NeoForge, resulting in compilation failures.

This refactoring removes the unsupported event logic and instead initializes a `SimpleChannel` via `net.minecraftforge.network.ChannelBuilder`. The registration process is now correctly hooked into `FMLCommonSetupEvent` within the main mod class. Tested successfully using standard Gradle build and test procedures.

---
*PR created automatically by Jules for task [13810955670350599457](https://jules.google.com/task/13810955670350599457) started by @SSoggyTacoMan*