### PR TITLE
📦 Porter: Ghost Mode teleport feedback ported to Forge, NeoForge, and Fabric

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,12 +56,15 @@ jobs:
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
-      - name: Build and analyze
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      - name: Build and Test
         run: |
           chmod +x ./gradlew
-          ./gradlew build sonar --info
+          ./gradlew build --info
+
+      - name: SonarQube Analysis
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew sonar --info
 
   dependency-submission:
     name: Submit Dependency Graph

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           chmod +x ./gradlew
-          ./gradlew sonar --info
+          ./gradlew classes sonar --info
 
   dependency-submission:
     name: Submit Dependency Graph

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,31 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
+      - name: Build and Test
+        run: |
+          chmod +x ./gradlew
+          ./gradlew build
+
+  sonar:
+    name: SonarQube Analysis
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: "21"
+          distribution: "temurin"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+
       - name: Cache SonarQube packages
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
@@ -56,15 +81,12 @@ jobs:
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
-      - name: Build and Test
-        run: |
-          chmod +x ./gradlew
-          ./gradlew build
-
       - name: SonarQube Analysis
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew sonar
+        run: |
+          chmod +x ./gradlew
+          ./gradlew classes sonar
 
   dependency-submission:
     name: Submit Dependency Graph

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,30 +49,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
-      - name: Build and Test
-        run: |
-          chmod +x ./gradlew
-          ./gradlew build --info
-
-  sonar:
-    name: SonarQube Analysis
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          java-version: "21"
-          distribution: "temurin"
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
-
       - name: Cache SonarQube packages
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
@@ -80,12 +56,15 @@ jobs:
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
+      - name: Build and Test
+        run: |
+          chmod +x ./gradlew
+          ./gradlew build
+
       - name: SonarQube Analysis
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: |
-          chmod +x ./gradlew
-          ./gradlew classes sonar --info
+        run: ./gradlew sonar
 
   dependency-submission:
     name: Submit Dependency Graph

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,30 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
+      - name: Build and Test
+        run: |
+          chmod +x ./gradlew
+          ./gradlew build --info
+
+  sonar:
+    name: SonarQube Analysis
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: "21"
+          distribution: "temurin"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+
       - name: Cache SonarQube packages
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
@@ -56,15 +80,12 @@ jobs:
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
-      - name: Build and Test
-        run: |
-          chmod +x ./gradlew
-          ./gradlew build --info
-
       - name: SonarQube Analysis
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew sonar --info
+        run: |
+          chmod +x ./gradlew
+          ./gradlew sonar --info
 
   dependency-submission:
     name: Submit Dependency Graph

--- a/common/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/shared/GhostRestrictionLogic.java
+++ b/common/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/shared/GhostRestrictionLogic.java
@@ -1,0 +1,33 @@
+package org.ssoggy.ssoggysouls.hrm.dlc.shared;
+
+/**
+ * Shared logic for ghost mode restrictions.
+ */
+public final class GhostRestrictionLogic {
+    private GhostRestrictionLogic() {
+    }
+
+    /** The message shown to players when they are teleported back to their death location. */
+    public static final String RESTRICTION_MESSAGE = "You may not travel that far away from your death location";
+
+    /**
+     * Checks if a ghost player has traveled beyond the allowed radius from their death location.
+     *
+     * @param deathX      X coordinate of death location
+     * @param deathY      Y coordinate of death location
+     * @param deathZ      Z coordinate of death location
+     * @param currentX    Current X coordinate of player
+     * @param currentY    Current Y coordinate of player
+     * @param currentZ    Current Z coordinate of player
+     * @param maxDistance Maximum allowed distance from death location
+     * @return true if the player is beyond the max distance
+     */
+    public static boolean isOutOfBounds(double deathX, double deathY, double deathZ,
+                                        double currentX, double currentY, double currentZ,
+                                        double maxDistance) {
+        double dx = deathX - currentX;
+        double dy = deathY - currentY;
+        double dz = deathZ - currentZ;
+        return (dx * dx + dy * dy + dz * dz) > (maxDistance * maxDistance);
+    }
+}

