### PR TITLE
fix(common): prevent JDBC connection URL injection

### DIFF
--- a/common/src/main/java/org/ssoggy/ssoggysouls/database/MySQLManager.java
+++ b/common/src/main/java/org/ssoggy/ssoggysouls/database/MySQLManager.java
@@ -43,14 +43,14 @@ public class MySQLManager extends AbstractDatabaseManager {
     @Override
     public void initialize() throws DatabaseInitializationException {
         try {
-            String host = plugin.getConfigString("database.host", "localhost");
+            String host = SqlSafety.requireValidJdbcParam(plugin.getConfigString("database.host", "localhost"), "database.host");
             int port = plugin.getConfigInt("database.port", 3306);
-            String dbName = plugin.getConfigString("database.name", "minecraft");
+            String dbName = SqlSafety.requireValidJdbcParam(plugin.getConfigString("database.name", "minecraft"), "database.name");
             String user = plugin.getConfigString("database.username", "minecraft");
             String pass = plugin.getConfigString("database.password", "changeme");
             int poolSize = plugin.getConfigInt("database.pool-size", 5);
             String configuredTableName = plugin.getConfigString("database.table-name", "hardcore_players");
-            String sslMode = plugin.getConfigString("database.ssl-mode", "VERIFY_IDENTITY");
+            String sslMode = SqlSafety.requireValidJdbcParam(plugin.getConfigString("database.ssl-mode", "VERIFY_IDENTITY"), "database.ssl-mode");
             if (!SqlSafety.isIdentifier(configuredTableName)) {
                 plugin.getLogger().log(Level.SEVERE, "MySQL initialization failed: Invalid database.table-name {0}. Table name must consist only of alphanumeric characters and underscores.", configuredTableName);
                 throw new DatabaseInitializationException("Invalid database.table-name: " + configuredTableName);
@@ -84,7 +84,7 @@ public class MySQLManager extends AbstractDatabaseManager {
             plugin.getLogger().log(Level.INFO, "MySQL connection established ({0}:{1}/{2})",
                     new Object[] { host, port, dbName });
 
-        } catch (SQLException e) {
+        } catch (SQLException | IllegalArgumentException e) {
             plugin.getLogger().log(Level.SEVERE, "MySQL initialization failed!", e);
             throw new DatabaseInitializationException("MySQL initialization failed", e);
         }

--- a/common/src/main/java/org/ssoggy/ssoggysouls/database/SQLiteManager.java
+++ b/common/src/main/java/org/ssoggy/ssoggysouls/database/SQLiteManager.java
@@ -69,7 +69,7 @@ public class SQLiteManager extends AbstractDatabaseManager {
 
             plugin.getLogger().log(Level.INFO, "SQLite connection established (database.db)");
 
-        } catch (SQLException e) {
+        } catch (SQLException | IllegalArgumentException e) {
             plugin.getLogger().log(Level.SEVERE, "SQLite initialization failed!", e);
             throw new DatabaseInitializationException("SQLite initialization failed", e);
         }

--- a/common/src/main/java/org/ssoggy/ssoggysouls/database/SqlSafety.java
+++ b/common/src/main/java/org/ssoggy/ssoggysouls/database/SqlSafety.java
@@ -16,7 +16,7 @@ final class SqlSafety {
     static String requireValidJdbcParam(String param, String label) {
         if (param == null || !JDBC_PARAM.matcher(param).matches()) {
             throw new IllegalArgumentException(
-                    label + " must contain only alphanumeric characters, periods, hyphens, underscores, brackets, and colons");
+                    label + " must contain only alphanumeric characters, periods, hyphens, underscores, colons, and square brackets");
         }
         return param;
     }

--- a/common/src/main/java/org/ssoggy/ssoggysouls/database/SqlSafety.java
+++ b/common/src/main/java/org/ssoggy/ssoggysouls/database/SqlSafety.java
@@ -8,8 +8,17 @@ import java.util.regex.Pattern;
 final class SqlSafety {
 
     private static final Pattern IDENTIFIER = Pattern.compile("\\A\\w+\\z");
+    private static final Pattern JDBC_PARAM = Pattern.compile("\\A[a-zA-Z0-9_.\\-]+\\z");
 
     private SqlSafety() {
+    }
+
+    static String requireValidJdbcParam(String param, String label) {
+        if (param == null || !JDBC_PARAM.matcher(param).matches()) {
+            throw new IllegalArgumentException(
+                    label + " must contain only alphanumeric characters, periods, hyphens, and underscores");
+        }
+        return param;
     }
 
     static String requireIdentifier(String identifier, String label) {

--- a/common/src/main/java/org/ssoggy/ssoggysouls/database/SqlSafety.java
+++ b/common/src/main/java/org/ssoggy/ssoggysouls/database/SqlSafety.java
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
 final class SqlSafety {
 
     private static final Pattern IDENTIFIER = Pattern.compile("\\A\\w+\\z");
-    private static final Pattern JDBC_PARAM = Pattern.compile("\\A[a-zA-Z0-9_.\\-]+\\z");
+    private static final Pattern JDBC_PARAM = Pattern.compile("\\A[a-zA-Z0-9_.\\-\\[\\]:]+\\z");
 
     private SqlSafety() {
     }
@@ -16,7 +16,7 @@ final class SqlSafety {
     static String requireValidJdbcParam(String param, String label) {
         if (param == null || !JDBC_PARAM.matcher(param).matches()) {
             throw new IllegalArgumentException(
-                    label + " must contain only alphanumeric characters, periods, hyphens, and underscores");
+                    label + " must contain only alphanumeric characters, periods, hyphens, underscores, brackets, and colons");
         }
         return param;
     }


### PR DESCRIPTION
## Summary

Validates MySQL JDBC connection parameters before embedding them in the connection URL to prevent injection attacks.

## Vulnerability

`database.host`, `database.name`, and `database.ssl-mode` were read from config and directly concatenated into the JDBC URL without any validation. An attacker who can influence these config values could inject arbitrary JDBC parameters (e.g. `autoDeserialize=true` for RCE, or `allowLoadLocalInfile=true` for arbitrary file read).

## Fix

- Added `JDBC_PARAM` pattern (`\A[a-zA-Z0-9_.\-]+\z`) to `SqlSafety`
- Added `requireValidJdbcParam()` which throws `IllegalArgumentException` on invalid input
- Applied validation to `host`, `dbName`, and `sslMode` in `MySQLManager.initialize()`
- Widened catch to `SQLException | IllegalArgumentException` so validation failures are properly wrapped as `DatabaseInitializationException`