### PR TITLE
fix: Prevent limbo transfer when using SQLite

### DIFF
--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/util/ConfigManager.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/util/ConfigManager.java
@@ -32,6 +32,13 @@ public class ConfigManager {
             config = new ModConfig();
             save();
         }
+
+        // Force spectator mode if using SQLite
+        if (("sqlite".equalsIgnoreCase(config.getDatabaseType()) || "local".equalsIgnoreCase(config.getDatabaseType()))
+                && config.isSendToLimboOnDeath()) {
+            org.ssoggy.ssoggysouls.SSoggySoulsMod.LOGGER.warn("SQLite is meant for single-server mode. Overriding sendToLimboOnDeath to false.");
+            config.setSendToLimboOnDeath(false);
+        }
     }
 
     public static void save() {

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/util/ConfigManager.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/util/ConfigManager.java
@@ -32,7 +32,11 @@ public class ConfigManager {
             config = new ModConfig();
             save();
         }
+        checkSqliteOverride();
+    }
 
+    public static void checkSqliteOverride() {
+        if (config == null) return;
         // Force spectator mode if using SQLite
         if (("sqlite".equalsIgnoreCase(config.getDatabaseType()) || "local".equalsIgnoreCase(config.getDatabaseType()))
                 && config.isSendToLimboOnDeath()) {

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/util/ConfigManager.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/util/ConfigManager.java
@@ -33,6 +33,11 @@ public class ConfigManager {
             save();
         }
 
+        checkSqliteOverride();
+    }
+
+    public static void checkSqliteOverride() {
+        if (config == null) return;
         // Force spectator mode if using SQLite
         if (("sqlite".equalsIgnoreCase(config.getDatabaseType()) || "local".equalsIgnoreCase(config.getDatabaseType()))
                 && config.isSendToLimboOnDeath()) {

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/util/ConfigManager.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/util/ConfigManager.java
@@ -32,6 +32,13 @@ public class ConfigManager {
             config = new ModConfig();
             save();
         }
+
+        // Force spectator mode if using SQLite
+        if (("sqlite".equalsIgnoreCase(config.getDatabaseType()) || "local".equalsIgnoreCase(config.getDatabaseType()))
+                && config.isSendToLimboOnDeath()) {
+            org.ssoggy.ssoggysouls.SSoggySoulsMod.LOGGER.warn("SQLite is meant for single-server mode. Overriding sendToLimboOnDeath to false.");
+            config.setSendToLimboOnDeath(false);
+        }
     }
 
     public static void save() {

--- a/src/main/java/org/ssoggy/ssoggysouls/SSoggySouls.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/SSoggySouls.java
@@ -124,16 +124,14 @@ public final class SSoggySouls extends JavaPlugin implements Listener, PluginCon
         getServer().getMessenger().registerOutgoingPluginChannel(this, "BungeeCord");
         getServer().getPluginManager().registerEvents(this, this);
 
-        String dbType = getConfig().getString("database.type", "mysql").toLowerCase();
-
-        if (dbType.equals("sqlite") || dbType.equals("local")) {
+        if (isDatabaseSqlite()) {
             databaseManager = new org.ssoggy.ssoggysouls.database.SQLiteManager(this);
         } else {
             databaseManager = new org.ssoggy.ssoggysouls.database.MySQLManager(this);
         }
 
         if (!databaseManager.initialize()) {
-            boolean isSqlite = dbType.equals("sqlite") || dbType.equals("local");
+            boolean isSqlite = isDatabaseSqlite();
             getLogger().log(Level.SEVERE, "Failed to connect to {0}! Disabling plugin.", isSqlite ? "SQLite" : "MySQL");
             getServer().getPluginManager().disablePlugin(this);
             return;

--- a/src/main/java/org/ssoggy/ssoggysouls/SSoggySouls.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/SSoggySouls.java
@@ -496,8 +496,9 @@ public final class SSoggySouls extends JavaPlugin implements Listener, PluginCon
 
     public boolean isDatabaseSqlite() {
         String dbType = getConfig().getString("database.type", "mysql").toLowerCase();
-        return dbType.equals("sqlite") || dbType.equals("local");
+        return java.util.Set.of("sqlite", "local").contains(dbType);
     }
+
 
     public String getMainServerName() {
         return mainServerName;

--- a/src/main/java/org/ssoggy/ssoggysouls/SSoggySouls.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/SSoggySouls.java
@@ -324,6 +324,12 @@ public final class SSoggySouls extends JavaPlugin implements Listener, PluginCon
         spectatorOnDeath = cfg.getBoolean("main.spectator-on-death", true);
         detectHrmRevive = cfg.getBoolean("main.detect-hrm-revive", true);
         deathMode = cfg.getString("main.death-mode", MODE_HYBRID);
+
+        if (isDatabaseSqlite() && !deathMode.equals(MODE_SPECTATOR)) {
+            getLogger().log(Level.WARNING, "SQLite is meant for single-server mode. Overriding death-mode to 'spectator'.");
+            deathMode = MODE_SPECTATOR;
+        }
+
         hybridTimeoutSeconds = cfg.getInt("main.hybrid-timeout-seconds", 300);
         reviveCooldownSeconds = cfg.getInt("lives.revive-cooldown-seconds", 30);
         extraLifeEnabled = cfg.getBoolean("extra-life.enabled", true);
@@ -488,6 +494,11 @@ public final class SSoggySouls extends JavaPlugin implements Listener, PluginCon
 
     public boolean isLimboServer() {
         return isLimboServer;
+    }
+
+    public boolean isDatabaseSqlite() {
+        String dbType = getConfig().getString("database.type", "mysql").toLowerCase();
+        return dbType.equals("sqlite") || dbType.equals("local");
     }
 
     public String getMainServerName() {


### PR DESCRIPTION
Fixes an issue where using SQLite (single server setup) with the default hybrid death mode caused the plugin to falsely warn about a Limbo server transfer. The configuration loading now detects SQLite and overrides the death mode to spectator.

---
*PR created automatically by Jules for task [16101915979855069890](https://jules.google.com/task/16101915979855069890) started by @SSoggyTacoMan*