### PR TITLE
fix(fabric): pin fabric loom version

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.8-SNAPSHOT'
+    id 'fabric-loom' version '1.8.13'
 }
 
 version = project.mod_version

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.8.13'
+    id 'fabric-loom' version "${loom_version}"
 }
 
 version = project.mod_version

--- a/fabric/gradle.properties
+++ b/fabric/gradle.properties
@@ -9,6 +9,7 @@ archives_base_name=SSoggySouls-Fabric
 minecraft_version=1.21.1
 yarn_mappings=1.21.1+build.3
 loader_version=0.16.0
+loom_version=1.8.13
 
 # Fabric API
 fabric_version=0.116.1+1.21.1


### PR DESCRIPTION
### Motivation
- Mitigate a supply-chain risk by avoiding the mutable Gradle plugin coordinate `fabric-loom:1.8-SNAPSHOT` which is executed during Gradle configuration and CI release jobs.

### Description
- Replace `id 'fabric-loom' version '1.8-SNAPSHOT'` with the pinned `id 'fabric-loom' version '1.8.13'` in `fabric/build.gradle` to ensure a fixed, immutable plugin implementation is used.

### Testing
- Verified the change and file contents with `git diff -- fabric/build.gradle`, `rg "fabric-loom' version" fabric/build.gradle`, and `nl -ba fabric/build.gradle | sed -n '1,12p'`, and all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fcbe5976dc8323b3694438cbc4e81c)