### PR TITLE
🧹 remove unused imports in ReviveSkullManager

### DIFF
--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/ReviveSkullManager.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/ReviveSkullManager.java
@@ -16,8 +16,6 @@ import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.item.component.ResolvableProfile;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
-import org.ssoggy.ssoggysouls.SSoggySoulsMod;
 import org.ssoggy.ssoggysouls.database.DatabaseManager;
 import org.ssoggy.ssoggysouls.model.PlayerData;
 


### PR DESCRIPTION
🎯 **What:** Removed unused imports `org.ssoggy.ssoggysouls.SSoggySoulsMod` and `net.minecraftforge.fml.common.Mod` from `ReviveSkullManager.java`.
💡 **Why:** This improves code maintainability and readability by removing dead code and reducing clutter.
✅ **Verification:** Verified through code inspection and successful code review. Local Gradle compilation was attempted but timed out due to environment limitations.
✨ **Result:** A cleaner and more maintainable `ReviveSkullManager` class in the Forge module.

---
*PR created automatically by Jules for task [6153602906067207009](https://jules.google.com/task/6153602906067207009) started by @SSoggyTacoMan*