### PR TITLE
fix(fabric): prevent dead/spectator players from triggering revival flows

### DIFF
--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java
@@ -70,14 +70,15 @@ public class RevivalStructureListener {
             return ActionResult.PASS;
         }
 
+        ItemStack stack = serverPlayer.getStackInHand(hand);
+        if (!stack.isOf(Items.PLAYER_HEAD)) {
+            return ActionResult.PASS;
+        }
+
         PlayerData actorData = db.getPlayer(serverPlayer.getUuid());
         if (actorData == null || actorData.isDead()) {
             return ActionResult.PASS;
         }
-
-        ItemStack stack = serverPlayer.getStackInHand(hand);
-        if (!stack.isOf(Items.PLAYER_HEAD)) {
-            return ActionResult.PASS;
         }
 
         ProfileComponent profile = stack.get(DataComponentTypes.PROFILE);

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java
@@ -66,6 +66,15 @@ public class RevivalStructureListener {
 
     private static ActionResult handleStructureInteraction(ServerPlayerEntity serverPlayer, World world, Hand hand,
             net.minecraft.util.hit.BlockHitResult hitResult, DatabaseManager db) {
+        if (serverPlayer.isSpectator()) {
+            return ActionResult.PASS;
+        }
+
+        PlayerData actorData = db.getPlayer(serverPlayer.getUuid());
+        if (actorData == null || actorData.isDead()) {
+            return ActionResult.PASS;
+        }
+
         ItemStack stack = serverPlayer.getStackInHand(hand);
         if (!stack.isOf(Items.PLAYER_HEAD)) {
             return ActionResult.PASS;

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java
@@ -79,7 +79,6 @@ public class RevivalStructureListener {
         if (actorData == null || actorData.isDead()) {
             return ActionResult.PASS;
         }
-        }
 
         ProfileComponent profile = stack.get(DataComponentTypes.PROFILE);
         if (profile == null) {

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/ReviveSkullManager.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/ReviveSkullManager.java
@@ -42,6 +42,10 @@ public class ReviveSkullManager {
                 return TypedActionResult.pass(stack);
             }
 
+            if (!canUseReviveFeatures(serverPlayer, db)) {
+                return TypedActionResult.pass(stack);
+            }
+
             // Async DB fetch
             CompletableFuture.runAsync(() -> {
                 List<PlayerData> deadPlayers = db.getDeadPlayers();
@@ -51,7 +55,7 @@ public class ReviveSkullManager {
                         serverPlayer.sendMessage(Text.literal("No dead players found.").styled(s -> s.withColor(Formatting.GRAY)), false);
                         return;
                     }
-                    openMenu(serverPlayer, deadPlayers);
+                    openMenu(serverPlayer, deadPlayers, db);
                 });
             });
 
@@ -59,13 +63,13 @@ public class ReviveSkullManager {
         });
     }
 
