### PR TITLE
Prevent Limbo escape race by blocking leave while async death status resolves

### DIFF
--- a/src/main/java/org/ssoggy/ssoggysouls/SSoggySouls.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/SSoggySouls.java
@@ -109,6 +109,7 @@ public final class SSoggySouls extends JavaPlugin implements Listener, PluginCon
 
     private Location limboSpawn;
     private final Set<UUID> limboDeadPlayers = ConcurrentHashMap.newKeySet();
+    private final Set<UUID> limboStatusPendingPlayers = ConcurrentHashMap.newKeySet();
 
     @Override
     public void onEnable() {
@@ -544,6 +545,10 @@ public final class SSoggySouls extends JavaPlugin implements Listener, PluginCon
 
     public Set<UUID> getLimboDeadPlayers() {
         return limboDeadPlayers;
+    }
+
+    public Set<UUID> getLimboStatusPendingPlayers() {
+        return limboStatusPendingPlayers;
     }
 
     public boolean isHrmEnabled() {

--- a/src/main/java/org/ssoggy/ssoggysouls/command/LeaveLimboCommand.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/command/LeaveLimboCommand.java
@@ -30,7 +30,8 @@ public class LeaveLimboCommand implements CommandExecutor {
     }
 
     private void handleLeave(Player player) {
-        if (plugin.getLimboDeadPlayers().contains(player.getUniqueId())) {
+        if (plugin.getLimboStatusPendingPlayers().contains(player.getUniqueId())
+                || plugin.getLimboDeadPlayers().contains(player.getUniqueId())) {
             player.sendMessage(MessageUtil.get("limbo-cannot-leave"));
             return;
         }

--- a/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
@@ -143,9 +143,12 @@ public class LimboServerListener implements Listener {
         if (player.hasPermission("ssoggysouls.admin")) return;
 
         if (plugin.getLimboStatusPendingPlayers().contains(player.getUniqueId())) {
-            event.setCancelled(true);
-            player.sendMessage(MessageUtil.get("limbo-cannot-leave"));
-            return;
+            String cmd = event.getMessage().toLowerCase().split(" ")[0];
+            if (!isWhitelistedCommand(cmd)) {
+                event.setCancelled(true);
+                player.sendMessage(MessageUtil.get("limbo-cannot-leave"));
+                return;
+            }
         }
 
         // visitors (not dead in main) are unrestricted

--- a/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
+++ b/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
@@ -50,11 +50,18 @@ public class LimboServerListener implements Listener {
             return;
         }
 
+        plugin.getLimboStatusPendingPlayers().add(player.getUniqueId());
+
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
             boolean isDead = plugin.getDatabaseManager().isPlayerDead(player.getUniqueId());
 
             Bukkit.getScheduler().runTask(plugin, () -> {
-                if (!player.isOnline()) return;
+                if (!player.isOnline()) {
+                    plugin.getLimboStatusPendingPlayers().remove(player.getUniqueId());
+                    return;
+                }
+
+                plugin.getLimboStatusPendingPlayers().remove(player.getUniqueId());
 
                 if (isDead) {
                     plugin.getLimboDeadPlayers().add(player.getUniqueId());
@@ -73,6 +80,7 @@ public class LimboServerListener implements Listener {
     @EventHandler
     public void onPlayerQuit(PlayerQuitEvent event) {
         plugin.getLimboDeadPlayers().remove(event.getPlayer().getUniqueId());
+        plugin.getLimboStatusPendingPlayers().remove(event.getPlayer().getUniqueId());
     }
 
     private void applyLimboState(Player player) {
@@ -133,6 +141,12 @@ public class LimboServerListener implements Listener {
         Player player = event.getPlayer();
         if (player.hasPermission(PERM_BYPASS)) return;
         if (player.hasPermission("ssoggysouls.admin")) return;
+
+        if (plugin.getLimboStatusPendingPlayers().contains(player.getUniqueId())) {
+            event.setCancelled(true);
+            player.sendMessage(MessageUtil.get("limbo-cannot-leave"));
+            return;
+        }
 
         // visitors (not dead in main) are unrestricted
         if (!plugin.getLimboDeadPlayers().contains(player.getUniqueId())) return;


### PR DESCRIPTION
### Motivation
- Joining Limbo performed an asynchronous DB check and only later added dead players to the in-memory `limboDeadPlayers` set, creating a race where a dead player could run `/leavelimbo` (alias `/hub`) before the check completed and be transferred to Main.
- The intent is to preserve the original fail-closed Limbo confinement boundary so dead players cannot transiently access Main or run commands during the DB resolution window.

### Description
- Added a new `limboStatusPendingPlayers` set in `SSoggySouls` and exposed a getter `getLimboStatusPendingPlayers()` to track players whose dead/alive status is being resolved asynchronously.
- On join, players are inserted into `limboStatusPendingPlayers` before the async DB lookup and removed in the main-thread callback (or on quit) once the status is known, preventing reconnect windows from reopening the race.
- `PlayerCommandPreprocessEvent` handling in `LimboServerListener` now cancels commands while a player's status is pending and returns the `limbo-cannot-leave` message to close the command race window.
- `LeaveLimboCommand` was hardened to deny leaving when a player's status is still pending in addition to the existing `limboDeadPlayers` check, preventing scheduled transfers initiated during the pending window.

### Testing
- Attempted to run an automated package build with `mvn -q -DskipTests package` and the build failed due to environment dependency resolution (Maven Central returned HTTP 403 for `org.codehaus.mojo:build-helper-maven-plugin:3.5.0`), so no successful compile/test artifacts were produced.
- Static code inspection and local grep/sed checks were used to verify the new references and call sites were updated as intended and the pending-check is exercised in command preprocessing and the leave command.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc3cd3d2a08323abfcf47ad260bc95)