### PR TITLE
Harden release workflow against Gradle supply-chain tampering

### DIFF
--- a/.github/workflows/build-plugin-release.yml
+++ b/.github/workflows/build-plugin-release.yml
@@ -26,8 +26,6 @@ jobs:
           java-version: '21'
           cache: maven
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
 
       - name: Build with Maven (Root)
         run: mvn -B clean package

--- a/fabric/gradle/wrapper/gradle-wrapper.properties
+++ b/fabric/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionSha256Sum=a4b4158601f8636cdeeab09bd76afb640030bb5b144aafe261a5e8af027dc612
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### Motivation
- The release job executed Gradle tooling in a workflow that has `contents: write`, and the Fabric Gradle wrapper lacked a `distributionSha256Sum`, leaving the release path vulnerable to tampered Gradle distributions or compromised actions. 
- A malicious Gradle distribution or compromised action could execute code in the release job and result in malicious artifacts being published to users.

### Description
- Removed the unpinned third-party action `gradle/actions/setup-gradle@v4` from `.github/workflows/build-plugin-release.yml` to avoid executing mutable external action code in the trusted release job. 
- Added `distributionSha256Sum=a4b4158601f8636cdeeab09bd76afb640030bb5b144aafe261a5e8af027dc612` to `fabric/gradle/wrapper/gradle-wrapper.properties` so the Gradle wrapper verifies the downloaded `gradle-8.8-bin.zip` before executing it.

### Testing
- Ran `./fabric/gradlew -p fabric --version` and it completed successfully with Gradle reporting `Gradle 8.8`.
- Verified the workflow and wrapper file diffs to confirm the `uses:` step was removed and the checksum line was added to the wrapper.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc2e220ff083238c9cc206d0dd1d45)