### PR TITLE
Harden release workflow against tag input command injection

### DIFF
--- a/.github/workflows/build-plugin-release.yml
+++ b/.github/workflows/build-plugin-release.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Java
         uses: actions/setup-java@v4
@@ -45,6 +47,8 @@ jobs:
       - name: Select jars for release
         id: package
         shell: bash
+        env:
+          RELEASE_TAG_INPUT: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail
 
@@ -59,9 +63,13 @@ jobs:
               exit 1
             fi
           else
-            TAG_NAME="${{ inputs.release_tag }}"
+            TAG_NAME="${RELEASE_TAG_INPUT}"
             if [[ -z "${TAG_NAME}" ]]; then
               TAG_NAME="${EXPECTED_TAG}"
+            elif [[ ! "${TAG_NAME}" =~ ^v[0-9]+(\.[0-9]+)*([.-][0-9A-Za-z]+)*$ ]]; then
+              echo "Manual release_tag '${TAG_NAME}' is invalid."
+              echo "Use a safe tag format like '${EXPECTED_TAG}'."
+              exit 1
             fi
           fi
 


### PR DESCRIPTION
### Motivation
- The `workflow_dispatch` `release_tag` input was interpolated directly into a bash `run` block, allowing shell metacharacters to be executed by the runner and enabling tampering of release artifacts.
- The job used `actions/checkout` with persisted credentials and `contents: write` permission, increasing the potential impact of a successful injection.
- The workflow should treat manual inputs as untrusted data and validate them before use to preserve release integrity.

### Description
- Disabled persisted checkout credentials by adding `persist-credentials: false` to the `actions/checkout@v4` step to reduce token exposure during the job. 
- Stopped direct interpolation of the `release_tag` expression into the shell by exporting it into an environment variable `RELEASE_TAG_INPUT` and reading that within the bash step. 
- Added strict validation of manual tags using a regex that enforces a safe tag format (examples like `v1.2.3`), and fail-fast behavior if the input is invalid while preserving the default behavior when no manual tag is provided. 
- All changes are confined to `.github/workflows/build-plugin-release.yml` and preserve the existing artifact selection and release publishing behavior when inputs are valid.

### Testing
- No repository unit tests were modified as this is a CI workflow configuration change and no runtime code was altered. 
- Validated the updated workflow file contents using `sed -n '1,220p' .github/workflows/build-plugin-release.yml`, which returned the modified YAML successfully. 
- Reviewed the produced diff with `git diff -- .github/workflows/build-plugin-release.yml` and inspected the file with `nl -ba .github/workflows/build-plugin-release.yml | sed -n '1,130p'`, both of which succeeded and show the applied changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc36075b98832397e5399a331a27dc)