### PR TITLE
fix(forge): adapt payload registration to LexForge 1.21.1

### DIFF
--- a/forge/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
@@ -26,6 +26,7 @@ import org.ssoggy.ssoggysouls.hrm.dlc.listener.GhostModeEvents;
 import org.ssoggy.ssoggysouls.hrm.dlc.listener.GhostBlockEvents;
 import org.ssoggy.ssoggysouls.hrm.dlc.shared.DlcServices;
 import org.ssoggy.ssoggysouls.listener.LimboServerListener;
+import org.ssoggy.ssoggysouls.util.ServerTransferUtil;
 
 @Mod(SSoggySoulsMod.MODID)
 public class SSoggySoulsMod implements PluginContext {
@@ -95,7 +96,7 @@ public class SSoggySoulsMod implements PluginContext {
     }
 
     private void commonSetup(final FMLCommonSetupEvent event) {
-        // Some common setup code
+        ServerTransferUtil.register();
     }
 
     @SubscribeEvent

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/util/ServerTransferUtil.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/util/ServerTransferUtil.java
@@ -5,9 +5,9 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.network.event.RegisterPayloadHandlersEvent;
+import net.minecraftforge.network.ChannelBuilder;
+import net.minecraftforge.network.SimpleChannel;
+import net.minecraftforge.network.Channel;
 import org.ssoggy.ssoggysouls.SSoggySoulsMod;
 
 import java.io.ByteArrayInputStream;
@@ -17,16 +17,20 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
-@Mod.EventBusSubscriber(modid = SSoggySoulsMod.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
 public class ServerTransferUtil {
 
-    @SubscribeEvent
-    public static void registerPayloads(RegisterPayloadHandlersEvent event) {
-        event.registrar(SSoggySoulsMod.MODID).playToClient(
-                BungeeConnectPayload.PAYLOAD_TYPE,
-                BungeeConnectPayload.CODEC,
-                (payload, context) -> {}
-        );
+    private static final int PROTOCOL_VERSION = 1;
+    public static final SimpleChannel CHANNEL = ChannelBuilder
+            .named(ResourceLocation.fromNamespaceAndPath(SSoggySoulsMod.MODID, "bungee_connect"))
+            .networkProtocolVersion(PROTOCOL_VERSION)
+            .acceptedVersions(Channel.VersionTest.exact(PROTOCOL_VERSION))
+            .simpleChannel();
+
+    public static void register() {
+        CHANNEL.messageBuilder(BungeeConnectPayload.class, 1)
+                .codec(BungeeConnectPayload.CODEC)
+                .consumerMainThread((payload, context) -> {}) // No action needed on the client or server side to handle this specific custom payload besides what the proxy does
+                .add();
     }
 
     public static void sendToServer(ServerPlayer player, String serverName) {


### PR DESCRIPTION
- Refactor `ServerTransferUtil` to use `net.minecraftforge.network.ChannelBuilder` instead of the NeoForge-exclusive `RegisterPayloadHandlersEvent`.
- Remove outdated event-driven custom payload registration code.
- Define a configured `SimpleChannel` instance and introduce a new `register()` method.
- Update `SSoggySoulsMod` to properly invoke payload registration during the `FMLCommonSetupEvent` initialization phase.