### PR TITLE
refactor(forge): remove unused mod import

### DIFF
--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java
@@ -23,7 +23,6 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
 import org.ssoggy.ssoggysouls.SSoggySoulsMod;
 import org.ssoggy.ssoggysouls.database.DatabaseManager;
 import org.ssoggy.ssoggysouls.hrm.dlc.listener.GhostModeEvents;


### PR DESCRIPTION
### Motivation
- Remove the unused `net.minecraftforge.fml.common.Mod` import from `RevivalStructureListener` to reduce dead‑code noise and improve readability without changing behavior.

### Description
- Deleted the unused import in `forge/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java` and committed the change.

### Testing
- Ran `./gradlew :forge:compileJava`, which exercised the build, but the run failed in this environment due to a missing Java 21 toolchain; the change is a simple import removal and does not affect runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0050dc927083239e0a79f8d41a7375)