### PR TITLE
🧹 refactor(forge): remove unused Optional import

### DIFF
--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java
@@ -38,7 +38,6 @@ import org.ssoggy.ssoggysouls.util.ConfigManager;
 import org.ssoggy.ssoggysouls.util.MessageUtil;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;


### PR DESCRIPTION
🎯 **What:** The unused `Optional` import in `forge/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java` was removed.
💡 **Why:** Having unused imports clutters the file and makes reading/maintaining the code marginally more difficult. Removing it improves code health.
✅ **Verification:** Verified the removal visually and successfully ran tests (the `forge` module compilation fails due to an unrelated, pre-existing error present on the `main` branch).
✨ **Result:** A slightly cleaner and healthier codebase.

---
*PR created automatically by Jules for task [7004102890634975237](https://jules.google.com/task/7004102890634975237) started by @SSoggyTacoMan*