### PR TITLE
refactor(common): propagate mysql startup failures with exception

### DIFF
--- a/common/src/main/java/org/ssoggy/ssoggysouls/database/DatabaseInitializationException.java
+++ b/common/src/main/java/org/ssoggy/ssoggysouls/database/DatabaseInitializationException.java
@@ -1,0 +1,11 @@
+package org.ssoggy.ssoggysouls.database;
+
+public class DatabaseInitializationException extends Exception {
+    public DatabaseInitializationException(String message) {
+        super(message);
+    }
+
+    public DatabaseInitializationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/common/src/main/java/org/ssoggy/ssoggysouls/database/DatabaseManager.java
+++ b/common/src/main/java/org/ssoggy/ssoggysouls/database/DatabaseManager.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 import org.ssoggy.ssoggysouls.model.PlayerData;
 
 public interface DatabaseManager {
-    boolean initialize();
+    void initialize() throws DatabaseInitializationException;
     void shutdown();
     PlayerData getPlayer(UUID uuid);
     PlayerData getPlayerByName(String username);

--- a/common/src/main/java/org/ssoggy/ssoggysouls/database/MySQLManager.java
+++ b/common/src/main/java/org/ssoggy/ssoggysouls/database/MySQLManager.java
@@ -58,7 +58,7 @@ public class MySQLManager implements DatabaseManager {
         this.tableName = tableName;
     }
 
-    public boolean initialize() {
+    public void initialize() throws DatabaseInitializationException {
         try {
             String host = plugin.getConfigString("database.host", "localhost");
             int port = plugin.getConfigInt("database.port", 3306);
@@ -69,7 +69,7 @@ public class MySQLManager implements DatabaseManager {
             tableName = plugin.getConfigString("database.table-name", "hardcore_players");
             if (!isValidIdentifier(tableName)) {
                 plugin.getLogger().log(Level.SEVERE, "MySQL initialization failed: Invalid database.table-name {0}. Table name must consist only of alphanumeric characters and underscores.", tableName);
-                return false;
+                throw new DatabaseInitializationException("Invalid database.table-name: " + tableName);
             }
 
             String jdbcUrl = "jdbc:mysql://" + host + ":" + port + "/" + dbName
@@ -100,7 +100,7 @@ public class MySQLManager implements DatabaseManager {
                 plugin.getLogger().severe("NOTICE: If you are only running a single server, you DO NOT need MySQL! The default database is SQLite. Open config.yml and change type: \"mysql\" back to type: \"sqlite\" to fix this instantly.");
                 plugin.getLogger().severe("=====================================================");
                 plugin.getLogger().log(Level.SEVERE, "MySQL connection error:", ex);
-                throw ex;
+                throw new DatabaseInitializationException("Could not connect to MySQL database", ex);
             }
 
             dataSource = hikariDataSource;
@@ -108,11 +108,10 @@ public class MySQLManager implements DatabaseManager {
 
             plugin.getLogger().log(Level.INFO, "MySQL connection established ({0}:{1}/{2})",
                     new Object[] { host, port, dbName });
-            return true;
 
         } catch (SQLException e) {
             plugin.getLogger().log(Level.SEVERE, "MySQL initialization failed!", e);
-            return false;
+            throw new DatabaseInitializationException("MySQL initialization failed", e);
         }
     }
 

--- a/common/src/main/java/org/ssoggy/ssoggysouls/database/SQLiteManager.java
+++ b/common/src/main/java/org/ssoggy/ssoggysouls/database/SQLiteManager.java
@@ -49,12 +49,12 @@ public class SQLiteManager implements DatabaseManager {
         this.plugin = plugin;
     }
 
-    public boolean initialize() {
+    public void initialize() throws DatabaseInitializationException {
         try {
             tableName = plugin.getConfigString("database.table-name", "hardcore_players");
             if (!isValidIdentifier(tableName)) {
                 plugin.getLogger().log(Level.SEVERE, "SQLite initialization failed: Invalid database.table-name {0}. Table name must consist only of alphanumeric characters and underscores.", tableName);
-                return false;
+                throw new DatabaseInitializationException("Invalid database.table-name: " + tableName);
             }
 
             java.io.File dataFolder = plugin.getDataFolder();
@@ -71,15 +71,19 @@ public class SQLiteManager implements DatabaseManager {
             config.setConnectionTimeout(10_000);
             config.setPoolName("SSoggySouls-SQLite-Pool");
 
-            dataSource = new HikariDataSource(config);
+            try {
+                dataSource = new HikariDataSource(config);
+            } catch (RuntimeException ex) {
+                plugin.getLogger().log(Level.SEVERE, "SQLite connection pool error:", ex);
+                throw new DatabaseInitializationException("Could not create SQLite connection pool", ex);
+            }
             createTable();
 
             plugin.getLogger().log(Level.INFO, "SQLite connection established (database.db)");
-            return true;
 
         } catch (SQLException e) {
             plugin.getLogger().log(Level.SEVERE, "SQLite initialization failed!", e);
-            return false;
+            throw new DatabaseInitializationException("SQLite initialization failed", e);
         }
     }
 

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 
 import org.ssoggy.ssoggysouls.database.DatabaseManager;
+import org.ssoggy.ssoggysouls.database.DatabaseInitializationException;
 import org.ssoggy.ssoggysouls.database.MySQLManager;
 import org.ssoggy.ssoggysouls.database.SQLiteManager;
 import org.ssoggy.ssoggysouls.listener.LimboServerListener;
@@ -54,8 +55,10 @@ public class SSoggySoulsMod implements ModInitializer, PluginContext {
         } else {
             databaseManager = new SQLiteManager(this);
         }
-        if (!databaseManager.initialize()) {
-            LOGGER.error("Failed to initialize database. Disabling features.");
+        try {
+            databaseManager.initialize();
+        } catch (DatabaseInitializationException e) {
+            LOGGER.error("Failed to initialize database. Disabling features. Error: {}", e.getMessage(), e);
             return;
         }
         DlcServices.init(this);

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
@@ -13,6 +13,7 @@ import net.minecraftforge.fml.loading.FMLPaths;
 import org.ssoggy.ssoggysouls.util.ConfigManager;
 
 import org.ssoggy.ssoggysouls.database.DatabaseManager;
+import org.ssoggy.ssoggysouls.database.DatabaseInitializationException;
 import org.ssoggy.ssoggysouls.database.MySQLManager;
 import org.ssoggy.ssoggysouls.database.SQLiteManager;
 import org.ssoggy.ssoggysouls.command.CommandRegistration;
@@ -59,8 +60,10 @@ public class SSoggySoulsMod implements PluginContext {
             databaseManager = new SQLiteManager(this);
         }
         
-        if (!databaseManager.initialize()) {
-            LOGGER.error("Failed to initialize database. Disabling features.");
+        try {
+            databaseManager.initialize();
+        } catch (DatabaseInitializationException e) {
+            LOGGER.error("Failed to initialize database. Disabling features. Error: {}", e.getMessage(), e);
             return;
         }
         DlcServices.init(this);

--- a/src/main/java/org/ssoggy/ssoggysouls/SSoggySouls.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/SSoggySouls.java
@@ -156,7 +156,7 @@ public final class SSoggySouls extends JavaPlugin implements Listener, PluginCon
         } catch (DatabaseInitializationException e) {
             boolean isSqlite = dbType.equals("sqlite") || dbType.equals("local");
             getLogger().log(Level.SEVERE, "Failed to connect to {0}! Disabling plugin.", isSqlite ? "SQLite" : "MySQL");
-            getLogger().log(Level.SEVERE, "Initialization error: " + e.getMessage());
+            getLogger().log(Level.SEVERE, "Initialization error details:", e);
             getServer().getPluginManager().disablePlugin(this);
             return;
         }

--- a/src/main/java/org/ssoggy/ssoggysouls/SSoggySouls.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/SSoggySouls.java
@@ -28,6 +28,7 @@ import org.ssoggy.ssoggysouls.command.SetLivesCommand;
 import org.ssoggy.ssoggysouls.command.StatusCommand;
 import org.ssoggy.ssoggysouls.command.VisitLimboCommand;
 import org.ssoggy.ssoggysouls.database.DatabaseManager;
+import org.ssoggy.ssoggysouls.database.DatabaseInitializationException;
 import org.ssoggy.ssoggysouls.hrm.ExtraLifeManager;
 import org.ssoggy.ssoggysouls.hrm.HeadDropListener;
 import org.ssoggy.ssoggysouls.hrm.HeadEffectsTask;
@@ -150,9 +151,12 @@ public final class SSoggySouls extends JavaPlugin implements Listener, PluginCon
             databaseManager = new org.ssoggy.ssoggysouls.database.MySQLManager(this);
         }
 
-        if (!databaseManager.initialize()) {
+        try {
+            databaseManager.initialize();
+        } catch (DatabaseInitializationException e) {
             boolean isSqlite = dbType.equals("sqlite") || dbType.equals("local");
             getLogger().log(Level.SEVERE, "Failed to connect to {0}! Disabling plugin.", isSqlite ? "SQLite" : "MySQL");
+            getLogger().log(Level.SEVERE, "Initialization error: " + e.getMessage());
             getServer().getPluginManager().disablePlugin(this);
             return;
         }


### PR DESCRIPTION
Propagate MySQL startup failures by updating the DatabaseManager interface to throw a specific `DatabaseInitializationException` instead of returning a boolean. All implementations (MySQL and SQLite) and call sites (Paper, Fabric, Forge) are refactored to conform to this consistent exception-based error handling contract, resolving a GitHub code review request.

---
*PR created automatically by Jules for task [6102239818634203011](https://jules.google.com/task/6102239818634203011) started by @SSoggyTacoMan*