--- a/common/src/test/java/org/ssoggy/ssoggysouls/hrm/dlc/shared/GhostRestrictionLogicTest.java
+++ b/common/src/test/java/org/ssoggy/ssoggysouls/hrm/dlc/shared/GhostRestrictionLogicTest.java
@@ -1,0 +1,27 @@
+package org.ssoggy.ssoggysouls.hrm.dlc.shared;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class GhostRestrictionLogicTest {
+
+    @Test
+    void testIsOutOfBounds() {
+        // Within bounds
+        assertFalse(GhostRestrictionLogic.isOutOfBounds(0, 0, 0, 3, 0, 4, 5.1));
+        
+        // Exactly on bounds (isOutOfBounds uses > not >=)
+        assertFalse(GhostRestrictionLogic.isOutOfBounds(0, 0, 0, 3, 0, 4, 5.0));
+        
+        // Out of bounds
+        assertTrue(GhostRestrictionLogic.isOutOfBounds(0, 0, 0, 3, 0, 4, 4.9));
+        
+        // Far out
+        assertTrue(GhostRestrictionLogic.isOutOfBounds(100, 100, 100, 200, 200, 200, 50));
+    }
+
+    @Test
+    void testMessageConstant() {
+        assertEquals("You may not travel that far away from your death location", GhostRestrictionLogic.RESTRICTION_MESSAGE);
+    }
+}

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
@@ -141,11 +141,13 @@ public class GhostModeEvents {
     private static void applyTeleportFeedback(ServerPlayerEntity player, BlockPos deathPos) {
         // Port of Paper's onPlayerMove teleport feedback (sound + particles).
         player.teleport(player.getServerWorld(), deathPos.getX() + 0.5, deathPos.getY(), deathPos.getZ() + 0.5, player.getYaw(), player.getPitch());
-        player.getServerWorld().playSound(null, deathPos, SoundEvents.ITEM_CHORUS_FRUIT_TELEPORT, SoundCategory.PLAYERS, 1.0f, 1.0f);
+        
+        // Scope sound and particles to the ghost only to prevent location leaking
+        player.playSound(SoundEvents.ITEM_CHORUS_FRUIT_TELEPORT, SoundCategory.PLAYERS, 1.0f, 1.0f);
         
         if (ConfigManager.getConfig().isGhostModeParticles()) {
-            player.getServerWorld().spawnParticles(ParticleTypes.DRAGON_BREATH,
-                    deathPos.getX() + 0.5, deathPos.getY(), deathPos.getZ() + 0.5,
+            player.getServerWorld().spawnParticles(player, ParticleTypes.DRAGON_BREATH,
+                    true, deathPos.getX() + 0.5, deathPos.getY(), deathPos.getZ() + 0.5,
                     50, 0.0, 1.0, 0.0, 0.2);
         }
         

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
@@ -143,7 +143,7 @@ public class GhostModeEvents {
         player.teleport(player.getServerWorld(), deathPos.getX() + 0.5, deathPos.getY(), deathPos.getZ() + 0.5, player.getYaw(), player.getPitch());
         
         // Scope sound and particles to the ghost only to prevent location leaking
-        player.playSound(SoundEvents.ITEM_CHORUS_FRUIT_TELEPORT, SoundCategory.PLAYERS, 1.0f, 1.0f);
+        player.playSound(SoundEvents.ITEM_CHORUS_FRUIT_TELEPORT, 1.0f, 1.0f);
         
         if (ConfigManager.getConfig().isGhostModeParticles()) {
             player.getServerWorld().spawnParticles(player, ParticleTypes.DRAGON_BREATH,

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
@@ -134,11 +134,11 @@ public class GhostModeEvents {
             if (distanceSq > (maxDistance * maxDistance)) {
                 // Port of Paper's onPlayerMove teleport feedback (sound + particles).
                 // Origin: paper/GhostModeEvents.java#onPlayerMove
-                player.teleport(player.getServerWorld(), deathPos.getX() + 0.5, deathPos.getY(), deathPos.getZ() + 0.5, player.getYaw(), player.getPitch());
-                player.getServerWorld().playSound(null, deathPos, SoundEvents.ITEM_CHORUS_FRUIT_TELEPORT, SoundCategory.PLAYERS, 1.0f, 1.0f);
+                player.teleport(player.getServerWorld(), deathPos.getX() + 0.5, deathPos.getY() + 0.5, deathPos.getZ() + 0.5, player.getYaw(), player.getPitch());
+                player.playSound(SoundEvents.ITEM_CHORUS_FRUIT_TELEPORT, SoundCategory.PLAYERS, 1.0f, 1.0f);
                 if (ConfigManager.getConfig().isGhostModeParticles()) {
                     player.getServerWorld().spawnParticles(ParticleTypes.DRAGON_BREATH,
-                            deathPos.getX() + 0.5, deathPos.getY(), deathPos.getZ() + 0.5,
+                            deathPos.getX() + 0.5, deathPos.getY() + 0.5, deathPos.getZ() + 0.5,
                             50, 0.0, 1.0, 0.0, 0.2);
                 }
                 player.sendMessage(net.minecraft.text.Text.literal("You may not travel that far away from your death location").styled(s -> s.withColor(net.minecraft.util.Formatting.GRAY)), true);

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
@@ -7,7 +7,10 @@ import net.fabricmc.fabric.api.event.player.UseEntityCallback;
 import net.fabricmc.fabric.api.event.player.UseItemCallback;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.particle.ParticleTypes;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.sound.SoundCategory;
+import net.minecraft.sound.SoundEvents;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.TypedActionResult;
 import net.minecraft.util.math.BlockPos;
@@ -129,7 +132,15 @@ public class GhostModeEvents {
             double maxDistance = ConfigManager.getConfig().getSpectatorHeadRestrictRadius();
 
             if (distanceSq > (maxDistance * maxDistance)) {
+                // Port of Paper's onPlayerMove teleport feedback (sound + particles).
+                // Origin: paper/GhostModeEvents.java#onPlayerMove
                 player.teleport(player.getServerWorld(), deathPos.getX() + 0.5, deathPos.getY(), deathPos.getZ() + 0.5, player.getYaw(), player.getPitch());
+                player.getServerWorld().playSound(null, deathPos, SoundEvents.ITEM_CHORUS_FRUIT_TELEPORT, SoundCategory.PLAYERS, 1.0f, 1.0f);
+                if (ConfigManager.getConfig().isGhostModeParticles()) {
+                    player.getServerWorld().spawnParticles(ParticleTypes.DRAGON_BREATH,
+                            deathPos.getX() + 0.5, deathPos.getY(), deathPos.getZ() + 0.5,
+                            50, 0.0, 1.0, 0.0, 0.2);
+                }
                 player.sendMessage(net.minecraft.text.Text.literal("You may not travel that far away from your death location").styled(s -> s.withColor(net.minecraft.util.Formatting.GRAY)), true);
             }
         }

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
@@ -16,6 +16,7 @@ import net.minecraft.util.TypedActionResult;
 import net.minecraft.util.math.BlockPos;
 import org.ssoggy.ssoggysouls.database.DatabaseManager;
 import org.ssoggy.ssoggysouls.hrm.dlc.util.GhostState;
+import org.ssoggy.ssoggysouls.hrm.dlc.shared.GhostRestrictionLogic;
 import org.ssoggy.ssoggysouls.model.PlayerData;
 import org.ssoggy.ssoggysouls.util.ConfigManager;
 
@@ -128,22 +129,28 @@ public class GhostModeEvents {
             BlockPos deathPos = state.deathLocations.get(uuid);
             BlockPos currentPos = player.getBlockPos();
 
-            double distanceSq = currentPos.getSquaredDistance(deathPos);
             double maxDistance = ConfigManager.getConfig().getSpectatorHeadRestrictRadius();
 
-            if (distanceSq > (maxDistance * maxDistance)) {
-                // Port of Paper's onPlayerMove teleport feedback (sound + particles).
-                // Origin: paper/GhostModeEvents.java#onPlayerMove
-                player.teleport(player.getServerWorld(), deathPos.getX() + 0.5, deathPos.getY() + 0.5, deathPos.getZ() + 0.5, player.getYaw(), player.getPitch());
-                player.playSound(SoundEvents.ITEM_CHORUS_FRUIT_TELEPORT, SoundCategory.PLAYERS, 1.0f, 1.0f);
-                if (ConfigManager.getConfig().isGhostModeParticles()) {
-                    player.getServerWorld().spawnParticles(ParticleTypes.DRAGON_BREATH,
-                            deathPos.getX() + 0.5, deathPos.getY() + 0.5, deathPos.getZ() + 0.5,
-                            50, 0.0, 1.0, 0.0, 0.2);
-                }
-                player.sendMessage(net.minecraft.text.Text.literal("You may not travel that far away from your death location").styled(s -> s.withColor(net.minecraft.util.Formatting.GRAY)), true);
+            if (GhostRestrictionLogic.isOutOfBounds(deathPos.getX(), deathPos.getY(), deathPos.getZ(),
+                    currentPos.getX(), currentPos.getY(), currentPos.getZ(), maxDistance)) {
+                applyTeleportFeedback(player, deathPos);
             }
         }
+    }
+
+    private static void applyTeleportFeedback(ServerPlayerEntity player, BlockPos deathPos) {
+        // Port of Paper's onPlayerMove teleport feedback (sound + particles).
+        player.teleport(player.getServerWorld(), deathPos.getX() + 0.5, deathPos.getY(), deathPos.getZ() + 0.5, player.getYaw(), player.getPitch());
+        player.getServerWorld().playSound(null, deathPos, SoundEvents.ITEM_CHORUS_FRUIT_TELEPORT, SoundCategory.PLAYERS, 1.0f, 1.0f);
+        
+        if (ConfigManager.getConfig().isGhostModeParticles()) {
+            player.getServerWorld().spawnParticles(ParticleTypes.DRAGON_BREATH,
+                    deathPos.getX() + 0.5, deathPos.getY(), deathPos.getZ() + 0.5,
+                    50, 0.0, 1.0, 0.0, 0.2);
+        }
+        
+        player.sendMessage(net.minecraft.text.Text.literal(GhostRestrictionLogic.RESTRICTION_MESSAGE)
+                .styled(s -> s.withColor(net.minecraft.util.Formatting.GRAY)), true);
     }
 
     public static void updateGhostStatus(UUID uuid, boolean isDead) {

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
@@ -141,10 +141,12 @@ public class GhostModeEvents {
     private static void applyTeleportFeedback(ServerPlayer player, BlockPos deathPos) {
         // Port of Paper's onPlayerMove teleport feedback (sound + particles).
         player.teleportTo(player.serverLevel(), deathPos.getX() + 0.5, deathPos.getY(), deathPos.getZ() + 0.5, player.getYRot(), player.getXRot());
-        player.serverLevel().playSound(null, deathPos, SoundEvents.CHORUS_FRUIT_TELEPORT, SoundSource.PLAYERS, 1.0f, 1.0f);
+        
+        // Scope sound and particles to the ghost only to prevent location leaking
+        player.playNotifySound(SoundEvents.CHORUS_FRUIT_TELEPORT, SoundSource.PLAYERS, 1.0f, 1.0f);
         
         if (ConfigManager.getConfig().isGhostModeParticles()) {
-            player.serverLevel().sendParticles(ParticleTypes.DRAGON_BREATH,
+            player.serverLevel().sendParticles(player, ParticleTypes.DRAGON_BREATH, true,
                     deathPos.getX() + 0.5, deathPos.getY(), deathPos.getZ() + 0.5,
                     50, 0.0, 1.0, 0.0, 0.2);
         }

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
@@ -17,6 +17,7 @@ import net.minecraftforge.fml.common.Mod;
 import org.ssoggy.ssoggysouls.SSoggySoulsMod;
 import org.ssoggy.ssoggysouls.database.DatabaseManager;
 import org.ssoggy.ssoggysouls.hrm.dlc.util.GhostState;
+import org.ssoggy.ssoggysouls.hrm.dlc.shared.GhostRestrictionLogic;
 import org.ssoggy.ssoggysouls.model.PlayerData;
 import org.ssoggy.ssoggysouls.util.ConfigManager;
 
@@ -129,21 +130,27 @@ public class GhostModeEvents {
         }
 
         BlockPos currentPos = player.blockPosition();
-        double distanceSq = currentPos.distSqr(deathPos);
         double maxDistance = ConfigManager.getConfig().getSpectatorHeadRestrictRadius();
 
-        if (distanceSq > (maxDistance * maxDistance)) {
-            // Port of Paper's onPlayerMove teleport feedback (sound + particles).
-            // Origin: paper/GhostModeEvents.java#onPlayerMove
-            player.teleportTo(player.serverLevel(), deathPos.getX() + 0.5, deathPos.getY() + 0.5, deathPos.getZ() + 0.5, player.getYRot(), player.getXRot());
-            player.playSound(SoundEvents.CHORUS_FRUIT_TELEPORT, SoundSource.PLAYERS, 1.0f, 1.0f);
-            if (ConfigManager.getConfig().isGhostModeParticles()) {
-                player.serverLevel().sendParticles(ParticleTypes.DRAGON_BREATH,
-                        deathPos.getX() + 0.5, deathPos.getY() + 0.5, deathPos.getZ() + 0.5,
-                        50, 0.0, 1.0, 0.0, 0.2);
-            }
-            player.displayClientMessage(Component.literal("You may not travel that far away from your death location").withStyle(net.minecraft.ChatFormatting.GRAY), true);
+        if (GhostRestrictionLogic.isOutOfBounds(deathPos.getX(), deathPos.getY(), deathPos.getZ(),
+                currentPos.getX(), currentPos.getY(), currentPos.getZ(), maxDistance)) {
+            applyTeleportFeedback(player, deathPos);
         }
+    }
+
+    private static void applyTeleportFeedback(ServerPlayer player, BlockPos deathPos) {
+        // Port of Paper's onPlayerMove teleport feedback (sound + particles).
+        player.teleportTo(player.serverLevel(), deathPos.getX() + 0.5, deathPos.getY(), deathPos.getZ() + 0.5, player.getYRot(), player.getXRot());
+        player.serverLevel().playSound(null, deathPos, SoundEvents.CHORUS_FRUIT_TELEPORT, SoundSource.PLAYERS, 1.0f, 1.0f);
+        
+        if (ConfigManager.getConfig().isGhostModeParticles()) {
+            player.serverLevel().sendParticles(ParticleTypes.DRAGON_BREATH,
+                    deathPos.getX() + 0.5, deathPos.getY(), deathPos.getZ() + 0.5,
+                    50, 0.0, 1.0, 0.0, 0.2);
+        }
+        
+        player.sendSystemMessage(Component.literal(GhostRestrictionLogic.RESTRICTION_MESSAGE)
+                .withStyle(net.minecraft.ChatFormatting.GRAY));
     }
 
     public static void updateGhostStatus(UUID uuid, boolean isDead) {

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
@@ -135,14 +135,14 @@ public class GhostModeEvents {
         if (distanceSq > (maxDistance * maxDistance)) {
             // Port of Paper's onPlayerMove teleport feedback (sound + particles).
             // Origin: paper/GhostModeEvents.java#onPlayerMove
-            player.teleportTo(player.serverLevel(), deathPos.getX() + 0.5, deathPos.getY(), deathPos.getZ() + 0.5, player.getYRot(), player.getXRot());
-            player.serverLevel().playSound(null, deathPos, SoundEvents.CHORUS_FRUIT_TELEPORT, SoundSource.PLAYERS, 1.0f, 1.0f);
+            player.teleportTo(player.serverLevel(), deathPos.getX() + 0.5, deathPos.getY() + 0.5, deathPos.getZ() + 0.5, player.getYRot(), player.getXRot());
+            player.playSound(SoundEvents.CHORUS_FRUIT_TELEPORT, SoundSource.PLAYERS, 1.0f, 1.0f);
             if (ConfigManager.getConfig().isGhostModeParticles()) {
                 player.serverLevel().sendParticles(ParticleTypes.DRAGON_BREATH,
-                        deathPos.getX() + 0.5, deathPos.getY(), deathPos.getZ() + 0.5,
+                        deathPos.getX() + 0.5, deathPos.getY() + 0.5, deathPos.getZ() + 0.5,
                         50, 0.0, 1.0, 0.0, 0.2);
             }
-            player.sendSystemMessage(Component.literal("You may not travel that far away from your death location").withStyle(net.minecraft.ChatFormatting.GRAY));
+            player.displayClientMessage(Component.literal("You may not travel that far away from your death location").withStyle(net.minecraft.ChatFormatting.GRAY), true);
         }
     }
 

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
@@ -1,8 +1,11 @@
 package org.ssoggy.ssoggysouls.hrm.dlc.listener;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.item.ItemTossEvent;
@@ -130,7 +133,15 @@ public class GhostModeEvents {
         double maxDistance = ConfigManager.getConfig().getSpectatorHeadRestrictRadius();
 
         if (distanceSq > (maxDistance * maxDistance)) {
+            // Port of Paper's onPlayerMove teleport feedback (sound + particles).
+            // Origin: paper/GhostModeEvents.java#onPlayerMove
             player.teleportTo(player.serverLevel(), deathPos.getX() + 0.5, deathPos.getY(), deathPos.getZ() + 0.5, player.getYRot(), player.getXRot());
+            player.serverLevel().playSound(null, deathPos, SoundEvents.CHORUS_FRUIT_TELEPORT, SoundSource.PLAYERS, 1.0f, 1.0f);
+            if (ConfigManager.getConfig().isGhostModeParticles()) {
+                player.serverLevel().sendParticles(ParticleTypes.DRAGON_BREATH,
+                        deathPos.getX() + 0.5, deathPos.getY(), deathPos.getZ() + 0.5,
+                        50, 0.0, 1.0, 0.0, 0.2);
+            }
             player.sendSystemMessage(Component.literal("You may not travel that far away from your death location").withStyle(net.minecraft.ChatFormatting.GRAY));
         }
     }

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
@@ -1,8 +1,11 @@
 package org.ssoggy.ssoggysouls.hrm.dlc.listener;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.entity.player.Player;
 import net.neoforged.neoforge.event.tick.ServerTickEvent;
 import net.neoforged.neoforge.event.entity.item.ItemTossEvent;
@@ -127,7 +130,15 @@ public class GhostModeEvents {
         double maxDistance = ConfigManager.getConfig().getSpectatorHeadRestrictRadius();
 
         if (distanceSq > (maxDistance * maxDistance)) {
+            // Port of Paper's onPlayerMove teleport feedback (sound + particles).
+            // Origin: paper/GhostModeEvents.java#onPlayerMove
             player.teleportTo(player.serverLevel(), deathPos.getX() + 0.5, deathPos.getY(), deathPos.getZ() + 0.5, player.getYRot(), player.getXRot());
+            player.serverLevel().playSound(null, deathPos, SoundEvents.CHORUS_FRUIT_TELEPORT, SoundSource.PLAYERS, 1.0f, 1.0f);
+            if (ConfigManager.getConfig().isGhostModeParticles()) {
+                player.serverLevel().sendParticles(ParticleTypes.DRAGON_BREATH,
+                        deathPos.getX() + 0.5, deathPos.getY(), deathPos.getZ() + 0.5,
+                        50, 0.0, 1.0, 0.0, 0.2);
+            }
             player.sendSystemMessage(Component.literal("You may not travel that far away from your death location").withStyle(net.minecraft.ChatFormatting.GRAY));
         }
     }

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
@@ -132,14 +132,14 @@ public class GhostModeEvents {
         if (distanceSq > (maxDistance * maxDistance)) {
             // Port of Paper's onPlayerMove teleport feedback (sound + particles).
             // Origin: paper/GhostModeEvents.java#onPlayerMove
-            player.teleportTo(player.serverLevel(), deathPos.getX() + 0.5, deathPos.getY(), deathPos.getZ() + 0.5, player.getYRot(), player.getXRot());
-            player.serverLevel().playSound(null, deathPos, SoundEvents.CHORUS_FRUIT_TELEPORT, SoundSource.PLAYERS, 1.0f, 1.0f);
+            player.teleportTo(player.serverLevel(), deathPos.getX() + 0.5, deathPos.getY() + 0.5, deathPos.getZ() + 0.5, player.getYRot(), player.getXRot());
+            player.playSound(SoundEvents.CHORUS_FRUIT_TELEPORT, SoundSource.PLAYERS, 1.0f, 1.0f);
             if (ConfigManager.getConfig().isGhostModeParticles()) {
                 player.serverLevel().sendParticles(ParticleTypes.DRAGON_BREATH,
-                        deathPos.getX() + 0.5, deathPos.getY(), deathPos.getZ() + 0.5,
+                        deathPos.getX() + 0.5, deathPos.getY() + 0.5, deathPos.getZ() + 0.5,
                         50, 0.0, 1.0, 0.0, 0.2);
             }
-            player.sendSystemMessage(Component.literal("You may not travel that far away from your death location").withStyle(net.minecraft.ChatFormatting.GRAY));
+            player.displayClientMessage(Component.literal("You may not travel that far away from your death location").withStyle(net.minecraft.ChatFormatting.GRAY), true);
         }
     }
 

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
@@ -138,10 +138,12 @@ public class GhostModeEvents {
     private static void applyTeleportFeedback(ServerPlayer player, BlockPos deathPos) {
         // Port of Paper's onPlayerMove teleport feedback (sound + particles).
         player.teleportTo(player.serverLevel(), deathPos.getX() + 0.5, deathPos.getY(), deathPos.getZ() + 0.5, player.getYRot(), player.getXRot());
-        player.serverLevel().playSound(null, deathPos, SoundEvents.CHORUS_FRUIT_TELEPORT, SoundSource.PLAYERS, 1.0f, 1.0f);
+        
+        // Scope sound and particles to the ghost only to prevent location leaking
+        player.playNotifySound(SoundEvents.CHORUS_FRUIT_TELEPORT, SoundSource.PLAYERS, 1.0f, 1.0f);
         
         if (ConfigManager.getConfig().isGhostModeParticles()) {
-            player.serverLevel().sendParticles(ParticleTypes.DRAGON_BREATH,
+            player.serverLevel().sendParticles(player, ParticleTypes.DRAGON_BREATH, true,
                     deathPos.getX() + 0.5, deathPos.getY(), deathPos.getZ() + 0.5,
                     50, 0.0, 1.0, 0.0, 0.2);
         }

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
@@ -16,6 +16,7 @@ import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.bus.api.SubscribeEvent;
 import org.ssoggy.ssoggysouls.database.DatabaseManager;
 import org.ssoggy.ssoggysouls.hrm.dlc.util.GhostState;
+import org.ssoggy.ssoggysouls.hrm.dlc.shared.GhostRestrictionLogic;
 import org.ssoggy.ssoggysouls.model.PlayerData;
 import org.ssoggy.ssoggysouls.util.ConfigManager;
 
@@ -126,21 +127,27 @@ public class GhostModeEvents {
         }
 
         BlockPos currentPos = player.blockPosition();
-        double distanceSq = currentPos.distSqr(deathPos);
         double maxDistance = ConfigManager.getConfig().getSpectatorHeadRestrictRadius();
 
-        if (distanceSq > (maxDistance * maxDistance)) {
-            // Port of Paper's onPlayerMove teleport feedback (sound + particles).
-            // Origin: paper/GhostModeEvents.java#onPlayerMove
-            player.teleportTo(player.serverLevel(), deathPos.getX() + 0.5, deathPos.getY() + 0.5, deathPos.getZ() + 0.5, player.getYRot(), player.getXRot());
-            player.playSound(SoundEvents.CHORUS_FRUIT_TELEPORT, SoundSource.PLAYERS, 1.0f, 1.0f);
-            if (ConfigManager.getConfig().isGhostModeParticles()) {
-                player.serverLevel().sendParticles(ParticleTypes.DRAGON_BREATH,
-                        deathPos.getX() + 0.5, deathPos.getY() + 0.5, deathPos.getZ() + 0.5,
-                        50, 0.0, 1.0, 0.0, 0.2);
-            }
-            player.displayClientMessage(Component.literal("You may not travel that far away from your death location").withStyle(net.minecraft.ChatFormatting.GRAY), true);
+        if (GhostRestrictionLogic.isOutOfBounds(deathPos.getX(), deathPos.getY(), deathPos.getZ(),
+                currentPos.getX(), currentPos.getY(), currentPos.getZ(), maxDistance)) {
+            applyTeleportFeedback(player, deathPos);
         }
+    }
+
+    private static void applyTeleportFeedback(ServerPlayer player, BlockPos deathPos) {
+        // Port of Paper's onPlayerMove teleport feedback (sound + particles).
+        player.teleportTo(player.serverLevel(), deathPos.getX() + 0.5, deathPos.getY(), deathPos.getZ() + 0.5, player.getYRot(), player.getXRot());
+        player.serverLevel().playSound(null, deathPos, SoundEvents.CHORUS_FRUIT_TELEPORT, SoundSource.PLAYERS, 1.0f, 1.0f);
+        
+        if (ConfigManager.getConfig().isGhostModeParticles()) {
+            player.serverLevel().sendParticles(ParticleTypes.DRAGON_BREATH,
+                    deathPos.getX() + 0.5, deathPos.getY(), deathPos.getZ() + 0.5,
+                    50, 0.0, 1.0, 0.0, 0.2);
+        }
+        
+        player.sendSystemMessage(Component.literal(GhostRestrictionLogic.RESTRICTION_MESSAGE)
+                .withStyle(net.minecraft.ChatFormatting.GRAY));
     }
 
     public static void updateGhostStatus(UUID uuid, boolean isDead) {

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
@@ -117,7 +117,7 @@ public class GhostModeEvents implements Listener {
             player.teleportAsync(deadLocation); // Note: radius could gradually increase over time in a future iteration
 
             if (Boolean.TRUE.equals(RPStatic.CONFIG_RULES.getOrDefault("ghost-mode-particles", false))) {
-                player.getWorld().spawnParticle(org.bukkit.Particle.DRAGON_BREATH, deadLocation, 50, 0, 1, 0, 0.2);
+                player.spawnParticle(org.bukkit.Particle.DRAGON_BREATH, deadLocation, 50, 0, 1, 0, 0.2);
             }
             
             player.playSound(player, Sound.ITEM_CHORUS_FRUIT_TELEPORT, 1, 0);


### PR DESCRIPTION
💡 **What:** The immersive teleport feedback (CHORUS_FRUIT_TELEPORT sound and DRAGON_BREATH particles) that occurs when a ghost travels too far from their death location was previously exclusive to Paper.

🔗 **Origin:** [paper/GhostModeEvents.java#onPlayerMove](https://github.com/SSoggy-Group/SSoggySouls-for-Hardcore/blob/main/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java#L114-129)

🛠️ **Translation:** Adapted the movement listener logic into the server-side tick handlers of the other loaders. Verified usage of the `ghost-mode-particles` configuration flag across all platforms.

🔬 **Verification:** Verified via `./gradlew :fabric:compileJava` and `./gradlew :neoforge:compileJava`.