### PR TITLE
🧪 chore(common): improve test coverage for MySQL savePlayer

### DIFF
--- a/common/src/test/java/org/ssoggy/ssoggysouls/database/MySQLManagerTest.java
+++ b/common/src/test/java/org/ssoggy/ssoggysouls/database/MySQLManagerTest.java
@@ -141,6 +141,12 @@ class MySQLManagerTest {
         verify(preparedStatement).setLong(6, 2000L);
         verify(preparedStatement).setLong(7, 3000L);
         verify(preparedStatement).setLong(8, 4000L);
+        verify(preparedStatement).setString(9, TEST_USER);
+        verify(preparedStatement).setInt(10, 3);
+        verify(preparedStatement).setBoolean(11, false);
+        verify(preparedStatement).setLong(12, 2000L);
+        verify(preparedStatement).setLong(13, 3000L);
+        verify(preparedStatement).setLong(14, 4000L);
         verify(preparedStatement).executeUpdate();
     }
 

--- a/common/src/test/java/org/ssoggy/ssoggysouls/database/MySQLManagerTest.java
+++ b/common/src/test/java/org/ssoggy/ssoggysouls/database/MySQLManagerTest.java
@@ -141,12 +141,12 @@ class MySQLManagerTest {
         verify(preparedStatement).setLong(6, 2000L);
         verify(preparedStatement).setLong(7, 3000L);
         verify(preparedStatement).setLong(8, 4000L);
-        verify(preparedStatement).setString(9, TEST_USER);
-        verify(preparedStatement).setInt(10, 3);
-        verify(preparedStatement).setBoolean(11, false);
-        verify(preparedStatement).setLong(12, 2000L);
-        verify(preparedStatement).setLong(13, 3000L);
-        verify(preparedStatement).setLong(14, 4000L);
+        verify(preparedStatement).setString(9, data.getUsername());
+        verify(preparedStatement).setInt(10, data.getLives());
+        verify(preparedStatement).setBoolean(11, data.isDead());
+        verify(preparedStatement).setLong(12, data.getLastDeath());
+        verify(preparedStatement).setLong(13, data.getLastSeen());
+        verify(preparedStatement).setLong(14, data.getGraceUntil());
         verify(preparedStatement).executeUpdate();
     }
 


### PR DESCRIPTION
🎯 **What:** The `savePlayer` method in `MySQLManager` executes an `INSERT ... ON DUPLICATE KEY UPDATE` statement with 14 parameters, but the test `testSavePlayer` only verified the first 8 parameters (the `INSERT` portion).
📊 **Coverage:** The test now verifies that all 14 parameters (including those for the `ON DUPLICATE KEY UPDATE` clause) are correctly populated from the `PlayerData` object.
✨ **Result:** Improved test coverage and reliability for this critical database path, ensuring future modifications don't break the upsert logic.

---
*PR created automatically by Jules for task [7810291480339380265](https://jules.google.com/task/7810291480339380265) started by @SSoggyTacoMan*