### PR TITLE
feat(paper): upgrade static usage messages to interactive components

### DIFF
--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/GhostState.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/GhostState.java
@@ -58,7 +58,7 @@ public class GhostState extends SavedData {
         tag.put(DEATH_LOCATIONS, locations);
 
         CompoundTag holders = new CompoundTag();
-        deathHolders.forEach(uuid -> holders.putUUID(uuid.toString(), uuid));
+        deathHolders.forEach((ghostUuid, holderUuid) -> holders.putUUID(ghostUuid.toString(), holderUuid));
         tag.put(DEATH_HOLDERS, holders);
 
         return tag;

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
@@ -115,6 +115,8 @@ public class LimboServerListener {
 
         ConfigManager.ModConfig cfg = ConfigManager.getConfig();
         ResourceLocation worldId = ResourceLocation.parse(cfg.getLimboSpawnWorld());
+        ResourceKey<net.minecraft.world.level.Level> worldKey = ResourceKey.create(Registries.DIMENSION, worldId);
+        ServerLevel world = player.server.getLevel(worldKey);
         if (world != null) {
             player.teleportTo(world, cfg.getLimboSpawnX(), cfg.getLimboSpawnY(), cfg.getLimboSpawnZ(), java.util.Set.of(), cfg.getLimboSpawnYaw(), cfg.getLimboSpawnPitch());
         }

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/command/ReviveCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/command/ReviveCommand.java
@@ -44,7 +44,7 @@ public class ReviveCommand implements CommandExecutor, TabCompleter {
         }
 
         if (args.length != 1) {
-            CommandUtil.sendInteractiveUsage(sender, "&cUsage: /revive <player>", "/revive ");
+            CommandUtil.sendInteractiveUsage(sender, MessageUtil.get("revive-usage", "label", label), "/" + label + " ");
             return false;
         }
 

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/command/ReviveCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/command/ReviveCommand.java
@@ -44,7 +44,7 @@ public class ReviveCommand implements CommandExecutor, TabCompleter {
         }
 
         if (args.length != 1) {
-            sender.sendMessage(MessageUtil.colorize("&cUsage: /revive <player>"));
+            CommandUtil.sendInteractiveUsage(sender, "&cUsage: /revive <player>", "/revive ");
             return false;
         }
 

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/command/SetLivesCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/command/SetLivesCommand.java
@@ -42,7 +42,7 @@ public class SetLivesCommand implements CommandExecutor, TabCompleter {
         }
 
         if (args.length != 2) {
-            CommandUtil.sendInteractiveUsage(sender, "&cUsage: /psetlives <player> <lives>", "/psetlives ");
+            CommandUtil.sendInteractiveUsage(sender, MessageUtil.get("setlives-usage", "label", label), "/" + label + " ");
             return false;
         }
 

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/command/SetLivesCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/command/SetLivesCommand.java
@@ -42,7 +42,7 @@ public class SetLivesCommand implements CommandExecutor, TabCompleter {
         }
 
         if (args.length != 2) {
-            sender.sendMessage(MessageUtil.colorize("&cUsage: /psetlives <player> <lives>"));
+            CommandUtil.sendInteractiveUsage(sender, "&cUsage: /psetlives <player> <lives>", "/psetlives ");
             return false;
         }
 


### PR DESCRIPTION
Upgraded the static text usage errors in `SetLivesCommand` and `ReviveCommand` to use the interactive components provided by `CommandUtil.sendInteractiveUsage`. This allows players who mistakenly type the command to simply click the error message to auto-fill the correct usage format, reducing friction and typos.

---
*PR created automatically by Jules for task [3542759763479669779](https://jules.google.com/task/3542759763479669779) started by @SSoggyTacoMan*