### PR TITLE
fix(forge): gate HRM event handlers behind runtime config checks

### DIFF
--- a/forge/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
@@ -74,19 +74,17 @@ public class SSoggySoulsMod implements PluginContext {
             MinecraftForge.EVENT_BUS.register(ServerLifecycleListener.class);
             ServerLifecycleListener.setDatabase(databaseManager);
 
-            if (ConfigManager.getConfig().isHrmEnabled()) {
-                MinecraftForge.EVENT_BUS.register(ExtraLifeManager.class);
-                ExtraLifeManager.register(databaseManager);
+            MinecraftForge.EVENT_BUS.register(ExtraLifeManager.class);
+            ExtraLifeManager.register(databaseManager);
 
-                MinecraftForge.EVENT_BUS.register(ReviveSkullManager.class);
-                ReviveSkullManager.register(databaseManager);
+            MinecraftForge.EVENT_BUS.register(ReviveSkullManager.class);
+            ReviveSkullManager.register(databaseManager);
 
-                MinecraftForge.EVENT_BUS.register(HeadEffectsTask.class);
-                HeadEffectsTask.register();
+            MinecraftForge.EVENT_BUS.register(HeadEffectsTask.class);
+            HeadEffectsTask.register();
 
-                MinecraftForge.EVENT_BUS.register(RevivalStructureListener.class);
-                RevivalStructureListener.register(databaseManager);
-            }
+            MinecraftForge.EVENT_BUS.register(RevivalStructureListener.class);
+            RevivalStructureListener.register(databaseManager);
 
             MinecraftForge.EVENT_BUS.register(GhostModeEvents.class);
             GhostModeEvents.register(databaseManager);

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/ExtraLifeManager.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/ExtraLifeManager.java
@@ -33,7 +33,7 @@ public class ExtraLifeManager {
 
     @SubscribeEvent
     public static void onItemRightClick(PlayerInteractEvent.RightClickItem event) {
-        if (db == null || event.getLevel().isClientSide() || !(event.getEntity() instanceof ServerPlayer serverPlayer)) {
+        if (!ConfigManager.getConfig().isHrmEnabled() || db == null || event.getLevel().isClientSide() || !(event.getEntity() instanceof ServerPlayer serverPlayer)) {
             return;
         }
 

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/HeadEffectsTask.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/HeadEffectsTask.java
@@ -27,6 +27,7 @@ public class HeadEffectsTask {
 
     @SubscribeEvent
     public static void onServerTick(TickEvent.ServerTickEvent event) {
+        if (!org.ssoggy.ssoggysouls.util.ConfigManager.getConfig().isHrmEnabled()) return;
         if (event.phase != TickEvent.Phase.END) return;
 
         MinecraftServer server = event.getServer();

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/ReviveSkullManager.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/ReviveSkullManager.java
@@ -36,7 +36,7 @@ public class ReviveSkullManager {
 
     @SubscribeEvent
     public static void onItemRightClick(PlayerInteractEvent.RightClickItem event) {
-        if (db == null || event.getLevel().isClientSide() || !(event.getEntity() instanceof ServerPlayer serverPlayer)) {
+        if (!org.ssoggy.ssoggysouls.util.ConfigManager.getConfig().isHrmEnabled() || db == null || event.getLevel().isClientSide() || !(event.getEntity() instanceof ServerPlayer serverPlayer)) {
             return;
         }
 

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostBlockEvents.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostBlockEvents.java
@@ -40,7 +40,7 @@ public class GhostBlockEvents {
 
     @SubscribeEvent
     public static void onItemPickup(EntityItemPickupEvent event) {
-        if (db == null || !(event.getEntity() instanceof ServerPlayer player)) {
+        if (!org.ssoggy.ssoggysouls.util.ConfigManager.getConfig().isHrmEnabled() || db == null || !(event.getEntity() instanceof ServerPlayer player)) {
             return;
         }
 
@@ -61,7 +61,7 @@ public class GhostBlockEvents {
 
     @SubscribeEvent
     public static void onBlockBreak(BlockEvent.BreakEvent event) {
-        if (db == null || event.getLevel().isClientSide() || !(event.getPlayer() instanceof ServerPlayer player)) {
+        if (!org.ssoggy.ssoggysouls.util.ConfigManager.getConfig().isHrmEnabled() || db == null || event.getLevel().isClientSide() || !(event.getPlayer() instanceof ServerPlayer player)) {
             return;
         }
 
@@ -108,7 +108,7 @@ public class GhostBlockEvents {
 
     @SubscribeEvent
     public static void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
-        if (db == null || event.getLevel().isClientSide() || !(event.getEntity() instanceof ServerPlayer player)) {
+        if (!org.ssoggy.ssoggysouls.util.ConfigManager.getConfig().isHrmEnabled() || db == null || event.getLevel().isClientSide() || !(event.getEntity() instanceof ServerPlayer player)) {
             return;
         }
 

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
@@ -34,7 +34,7 @@ public class GhostModeEvents {
 
     @SubscribeEvent
     public static void onPlayerJoin(PlayerEvent.PlayerLoggedInEvent event) {
-        if (db == null || !(event.getEntity() instanceof ServerPlayer player)) return;
+        if (!ConfigManager.getConfig().isHrmEnabled() || db == null || !(event.getEntity() instanceof ServerPlayer player)) return;
         UUID uuid = player.getUUID();
         
         CompletableFuture.runAsync(() -> {
@@ -56,6 +56,7 @@ public class GhostModeEvents {
 
     @SubscribeEvent
     public static void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
+        if (!ConfigManager.getConfig().isHrmEnabled()) return;
         if (isGhost(event.getEntity())) {
             event.setCanceled(true);
         }
@@ -63,6 +64,7 @@ public class GhostModeEvents {
 
     @SubscribeEvent
     public static void onRightClickItem(PlayerInteractEvent.RightClickItem event) {
+        if (!ConfigManager.getConfig().isHrmEnabled()) return;
         if (isGhost(event.getEntity())) {
             event.setCanceled(true);
         }
@@ -70,6 +72,7 @@ public class GhostModeEvents {
 
     @SubscribeEvent
     public static void onAttackEntity(AttackEntityEvent event) {
+        if (!ConfigManager.getConfig().isHrmEnabled()) return;
         if (isGhost(event.getEntity())) {
             event.setCanceled(true);
         }
@@ -77,6 +80,7 @@ public class GhostModeEvents {
 
     @SubscribeEvent
     public static void onItemToss(ItemTossEvent event) {
+        if (!ConfigManager.getConfig().isHrmEnabled()) return;
         if (isGhost(event.getPlayer())) {
             event.setCanceled(true);
         }
@@ -84,6 +88,7 @@ public class GhostModeEvents {
 
     @SubscribeEvent
     public static void onInteractEntity(PlayerInteractEvent.EntityInteract event) {
+        if (!ConfigManager.getConfig().isHrmEnabled()) return;
         if (isGhost(event.getEntity())) {
             if (event.getEntity() instanceof ServerPlayer serverPlayer) {
                 serverPlayer.setCamera(event.getTarget());
@@ -94,6 +99,7 @@ public class GhostModeEvents {
 
     @SubscribeEvent
     public static void onServerTick(TickEvent.ServerTickEvent event) {
+        if (!ConfigManager.getConfig().isHrmEnabled()) return;
         if (event.phase != TickEvent.Phase.END) return;
 
         for (ServerPlayer player : event.getServer().getPlayerList().getPlayers()) {
@@ -126,11 +132,13 @@ public class GhostModeEvents {
     }
 
     public static void updateGhostStatus(UUID uuid, boolean isDead) {
+        if (!ConfigManager.getConfig().isHrmEnabled()) return;
         if (isDead) GHOST_CACHE.add(uuid);
         else GHOST_CACHE.remove(uuid);
     }
 
     private static boolean isGhost(Player player) {
+        if (!ConfigManager.getConfig().isHrmEnabled()) return false;
         return GHOST_CACHE.contains(player.getUUID());
     }
 }


### PR DESCRIPTION
This commit updates the way Hardcore Revival Mechanism (HRM) features are gated in the Forge implementation. It addresses PR feedback by shifting from conditional listener class registration at startup (which breaks upon `/revivalconfig reload`) to runtime configuration checks inside the event handlers themselves. It also extends the gating to include the `GhostModeEvents` and `GhostBlockEvents` classes to prevent unintended ghost mode tracking when the feature is disabled.

---
*PR created automatically by Jules for task [367494151362232870](https://jules.google.com/task/367494151362232870) started by @SSoggyTacoMan*