### PR TITLE
fix(common): prevent fail-open bypass on MySQL connection failure

### DIFF
--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
@@ -59,7 +59,7 @@ public class SSoggySoulsMod implements ModInitializer, PluginContext {
             databaseManager.initialize();
         } catch (DatabaseInitializationException e) {
             LOGGER.error("Failed to initialize database. Disabling features. Error: {}", e.getMessage(), e);
-            return;
+            throw new RuntimeException("Failed to initialize SSoggySouls database", e);
         }
         DlcServices.init(this);
 

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
@@ -59,7 +59,7 @@ public class SSoggySoulsMod implements ModInitializer, PluginContext {
             databaseManager.initialize();
         } catch (DatabaseInitializationException e) {
             LOGGER.error("Failed to initialize database. Disabling features. Error: {}", e.getMessage(), e);
-            throw new RuntimeException("Failed to initialize SSoggySouls database", e);
+            throw new IllegalStateException("Failed to initialize SSoggySouls database", e);
         }
         DlcServices.init(this);
 

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
@@ -65,7 +65,7 @@ public class SSoggySoulsMod implements PluginContext {
             databaseManager.initialize();
         } catch (DatabaseInitializationException e) {
             LOGGER.error("Failed to initialize database. Disabling features. Error: {}", e.getMessage(), e);
-            return;
+            throw new RuntimeException("Failed to initialize SSoggySouls database", e);
         }
         DlcServices.init(this);
 

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
@@ -65,7 +65,7 @@ public class SSoggySoulsMod implements PluginContext {
             databaseManager.initialize();
         } catch (DatabaseInitializationException e) {
             LOGGER.error("Failed to initialize database. Disabling features. Error: {}", e.getMessage(), e);
-            throw new RuntimeException("Failed to initialize SSoggySouls database", e);
+            throw new IllegalStateException("Failed to initialize SSoggySouls database", e);
         }
         DlcServices.init(this);
 


### PR DESCRIPTION
Fixes a fail-open bypass vulnerability where the Fabric and Forge implementations swallow MySQL connection failures and continue starting up.

---
*PR created automatically by Jules for task [8610413320538236425](https://jules.google.com/task/8610413320538236425) started by @SSoggyTacoMan*