### PR TITLE
feat(paper): make command usage errors interactive

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,6 @@
 **Learning:** Admin help menus in legacy command systems (like Bukkit/Paper) are often static text, forcing users to manually type complex subcommands.
 **Action:** Upgrade static text help menus to use Rich Components with `ClickEvent.suggestCommand()` and `HoverEvent.showText()` to reduce friction and typos for command-line users.
 ## 2026-05-10 - [Interactive CLI Usage Error Catching]\n**Learning:** Implementing interactive components (like clickable auto-fill suggestions) on error handling messages transforms static frustration points into helpful recovery paths.\n**Action:** Use `CommandUtil.sendInteractiveUsage()` when catching command formatting errors in Bukkit to allow users to quickly fix their typos with a single click.
+## 2026-05-15 - [Interactive CLI Error Messages]
+**Learning:** When users mistype a command (like missing an argument in /revive), the default static error message forces them to re-type the whole thing. By using Kyori Adventure Rich Components (via CommandUtil.sendInteractiveUsage) for the usage error message, they can just click the error text to auto-fill the command in their chat bar.
+**Action:** Update static command error messages to use sendInteractiveUsage so that mistakes are easily correctable.

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/command/ReviveCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/command/ReviveCommand.java
@@ -44,7 +44,7 @@ public class ReviveCommand implements CommandExecutor, TabCompleter {
         }
 
         if (args.length != 1) {
-            CommandUtil.sendInteractiveUsage(sender, "&cUsage: /revive <player>", "/revive ");
+            CommandUtil.sendInteractiveUsage(sender, MessageUtil.get("revive-usage"), "/revive ");
             return false;
         }
 

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/command/ReviveCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/command/ReviveCommand.java
@@ -44,7 +44,7 @@ public class ReviveCommand implements CommandExecutor, TabCompleter {
         }
 
         if (args.length != 1) {
-            sender.sendMessage(MessageUtil.colorize("&cUsage: /revive <player>"));
+            CommandUtil.sendInteractiveUsage(sender, "&cUsage: /revive <player>", "/revive ");
             return false;
         }
 

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/command/SetLivesCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/command/SetLivesCommand.java
@@ -42,7 +42,7 @@ public class SetLivesCommand implements CommandExecutor, TabCompleter {
         }
 
         if (args.length != 2) {
-            sender.sendMessage(MessageUtil.colorize("&cUsage: /psetlives <player> <lives>"));
+            CommandUtil.sendInteractiveUsage(sender, "&cUsage: /psetlives <player> <lives>", "/psetlives ");
             return false;
         }
 

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/command/SetLivesCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/command/SetLivesCommand.java
@@ -42,7 +42,7 @@ public class SetLivesCommand implements CommandExecutor, TabCompleter {
         }
 
         if (args.length != 2) {
-            CommandUtil.sendInteractiveUsage(sender, "&cUsage: /psetlives <player> <lives>", "/psetlives ");
+            CommandUtil.sendInteractiveUsage(sender, MessageUtil.get("setlives-usage"), "/psetlives ");
             return false;
         }
 


### PR DESCRIPTION
Added a small UX enhancement by making the usage error messages in `/psetlives` and `/revive` commands interactive. When a user forgets an argument, the usage message can now be clicked to auto-fill the command in their chat, saving them from retyping the whole prefix.

---
*PR created automatically by Jules for task [14856315390089681273](https://jules.google.com/task/14856315390089681273) started by @SSoggyTacoMan*