### PR TITLE
Fix for Useless comparison test

### DIFF
--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/RPConfigCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/RPConfigCommand.java
@@ -228,8 +228,8 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
                     result.message = CMD_PREFIX + args[0] + " " + args[1] + ERR_MARKER_OPEN + args[2] + ERR_MARKER_CLOSE;
                     break;
                 }
-                // fall through to default intentionally for reset action
-                executeStructureCMD(args.length > 3 ? args[3].toUpperCase() : "", args[2], args[1], result);
+                // reset action has exactly 3 args, so no material argument is available
+                executeStructureCMD("", args[2], args[1], result);
                 break;
             default:
                 executeStructureCMD(args.length > 3 ? args[3].toUpperCase() : "", args[2], args[1], result); // All params are successfully entered


### PR DESCRIPTION
The best fix is to remove the impossible conditional in the `case 3` branch and pass the explicit empty string directly to `executeStructureCMD`, since a 4th argument cannot exist when `args.length == 3`.

Concretely, in `paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/RPConfigCommand.java`, update the line in `handleStructure` under `case 3`:
- Replace `executeStructureCMD(args.length > 3 ? args[3].toUpperCase() : "", args[2], args[1], result);`
- With `executeStructureCMD("", args[2], args[1], result);`

No imports, helper methods, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._