### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS vulnerability in network packet decoding

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,11 @@
 **Vulnerability:** `ServerTransferUtil.java` (across Fabric, Forge, and NeoForge) decoded network packets by allocating a byte array exactly the size of `buf.readableBytes()` without bounds checking. A malicious client could send an oversized payload, causing excessive memory allocation and leading to an OutOfMemoryError (Denial of Service).
 **Learning:** Even when reading from simple custom network packets (like BungeeCord sub-channels), trusting the network buffer's stated readable bytes size for memory allocation is dangerous.
 **Prevention:** Always validate `buf.readableBytes()` against a sensible strict limit (e.g., 1024 bytes) and throw an exception (`IOException` or `IllegalArgumentException`) before instantiating byte arrays or reading the payload.
+## 2026-05-06 - [Fix OutOfMemoryError reading admin log]
+**Vulnerability:** `Files.readAllLines()` was used to read the admin log file, which can grow arbitrarily large and cause an OOM error.
+**Learning:** Admin log files should always be read using a streaming approach if only the most recent N lines are needed.
+**Prevention:** Use a `Stream` via `Files.lines()` combined with a `Deque` to store only the last N lines.
+## 2024-05-07 - [Prevent potential SQL Injection in schema generation]
+**Vulnerability:** In database managers (`MySQLManager`, `SQLiteManager`), dynamic DDL methods like `createMetadataTableIfNeeded` directly concatenated string arguments (`metaTable`) into `CREATE TABLE` commands. Even though the table name was internally hardcoded, lack of validation poses an SQL injection risk if the method's signature or usage expands.
+**Learning:** Defensive programming requires validating all dynamic identifiers used in non-parameterizable SQL statements (DDL).
+**Prevention:** Apply the existing `isValidIdentifier` (whitelisting regex `^\w+$`) check to table and column name parameters before they are concatenated into SQL queries.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,8 +1,4 @@
-## 2026-05-06 - [Fix OutOfMemoryError reading admin log]
-**Vulnerability:** `Files.readAllLines()` was used to read the admin log file, which can grow arbitrarily large and cause an OOM error.
-**Learning:** Admin log files should always be read using a streaming approach if only the most recent N lines are needed.
-**Prevention:** Use a `Stream` via `Files.lines()` combined with a `Deque` to store only the last N lines.
-## 2024-05-07 - [Prevent potential SQL Injection in schema generation]
-**Vulnerability:** In database managers (`MySQLManager`, `SQLiteManager`), dynamic DDL methods like `createMetadataTableIfNeeded` directly concatenated string arguments (`metaTable`) into `CREATE TABLE` commands. Even though the table name was internally hardcoded, lack of validation poses an SQL injection risk if the method's signature or usage expands.
-**Learning:** Defensive programming requires validating all dynamic identifiers used in non-parameterizable SQL statements (DDL).
-**Prevention:** Apply the existing `isValidIdentifier` (whitelisting regex `^\w+$`) check to table and column name parameters before they are concatenated into SQL queries.
+## 2025-05-13 - [HIGH] Fix DoS vulnerability in network packet decoding
+**Vulnerability:** `ServerTransferUtil.java` (across Fabric, Forge, and NeoForge) decoded network packets by allocating a byte array exactly the size of `buf.readableBytes()` without bounds checking. A malicious client could send an oversized payload, causing excessive memory allocation and leading to an OutOfMemoryError (Denial of Service).
+**Learning:** Even when reading from simple custom network packets (like BungeeCord sub-channels), trusting the network buffer's stated readable bytes size for memory allocation is dangerous.
+**Prevention:** Always validate `buf.readableBytes()` against a sensible strict limit (e.g., 1024 bytes) and throw an exception (`IOException` or `IllegalArgumentException`) before instantiating byte arrays or reading the payload.

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/util/ServerTransferUtil.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/util/ServerTransferUtil.java
@@ -44,7 +44,11 @@ public class ServerTransferUtil {
                 },
                 buf -> {
                     try {
-                        byte[] bytes = new byte[buf.readableBytes()];
+                        int readable = buf.readableBytes();
+                        if (readable > 1024) {
+                            throw new java.io.IOException("Payload too large: " + readable + " bytes (max 1024)");
+                        }
+                        byte[] bytes = new byte[readable];
                         buf.readBytes(bytes);
                         java.io.DataInputStream dis = new java.io.DataInputStream(
                                 new java.io.ByteArrayInputStream(bytes));

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/util/ServerTransferUtil.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/util/ServerTransferUtil.java
@@ -66,7 +66,11 @@ public class ServerTransferUtil {
                 },
                 buf -> {
                     try {
-                        byte[] bytes = new byte[buf.readableBytes()];
+                        int readable = buf.readableBytes();
+                        if (readable > 1024) {
+                            throw new IOException("Payload too large: " + readable + " bytes (max 1024)");
+                        }
+                        byte[] bytes = new byte[readable];
                         buf.readBytes(bytes);
                         DataInputStream dis = new DataInputStream(new ByteArrayInputStream(bytes));
                         dis.readUTF(); // Skip sub-channel name ("Connect")

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/util/ServerTransferUtil.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/util/ServerTransferUtil.java
@@ -52,7 +52,11 @@ public class ServerTransferUtil {
                 },
                 buf -> {
                     try {
-                        byte[] bytes = new byte[buf.readableBytes()];
+                        int readable = buf.readableBytes();
+                        if (readable > 1024) {
+                            throw new IOException("Payload too large: " + readable + " bytes (max 1024)");
+                        }
+                        byte[] bytes = new byte[readable];
                         buf.readBytes(bytes);
                         DataInputStream dis = new DataInputStream(new ByteArrayInputStream(bytes));
                         dis.readUTF(); // Skip sub-channel name ("Connect")


### PR DESCRIPTION
This pull request introduces a security enhancement by preventing an unhandled OutOfMemoryError vulnerability. Previously, custom network packets in `ServerTransferUtil` allocated a byte array directly based on `buf.readableBytes()` without bounds checking. A malicious actor could have sent an oversized payload, causing the server to allocate massive amounts of memory and crash.

Changes:
- Added a 1024 byte limit to `buf.readableBytes()` in `fabric/src/main/java/org/ssoggy/ssoggysouls/util/ServerTransferUtil.java`.
- Added a 1024 byte limit to `buf.readableBytes()` in `forge/src/main/java/org/ssoggy/ssoggysouls/util/ServerTransferUtil.java`.
- Added a 1024 byte limit to `buf.readableBytes()` in `neoforge/src/main/java/org/ssoggy/ssoggysouls/util/ServerTransferUtil.java`.
- Update `.jules/sentinel.md` with relevant vulnerability and prevention learnings.

---
*PR created automatically by Jules for task [1782628139139046514](https://jules.google.com/task/1782628139139046514) started by @SSoggyTacoMan*