### PR TITLE
Enforce TLS identity verification for MySQL connections

### DIFF
--- a/common/src/main/java/org/ssoggy/ssoggysouls/database/MySQLManager.java
+++ b/common/src/main/java/org/ssoggy/ssoggysouls/database/MySQLManager.java
@@ -73,7 +73,7 @@ public class MySQLManager implements DatabaseManager {
             }
 
             String jdbcUrl = "jdbc:mysql://" + host + ":" + port + "/" + dbName
-                    + "?useSSL=false&allowPublicKeyRetrieval=true&autoReconnect=true"
+                    + "?sslMode=VERIFY_IDENTITY&autoReconnect=true"
                     + "&characterEncoding=UTF-8&useUnicode=true";
 
             HikariConfig config = new HikariConfig();


### PR DESCRIPTION
### Motivation
- Prevent credential interception and on-path tampering caused by building a JDBC URL with `useSSL=false` and `allowPublicKeyRetrieval=true`, which allowed unauthenticated public-key retrieval during MySQL authentication.

### Description
- Replace the insecure JDBC query parameters in `common/src/main/java/org/ssoggy/ssoggysouls/database/MySQLManager.java` by changing `?useSSL=false&allowPublicKeyRetrieval=true&autoReconnect=true` to `?sslMode=VERIFY_IDENTITY&autoReconnect=true`, enforcing TLS with server identity verification while preserving the existing connection options.

### Testing
- Ran `mvn -q -DskipTests compile`, which failed to complete due to an external Maven Central dependency resolution error (HTTP 403), so no successful local build or test suite run was possible in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc3d0c143083239b7c68f432ba9dc6)