-    private static void openMenu(ServerPlayerEntity player, List<PlayerData> deadPlayers) {
+    private static void openMenu(ServerPlayerEntity player, List<PlayerData> deadPlayers, DatabaseManager db) {
         int rows = Math.min(6, ((deadPlayers.size() - 1) / 9) + 1);
         int slots = rows * 9;
         SimpleInventory inventory = populateInventory(deadPlayers, slots);
 
         SimpleNamedScreenHandlerFactory factory = new SimpleNamedScreenHandlerFactory(
-            (syncId, playerInventory, p) -> createScreenHandler(syncId, playerInventory, inventory, rows),
+            (syncId, playerInventory, p) -> createScreenHandler(syncId, playerInventory, inventory, rows, db),
             Text.literal("Revive - Select Player").styled(s -> s.withColor(Formatting.DARK_PURPLE).withBold(true))
         );
 
@@ -80,13 +84,14 @@ public class ReviveSkullManager {
         return inventory;
     }
 
-    private static GenericContainerScreenHandler createScreenHandler(int syncId, PlayerInventory playerInventory, SimpleInventory inventory, int rows) {
+    private static GenericContainerScreenHandler createScreenHandler(int syncId, PlayerInventory playerInventory,
+            SimpleInventory inventory, int rows, DatabaseManager db) {
         ScreenHandlerType<GenericContainerScreenHandler> type = getScreenHandlerType(rows);
         return new GenericContainerScreenHandler(type, syncId, playerInventory, inventory, rows) {
             @Override
             public void onSlotClick(int slotIndex, int button, SlotActionType actionType, PlayerEntity clickingPlayer) {
                 if (slotIndex >= 0 && slotIndex < inventory.size()) {
-                    handleMenuClick(inventory.getStack(slotIndex), clickingPlayer);
+                    handleMenuClick(inventory.getStack(slotIndex), clickingPlayer, db);
                 } else if (actionType != SlotActionType.QUICK_MOVE && actionType != SlotActionType.SWAP) {
                     super.onSlotClick(slotIndex, button, actionType, clickingPlayer);
                 }
@@ -105,8 +110,12 @@ public class ReviveSkullManager {
         };
     }
 
-    private static void handleMenuClick(ItemStack clicked, PlayerEntity clickingPlayer) {
+    private static void handleMenuClick(ItemStack clicked, PlayerEntity clickingPlayer, DatabaseManager db) {
         if (!clicked.isEmpty() && clicked.isOf(Items.PLAYER_HEAD)) {
+            if (!(clickingPlayer instanceof ServerPlayerEntity spe) || !canUseReviveFeatures(spe, db)) {
+                return;
+            }
+
             ProfileComponent profile = clicked.get(DataComponentTypes.PROFILE);
             if (profile != null) {
                 profile.id().ifPresent(id -> {
@@ -122,12 +131,19 @@ public class ReviveSkullManager {
                     }
                     clickingPlayer.sendMessage(Text.literal("Received " + name + "'s head.").styled(s -> s.withColor(Formatting.GREEN)), false);
 
-                    if (clickingPlayer instanceof ServerPlayerEntity spe) {
-                        spe.getServer().execute(spe::closeHandledScreen);
-                    }
+                    spe.getServer().execute(spe::closeHandledScreen);
                 });
             }
         }
+    }
+
+    private static boolean canUseReviveFeatures(ServerPlayerEntity player, DatabaseManager db) {
+        if (player.isSpectator()) {
+            return false;
+        }
+
+        PlayerData data = db.getPlayer(player.getUuid());
+        return data != null && !data.isDead();
     }
 
     private static ItemStack createMenuHead(PlayerData data) {

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/ReviveSkullManager.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/ReviveSkullManager.java
@@ -69,7 +69,7 @@ public class ReviveSkullManager {
         SimpleInventory inventory = populateInventory(deadPlayers, slots);
 
         SimpleNamedScreenHandlerFactory factory = new SimpleNamedScreenHandlerFactory(
-            (syncId, playerInventory, p) -> createScreenHandler(syncId, playerInventory, inventory, rows, db),
+            (syncId, playerInventory, _) -> createScreenHandler(syncId, playerInventory, inventory, rows, db),
             Text.literal("Revive - Select Player").styled(s -> s.withColor(Formatting.DARK_PURPLE).withBold(true))
         );
 

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/ReviveSkullManager.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/ReviveSkullManager.java
@@ -69,7 +69,7 @@ public class ReviveSkullManager {
         SimpleInventory inventory = populateInventory(deadPlayers, slots);
 
         SimpleNamedScreenHandlerFactory factory = new SimpleNamedScreenHandlerFactory(
-            (syncId, playerInventory, _) -> createScreenHandler(syncId, playerInventory, inventory, rows, db),
+            (syncId, playerInventory, p) -> createScreenHandler(syncId, playerInventory, inventory, rows, db),
             Text.literal("Revive - Select Player").styled(s -> s.withColor(Formatting.DARK_PURPLE).withBold(true))
         );
 


### PR DESCRIPTION
### Motivation
- Close an authorization/confinement gap where dead or spectator actors could trigger Fabric callbacks (ritual block use and revive-skull item) to obtain heads or revive players despite the plugin's dead-player model.

### Description
- Added actor-side gating to `RevivalStructureListener.handleStructureInteraction` to early-return for `serverPlayer.isSpectator()` and for DB-marked dead or unknown actor rows (`db.getPlayer(serverPlayer.getUuid()) == null || .isDead()`).
- Hardened `ReviveSkullManager` by introducing `canUseReviveFeatures(ServerPlayerEntity, DatabaseManager)` and applying it before opening the dead-player menu and before minting/giving a real head on menu click.
- Threaded `DatabaseManager` through the revive-skull menu and screen handler so authorization is revalidated at click/action time instead of only at menu-open time.
- Kept behavior unchanged for creative players and preserved refund/consumption semantics; changes are minimal checks that return/pass when the actor is not authorized.

### Testing
- Attempted to compile the Fabric subproject with `cd fabric && ./gradlew --no-daemon compileJava`, which failed due to environment/toolchain incompatibility (`Unsupported class file major version 69`), so runtime verification could not be performed here.
- Observed repository state with `git status` locally and applied the changes; static code inspection confirms the new early-returns and authorization checks are in place and cover both the UseBlockCallback and UseItemCallback paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc302354d08323967540528184cfca)