### PR TITLE
🎨 Palette: Improve documentation accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-08 - Skip-to-Content Link Visibility
 **Learning:** A "skip-to-content" link was present in the HTML but lacked styling, meaning it wasn't visible when focused via keyboard navigation. This defeats the purpose of the skip link for sighted keyboard users.
 **Action:** When adding or maintaining a skip-to-content link, ensure it has specific `:focus` styles that make it visible and easily readable when receiving keyboard focus.
+## 2024-05-09 - Sidebar Navigation Context
+**Learning:** A `<nav>` element without an accessible name can be confusing for screen reader users, especially when there are multiple navigation landmarks on a page. Linking the `<nav>` to its visual title using `aria-labelledby` provides crucial context about what the navigation section is for (e.g., "Documentation navigation").
+**Action:** Always provide an accessible name for `<nav>` elements, either by using `aria-label` or by associating it with a visible heading using `aria-labelledby`.

--- a/docs/_includes/docs-sidebar.html
+++ b/docs/_includes/docs-sidebar.html
@@ -1,6 +1,6 @@
 <aside class="docs-sidebar" aria-label="Documentation navigation">
-  <p class="docs-sidebar-title">Documentation</p>
-  <nav>
+  <p id="docs-sidebar-title" class="docs-sidebar-title">Documentation</p>
+  <nav aria-labelledby="docs-sidebar-title">
     <ul class="docs-sidebar-list">
       <li><a class="{% if page.url == '/' or page.url == '/index.html' %}is-active{% endif %}" {% if page.url == '/' or page.url == '/index.html' %}aria-current="page"{% endif %} href="{{ '/' | relative_url }}">Home</a></li>
       <li><a class="{% if page.url contains 'quick-start' %}is-active{% endif %}" {% if page.url contains 'quick-start' %}aria-current="page"{% endif %} href="{{ '/quick-start' | relative_url }}">Quick Start</a></li>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -19,7 +19,7 @@
       <h1 class="project-name">{{ page.title | default: site.title | default: site.github.repository_name }}</h1>
       <h2 class="project-tagline">{{ page.description | default: site.description | default: site.github.project_tagline }}</h2>
       {% if site.github.is_project_page %}
-        <a href="{{ site.github.repository_url }}" class="btn">View on GitHub</a>
+        <a href="{{ site.github.repository_url }}" class="btn" target="_blank" rel="noopener noreferrer" aria-label="View on GitHub (opens in a new tab)">View on GitHub</a>
       {% endif %}
       <a href="https://modrinth.com/project/Pb03qu6T" class="btn" target="_blank" rel="noopener noreferrer" aria-label="View on Modrinth (opens in a new tab)">View on Modrinth</a>
       {% if site.show_downloads %}


### PR DESCRIPTION
This pull request introduces minor micro-UX and accessibility enhancements to the documentation site's Jekyll layouts.

**Improvements:**
1.  **"View on GitHub" button:** Added `target="_blank"` and `rel="noopener noreferrer"` to match the behavior of the Modrinth button, improving security and preventing reverse tabnabbing. Also added an `aria-label` to explicitly warn screen reader users that the link opens in a new tab.
2.  **Sidebar Navigation:** Linked the sidebar `<nav>` element to its visual "Documentation" title by giving the title an ID and adding `aria-labelledby` to the nav. This provides much-needed context to screen reader users navigating the landmarks.

---
*PR created automatically by Jules for task [17792222595679749183](https://jules.google.com/task/17792222595679749183) started by @SSoggyTacoMan*