### PR TITLE
🧹 [code health] Remove unused InteractionHand import in forge/RevivalStructureListener

### DIFF
--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java
@@ -9,7 +9,6 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
-import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;


### PR DESCRIPTION
🎯 **What:** Removed unused import `net.minecraft.world.InteractionHand` from `forge/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java`.
💡 **Why:** To clean up the code and improve code maintainability by eliminating an unnecessary import.
✅ **Verification:** Verified that the code no longer references this unused import. Ignored pre-existing failing test unrelated to my change based on prompt. 
✨ **Result:** A cleaner codebase with no unused imports in the target file.

---
*PR created automatically by Jules for task [11333390487416842308](https://jules.google.com/task/11333390487416842308) started by @SSoggyTacoMan*