### PR TITLE
🧹 refactor admin onCommand readability

### DIFF
--- a/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminCommand.java
@@ -102,22 +102,35 @@ public class AdminCommand implements CommandExecutor, TabCompleter {
     @SuppressWarnings("java:S3516") // onCommand always returns true by design (Bukkit CommandExecutor convention)
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        if (!CommandUtil.checkPermission(sender, "ssoggysouls.admin")) {
+        if (!hasCommandAccess(sender)) {
             return true;
+        }
+
+        handleRootCommand(sender, args);
+        return true;
+    }
+
+    private boolean hasCommandAccess(CommandSender sender) {
+        if (!CommandUtil.checkPermission(sender, "ssoggysouls.admin")) {
+            return false;
         }
 
         // Security check: Prevent Limbo-only OP from using this command
         if (PermissionUtil.isBlockedByLimboOpSecurity(sender, plugin)) {
             PermissionUtil.sendSecurityBlockMessage(sender);
-            return true;
+            return false;
         }
 
+        return true;
+    }
+
+    private void handleRootCommand(CommandSender sender, String[] args) {
         if (args.length == 0) {
             sendHelp(sender);
-        } else {
-            dispatch(sender, args);
+            return;
         }
-        return true;
+
+        dispatch(sender, args);
     }
 
     private void dispatch(CommandSender sender, String[] args) {


### PR DESCRIPTION
### Motivation
- Reduce complexity in `AdminCommand#onCommand` by separating access checks and top-level routing to make the entry point easier to read and maintain while preserving existing behavior.

### Description
- Extracted permission and Limbo OP security checks into `hasCommandAccess(CommandSender)` and moved root argument handling into `handleRootCommand(CommandSender, String[])`, with `onCommand` delegating to these helpers.

### Testing
- Ran `./gradlew :paper:check` successfully and verified the command dispatch behavior remains unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a00510e3c3c832383ebba1c9ea8e025)