### PR TITLE
🎨 Palette: Interactive CLI Number Parsing Errors

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -11,3 +11,6 @@
 ## 2026-05-15 - [Interactive CLI Error Messages]
 **Learning:** When users mistype a command (like missing an argument in /revive), the default static error message forces them to re-type the whole thing. By using Kyori Adventure Rich Components (via CommandUtil.sendInteractiveUsage) for the usage error message, they can just click the error text to auto-fill the command in their chat bar.
 **Action:** Update static command error messages to use sendInteractiveUsage so that mistakes are easily correctable.
+## 2026-05-15 - [Interactive CLI Number Parsing Errors]
+**Learning:** Number parsing errors (e.g., NumberFormatException) in legacy command systems often default to static "Invalid number" messages. By refactoring methods like `parseIntOrError` to accept a base `suggestCmd`, these static errors can be upgraded to use `CommandUtil.sendInteractiveUsage`, allowing users to quickly correct invalid numeric inputs via a clickable chat component.
+**Action:** Always provide the base command context when catching input format errors to build actionable auto-fill error suggestions.

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminCommand.java
@@ -142,7 +142,7 @@ public class AdminCommand implements CommandExecutor, TabCompleter {
 
         String action = args[1].toLowerCase();
         String targetName = args[2];
-        int amount = parseIntOrError(sender, args[3]);
+        int amount = parseIntOrError(sender, args[3], "/psadmin lives " + action + " " + targetName + " ");
         if (amount < 0) return;
 
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () ->
@@ -489,7 +489,7 @@ public class AdminCommand implements CommandExecutor, TabCompleter {
 
         String targetName = args[1];
         int livesToRestore = args.length >= 3
-                ? parseIntOrError(sender, args[2])
+                ? parseIntOrError(sender, args[2], "/psadmin revive " + targetName + " ")
                 : plugin.getLivesOnRevive();
         if (livesToRestore < 0) return;
 
@@ -661,11 +661,11 @@ public class AdminCommand implements CommandExecutor, TabCompleter {
         }
     }
 
-    private static int parseIntOrError(CommandSender sender, String text) {
+    private static int parseIntOrError(CommandSender sender, String text, String suggestCmd) {
         try {
             return Integer.parseInt(text);
         } catch (NumberFormatException e) {
-            sender.sendMessage(MessageUtil.colorize(ERR_NUMBER + text));
+            org.ssoggy.ssoggysouls.util.CommandUtil.sendInteractiveUsage(sender, ERR_NUMBER + text, suggestCmd);
             return -1;
         }
     }

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminCommand.java
@@ -665,7 +665,7 @@ public class AdminCommand implements CommandExecutor, TabCompleter {
         try {
             return Integer.parseInt(text);
         } catch (NumberFormatException e) {
-            org.ssoggy.ssoggysouls.util.CommandUtil.sendInteractiveUsage(sender, ERR_NUMBER + text, suggestCmd);
+            CommandUtil.sendInteractiveUsage(sender, ERR_NUMBER + text, suggestCmd);
             return -1;
         }
     }

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminLogCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminLogCommand.java
@@ -70,7 +70,7 @@ public class AdminLogCommand implements CommandExecutor {
             }
             return count;
         } catch (NumberFormatException e) {
-            sender.sendMessage(MessageUtil.colorize("&cInvalid number: " + args[0]));
+            org.ssoggy.ssoggysouls.util.CommandUtil.sendInteractiveUsage(sender, "&cInvalid number: " + args[0], "/adminlog ");
             return -1;
         }
     }

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/command/SetLivesCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/command/SetLivesCommand.java
@@ -52,7 +52,7 @@ public class SetLivesCommand implements CommandExecutor, TabCompleter {
         try {
             lives = Integer.parseInt(args[1]);
         } catch (NumberFormatException e) {
-            sender.sendMessage(MessageUtil.colorize("&cInvalid number: " + args[1]));
+            CommandUtil.sendInteractiveUsage(sender, "&cInvalid number: " + args[1], "/psetlives " + targetName + " ");
             return false;
         }
 


### PR DESCRIPTION
This PR upgrades several static command error messages (specifically `NumberFormatException` invalid inputs) in the Bukkit/Paper implementation to use Kyori Adventure Rich Components. By routing these errors through `CommandUtil.sendInteractiveUsage()`, users are provided with a clickable chat element that auto-fills the base command, significantly reducing friction when correcting typos.

---
*PR created automatically by Jules for task [14756637935662832367](https://jules.google.com/task/14756637935662832367) started by @SSoggyTacoMan*