### PR TITLE
🧹 [refactor(forge): remove unused DatabaseManager import]

### DIFF
--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/HeadDropListener.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/HeadDropListener.java
@@ -13,7 +13,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.SkullBlockEntity;
 import org.ssoggy.ssoggysouls.SSoggySoulsMod;
-import org.ssoggy.ssoggysouls.database.DatabaseManager;
 import org.ssoggy.ssoggysouls.util.ConfigManager;
 
 public class HeadDropListener {


### PR DESCRIPTION
🎯 **What:** Removed the unused `DatabaseManager` import from `HeadDropListener.java` in the Forge module.
💡 **Why:** A regex check indicated that `DatabaseManager` was imported but not utilized in `HeadDropListener`, adding unnecessary bloat. Removing unused imports helps maintain a cleaner, more readable codebase and adheres to standard code health practices without impacting functionality.
✅ **Verification:** Verified by checking the file contents post-removal and ensuring there were no compilation errors by running `./gradlew :forge:build`.
✨ **Result:** The codebase is slightly cleaner and more maintainable with fewer unnecessary dependencies in the Forge module.

---
*PR created automatically by Jules for task [16002646731912442089](https://jules.google.com/task/16002646731912442089) started by @SSoggyTacoMan*