### PR TITLE
fix(forge): ensure HRM mechanics are gated by config flags

### DIFF
--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/ExtraLifeManager.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/ExtraLifeManager.java
@@ -33,9 +33,8 @@ public class ExtraLifeManager {
 
     @SubscribeEvent
     public static void onItemRightClick(PlayerInteractEvent.RightClickItem event) {
-        if (!ConfigManager.getConfig().isHrmEnabled()) return;
-
-        if (db == null || event.getLevel().isClientSide() || !(event.getEntity() instanceof ServerPlayer serverPlayer)) {
+        ServerPlayer serverPlayer = org.ssoggy.ssoggysouls.util.HrmUtil.getValidServerPlayer(event, db);
+        if (serverPlayer == null) {
             return;
         }
 

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/ExtraLifeManager.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/ExtraLifeManager.java
@@ -33,6 +33,8 @@ public class ExtraLifeManager {
 
     @SubscribeEvent
     public static void onItemRightClick(PlayerInteractEvent.RightClickItem event) {
+        if (!ConfigManager.getConfig().isHrmEnabled()) return;
+
         if (db == null || event.getLevel().isClientSide() || !(event.getEntity() instanceof ServerPlayer serverPlayer)) {
             return;
         }

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/HeadEffectsTask.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/HeadEffectsTask.java
@@ -27,9 +27,9 @@ public class HeadEffectsTask {
 
     @SubscribeEvent
     public static void onServerTick(TickEvent.ServerTickEvent event) {
-        if (event.phase != TickEvent.Phase.END) return;
-
         if (!org.ssoggy.ssoggysouls.util.ConfigManager.getConfig().isHrmEnabled() || !org.ssoggy.ssoggysouls.util.ConfigManager.getConfig().isHeadWearingEffects()) return;
+
+        if (event.phase != TickEvent.Phase.END) return;
 
         MinecraftServer server = event.getServer();
         if (server.getTickCount() % 20 != 0) return; // Once per second

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/HeadEffectsTask.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/HeadEffectsTask.java
@@ -27,6 +27,8 @@ public class HeadEffectsTask {
 
     @SubscribeEvent
     public static void onServerTick(TickEvent.ServerTickEvent event) {
+        if (!org.ssoggy.ssoggysouls.util.ConfigManager.getConfig().isHrmEnabled() || !org.ssoggy.ssoggysouls.util.ConfigManager.getConfig().isHeadWearingEffects()) return;
+
         if (event.phase != TickEvent.Phase.END) return;
 
         MinecraftServer server = event.getServer();

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/HeadEffectsTask.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/HeadEffectsTask.java
@@ -27,9 +27,9 @@ public class HeadEffectsTask {
 
     @SubscribeEvent
     public static void onServerTick(TickEvent.ServerTickEvent event) {
-        if (!org.ssoggy.ssoggysouls.util.ConfigManager.getConfig().isHrmEnabled() || !org.ssoggy.ssoggysouls.util.ConfigManager.getConfig().isHeadWearingEffects()) return;
-
         if (event.phase != TickEvent.Phase.END) return;
+
+        if (!org.ssoggy.ssoggysouls.util.ConfigManager.getConfig().isHrmEnabled() || !org.ssoggy.ssoggysouls.util.ConfigManager.getConfig().isHeadWearingEffects()) return;
 
         MinecraftServer server = event.getServer();
         if (server.getTickCount() % 20 != 0) return; // Once per second

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java
@@ -60,13 +60,11 @@ public class RevivalStructureListener {
 
     @SubscribeEvent
     public static void onBlockPlace(PlayerInteractEvent.RightClickBlock event) {
-        if (!ConfigManager.getConfig().isHrmEnabled()) return;
-
-        if (db == null || event.getLevel().isClientSide() || !(event.getEntity() instanceof ServerPlayer)) {
+        ServerPlayer serverPlayer = org.ssoggy.ssoggysouls.util.HrmUtil.getValidServerPlayer(event, db);
+        if (serverPlayer == null) {
             return;
         }
 
-        ServerPlayer serverPlayer = (ServerPlayer) event.getEntity();
         Level world = event.getLevel();
         ItemStack stack = event.getItemStack();
 

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java
@@ -60,6 +60,8 @@ public class RevivalStructureListener {
 
     @SubscribeEvent
     public static void onBlockPlace(PlayerInteractEvent.RightClickBlock event) {
+        if (!ConfigManager.getConfig().isHrmEnabled()) return;
+
         if (db == null || event.getLevel().isClientSide() || !(event.getEntity() instanceof ServerPlayer)) {
             return;
         }

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/ReviveSkullManager.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/ReviveSkullManager.java
@@ -37,9 +37,8 @@ public class ReviveSkullManager {
 
     @SubscribeEvent
     public static void onItemRightClick(PlayerInteractEvent.RightClickItem event) {
-        if (!ConfigManager.getConfig().isHrmEnabled()) return;
-
-        if (db == null || event.getLevel().isClientSide() || !(event.getEntity() instanceof ServerPlayer serverPlayer)) {
+        ServerPlayer serverPlayer = org.ssoggy.ssoggysouls.util.HrmUtil.getValidServerPlayer(event, db);
+        if (serverPlayer == null) {
             return;
         }
 

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/ReviveSkullManager.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/ReviveSkullManager.java
@@ -20,6 +20,7 @@ import net.minecraftforge.fml.common.Mod;
 import org.ssoggy.ssoggysouls.SSoggySoulsMod;
 import org.ssoggy.ssoggysouls.database.DatabaseManager;
 import org.ssoggy.ssoggysouls.model.PlayerData;
+import org.ssoggy.ssoggysouls.util.ConfigManager;
 
 import java.util.List;
 import java.util.Optional;
@@ -36,6 +37,8 @@ public class ReviveSkullManager {
 
     @SubscribeEvent
     public static void onItemRightClick(PlayerInteractEvent.RightClickItem event) {
+        if (!ConfigManager.getConfig().isHrmEnabled()) return;
+
         if (db == null || event.getLevel().isClientSide() || !(event.getEntity() instanceof ServerPlayer serverPlayer)) {
             return;
         }

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostBlockEvents.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostBlockEvents.java
@@ -40,6 +40,8 @@ public class GhostBlockEvents {
 
     @SubscribeEvent
     public static void onItemPickup(EntityItemPickupEvent event) {
+        if (!org.ssoggy.ssoggysouls.util.ConfigManager.getConfig().isHrmEnabled()) return;
+
         if (db == null || !(event.getEntity() instanceof ServerPlayer player)) {
             return;
         }
@@ -61,6 +63,8 @@ public class GhostBlockEvents {
 
     @SubscribeEvent
     public static void onBlockBreak(BlockEvent.BreakEvent event) {
+        if (!org.ssoggy.ssoggysouls.util.ConfigManager.getConfig().isHrmEnabled()) return;
+
         if (db == null || event.getLevel().isClientSide() || !(event.getPlayer() instanceof ServerPlayer player)) {
             return;
         }
@@ -108,6 +112,8 @@ public class GhostBlockEvents {
 
     @SubscribeEvent
     public static void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
+        if (!org.ssoggy.ssoggysouls.util.ConfigManager.getConfig().isHrmEnabled()) return;
+
         if (db == null || event.getLevel().isClientSide() || !(event.getEntity() instanceof ServerPlayer player)) {
             return;
         }

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostBlockEvents.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostBlockEvents.java
@@ -112,9 +112,8 @@ public class GhostBlockEvents {
 
     @SubscribeEvent
     public static void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
-        if (!org.ssoggy.ssoggysouls.util.ConfigManager.getConfig().isHrmEnabled()) return;
-
-        if (db == null || event.getLevel().isClientSide() || !(event.getEntity() instanceof ServerPlayer player)) {
+        ServerPlayer player = org.ssoggy.ssoggysouls.util.HrmUtil.getValidServerPlayer(event, db);
+        if (player == null) {
             return;
         }
 

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
@@ -108,9 +108,9 @@ public class GhostModeEvents {
 
     @SubscribeEvent
     public static void onServerTick(TickEvent.ServerTickEvent event) {
-        if (!ConfigManager.getConfig().isHrmEnabled()) return;
-
         if (event.phase != TickEvent.Phase.END) return;
+
+        if (!ConfigManager.getConfig().isHrmEnabled()) return;
 
         for (ServerPlayer player : event.getServer().getPlayerList().getPlayers()) {
             if (isGhost(player)) {

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
@@ -34,6 +34,8 @@ public class GhostModeEvents {
 
     @SubscribeEvent
     public static void onPlayerJoin(PlayerEvent.PlayerLoggedInEvent event) {
+        if (!ConfigManager.getConfig().isHrmEnabled()) return;
+
         if (db == null || !(event.getEntity() instanceof ServerPlayer player)) return;
         UUID uuid = player.getUUID();
         
@@ -49,6 +51,8 @@ public class GhostModeEvents {
 
     @SubscribeEvent
     public static void onPlayerQuit(PlayerEvent.PlayerLoggedOutEvent event) {
+        if (!ConfigManager.getConfig().isHrmEnabled()) return;
+
         if (event.getEntity() instanceof ServerPlayer player) {
             GHOST_CACHE.remove(player.getUUID());
         }
@@ -56,6 +60,8 @@ public class GhostModeEvents {
 
     @SubscribeEvent
     public static void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
+        if (!ConfigManager.getConfig().isHrmEnabled()) return;
+
         if (isGhost(event.getEntity())) {
             event.setCanceled(true);
         }
@@ -63,6 +69,8 @@ public class GhostModeEvents {
 
     @SubscribeEvent
     public static void onRightClickItem(PlayerInteractEvent.RightClickItem event) {
+        if (!ConfigManager.getConfig().isHrmEnabled()) return;
+
         if (isGhost(event.getEntity())) {
             event.setCanceled(true);
         }
@@ -70,6 +78,8 @@ public class GhostModeEvents {
 
     @SubscribeEvent
     public static void onAttackEntity(AttackEntityEvent event) {
+        if (!ConfigManager.getConfig().isHrmEnabled()) return;
+
         if (isGhost(event.getEntity())) {
             event.setCanceled(true);
         }
@@ -77,6 +87,8 @@ public class GhostModeEvents {
 
     @SubscribeEvent
     public static void onItemToss(ItemTossEvent event) {
+        if (!ConfigManager.getConfig().isHrmEnabled()) return;
+
         if (isGhost(event.getPlayer())) {
             event.setCanceled(true);
         }
@@ -84,6 +96,8 @@ public class GhostModeEvents {
 
     @SubscribeEvent
     public static void onInteractEntity(PlayerInteractEvent.EntityInteract event) {
+        if (!ConfigManager.getConfig().isHrmEnabled()) return;
+
         if (isGhost(event.getEntity())) {
             if (event.getEntity() instanceof ServerPlayer serverPlayer) {
                 serverPlayer.setCamera(event.getTarget());
@@ -94,6 +108,8 @@ public class GhostModeEvents {
 
     @SubscribeEvent
     public static void onServerTick(TickEvent.ServerTickEvent event) {
+        if (!ConfigManager.getConfig().isHrmEnabled()) return;
+
         if (event.phase != TickEvent.Phase.END) return;
 
         for (ServerPlayer player : event.getServer().getPlayerList().getPlayers()) {

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
@@ -60,36 +60,28 @@ public class GhostModeEvents {
 
     @SubscribeEvent
     public static void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
-        if (!ConfigManager.getConfig().isHrmEnabled()) return;
-
-        if (isGhost(event.getEntity())) {
-            event.setCanceled(true);
-        }
+        handleCancelableEvent(event, event.getEntity());
     }
 
     @SubscribeEvent
     public static void onRightClickItem(PlayerInteractEvent.RightClickItem event) {
-        if (!ConfigManager.getConfig().isHrmEnabled()) return;
-
-        if (isGhost(event.getEntity())) {
-            event.setCanceled(true);
-        }
+        handleCancelableEvent(event, event.getEntity());
     }
 
     @SubscribeEvent
     public static void onAttackEntity(AttackEntityEvent event) {
-        if (!ConfigManager.getConfig().isHrmEnabled()) return;
-
-        if (isGhost(event.getEntity())) {
-            event.setCanceled(true);
-        }
+        handleCancelableEvent(event, event.getEntity());
     }
 
     @SubscribeEvent
     public static void onItemToss(ItemTossEvent event) {
+        handleCancelableEvent(event, event.getPlayer());
+    }
+
+    private static void handleCancelableEvent(net.minecraftforge.eventbus.api.Event event, Player player) {
         if (!ConfigManager.getConfig().isHrmEnabled()) return;
 
-        if (isGhost(event.getPlayer())) {
+        if (isGhost(player) && event.isCancelable()) {
             event.setCanceled(true);
         }
     }
@@ -108,9 +100,9 @@ public class GhostModeEvents {
 
     @SubscribeEvent
     public static void onServerTick(TickEvent.ServerTickEvent event) {
-        if (event.phase != TickEvent.Phase.END) return;
-
         if (!ConfigManager.getConfig().isHrmEnabled()) return;
+
+        if (event.phase != TickEvent.Phase.END) return;
 
         for (ServerPlayer player : event.getServer().getPlayerList().getPlayers()) {
             if (isGhost(player)) {

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/util/HrmUtil.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/util/HrmUtil.java
@@ -1,0 +1,36 @@
+package org.ssoggy.ssoggysouls.util;
+
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import org.ssoggy.ssoggysouls.database.DatabaseManager;
+
+/**
+ * Utility class for Hardcore Revival Mechanic (HRM) helpers to reduce code duplication.
+ */
+public final class HrmUtil {
+
+    private HrmUtil() {
+        // Utility class
+    }
+
+    /**
+     * Common validation helper for HRM (Hardcore Revival Mechanic) events to avoid code duplication.
+     * Checks if HRM is enabled, if the database manager is registered, if we are on the server side,
+     * and if the event entity is a ServerPlayer.
+     *
+     * @param event The player interact event
+     * @param db    The database manager
+     * @return The ServerPlayer instance if all checks pass, otherwise null
+     */
+    public static ServerPlayer getValidServerPlayer(PlayerInteractEvent event, DatabaseManager db) {
+        if (!ConfigManager.getConfig().isHrmEnabled()) {
+            return null;
+        }
+
+        if (db == null || event.getLevel().isClientSide() || !(event.getEntity() instanceof ServerPlayer serverPlayer)) {
+            return null;
+        }
+
+        return serverPlayer;
+    }
+}


### PR DESCRIPTION
Fixes a high-severity issue where HRM revival handlers were registered unconditionally, bypassing config flags. Adds checks for `ConfigManager.getConfig().isHrmEnabled()` to relevant handlers.

---
*PR created automatically by Jules for task [5305541429059611162](https://jules.google.com/task/5305541429059611162) started by @SSoggyTacoMan*