### PR TITLE
fix(fabric): enforce local ghost confinement fallback when sending players to Limbo

### DIFF
--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/listener/MainServerListener.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/listener/MainServerListener.java
@@ -77,6 +77,7 @@ public class MainServerListener {
 
         if (data.isDead()) {
             if (ConfigManager.getConfig().isSendToLimboOnDeath()) {
+                player.sendMessage(MessageUtil.get("death-sending-to-limbo"), false);
                 ServerTransferUtil.sendToLimbo(player);
             }
 
@@ -179,6 +180,7 @@ public class MainServerListener {
 
     private void handleRespawnSync(ServerPlayerEntity player) {
         if (ConfigManager.getConfig().isSendToLimboOnDeath()) {
+            player.sendMessage(MessageUtil.get("death-sending-to-limbo"), false);
             ServerTransferUtil.sendToLimbo(player);
         }
 

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/listener/MainServerListener.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/listener/MainServerListener.java
@@ -78,7 +78,6 @@ public class MainServerListener {
         if (data.isDead()) {
             if (ConfigManager.getConfig().isSendToLimboOnDeath()) {
                 ServerTransferUtil.sendToLimbo(player);
-                return;
             }
 
             // Dead player joined -> Ghost mode (Adventure)
@@ -137,7 +136,6 @@ public class MainServerListener {
             if (ConfigManager.getConfig().isSendToLimboOnDeath()) {
                 player.sendMessage(MessageUtil.get("death-sending-to-limbo"), false);
                 ServerTransferUtil.sendToLimbo(player);
-                return;
             }
 
             GhostState state = GhostState.getServerState(player.getServer());
@@ -182,7 +180,6 @@ public class MainServerListener {
     private void handleRespawnSync(ServerPlayerEntity player) {
         if (ConfigManager.getConfig().isSendToLimboOnDeath()) {
             ServerTransferUtil.sendToLimbo(player);
-            return;
         }
 
         player.changeGameMode(GameMode.ADVENTURE);


### PR DESCRIPTION
### Motivation
- Prevent a fail-open where enabling `sendToLimboOnDeath` could leave dead players unconstrained on the main server if proxy transfer failed or was unavailable.
- Preserve the best-effort Limbo transfer while ensuring the original local ghost/adventure confinement and death-state recording always run as a fallback.

### Description
- Removed the early `return` statements immediately following `ServerTransferUtil.sendToLimbo(...)` in the join, final-death, and respawn code paths in `MainServerListener.java` so execution continues to the existing local confinement logic.
- Kept the `ServerTransferUtil.sendToLimbo(...)` calls intact so proxy routing remains best-effort while guaranteeing `GameMode.ADVENTURE` and `setGhostModeAttributes(...)` are still applied locally.
- Ensured final-death still records `GhostState.deathLocations` and related `DlcDeaths` bookkeeping even when limbo transfer is attempted.

### Testing
- Ran `./gradlew -q :fabric:compileJava` from the repo root which could not run in this environment because the wrapper was not invoked from the root (no `./gradlew` at root), so build was not executed there.
- Ran `./gradlew -q compileJava` inside `fabric/` which failed due to the environment toolchain mismatch with the error `Unsupported class file major version 69`, so compilation could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc30d153288323b37d685739a35bf3)