### PR TITLE
fix(paper): fix race condition in leave limbo command allowing dead players to escape

### DIFF
--- a/paper/src/main/java/org/ssoggy/ssoggysouls/command/LeaveLimboCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/command/LeaveLimboCommand.java
@@ -30,16 +30,26 @@ public class LeaveLimboCommand implements CommandExecutor {
     }
 
     private void handleLeave(Player player) {
-        if (plugin.getLimboDeadPlayers().contains(player.getUniqueId())) {
-            player.sendMessage(MessageUtil.get("limbo-cannot-leave"));
-            return;
-        }
+        // Run asynchronously to catch players who might not yet be in limboDeadPlayers
+        // during the initial join delay
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            boolean isDead = plugin.getDatabaseManager().isPlayerDead(player.getUniqueId());
 
-        player.sendMessage(MessageUtil.get("limbo-visit-leaving"));
-        Bukkit.getScheduler().runTaskLater(plugin, () -> {
-            if (player.isOnline()) {
-                ServerTransferUtil.sendToMain(player);
-            }
-        }, 20L);
+            Bukkit.getScheduler().runTask(plugin, () -> {
+                if (!player.isOnline()) return;
+
+                if (isDead || plugin.getLimboDeadPlayers().contains(player.getUniqueId())) {
+                    player.sendMessage(MessageUtil.get("limbo-cannot-leave"));
+                    return;
+                }
+
+                player.sendMessage(MessageUtil.get("limbo-visit-leaving"));
+                Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                    if (player.isOnline()) {
+                        ServerTransferUtil.sendToMain(player);
+                    }
+                }, 20L);
+            });
+        });
     }
 }


### PR DESCRIPTION
Fix a bug where players could spam `/leavelimbo` or `/hub` right after joining a server to return back to main without being verified as a dead player yet.

---
*PR created automatically by Jules for task [5649547325097722982](https://jules.google.com/task/5649547325097722982) started by @SSoggyTacoMan*