### PR TITLE
📦 Porter: checkForUpdates config getter/setter ported to Fabric

### DIFF
--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/util/ConfigManager.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/util/ConfigManager.java
@@ -148,6 +148,7 @@ public class ConfigManager {
 
         // --- Debug ---
         private boolean debug = false;
+        private boolean checkForUpdates = true;
 
         public ModConfig() {
             // Default messages
@@ -227,6 +228,7 @@ public class ConfigManager {
         public java.util.List<String> getFenceBlocktag() { return fenceBlocktag; }
         public java.util.List<String> getStairBlocktag() { return stairBlocktag; }
         public boolean isDebug() { return debug; }
+        public boolean isCheckForUpdates() { return checkForUpdates; }
 
         /**
          * Bridge method for PluginContext compatibility.
@@ -306,6 +308,7 @@ public class ConfigManager {
         public void setFenceBlocktag(java.util.Collection<String> blocks) { fenceBlocktag = normalizeBlockList(blocks); }
         public void setStairBlocktag(java.util.Collection<String> blocks) { stairBlocktag = normalizeBlockList(blocks); }
         public void setDebug(boolean d) { debug = d; }
+        public void setCheckForUpdates(boolean check) { checkForUpdates = check; }
 
         private static java.util.List<String> normalizeBlockList(java.util.Collection<String> blocks) {
             java.util.List<String> normalized = new java.util.ArrayList<>();


### PR DESCRIPTION
💡 What: The `checkForUpdates` config field, getter, and setter were missing in the Fabric implementation of ConfigManager.
🔗 Origin: Commit a0e66cc (from the Forge port).
🛠️ Translation: Added `private boolean checkForUpdates = true;`, `isCheckForUpdates()`, and `setCheckForUpdates(boolean)` directly to the `ModConfig` inner class in `fabric/src/main/java/org/ssoggy/ssoggysouls/util/ConfigManager.java`.
🔬 Verification: Ran `./gradlew -p fabric build test` successfully with Gradle 8.10.

---
*PR created automatically by Jules for task [9865318437098118406](https://jules.google.com/task/9865318437098118406) started by @SSoggyTacoMan*