### PR TITLE
🧹 [code health improvement] Remove unused import in LimboCheckTaskTest

### DIFF
--- a/paper/src/test/java/org/ssoggy/ssoggysouls/task/LimboCheckTaskTest.java
+++ b/paper/src/test/java/org/ssoggy/ssoggysouls/task/LimboCheckTaskTest.java
@@ -1,7 +1,6 @@
 package org.ssoggy.ssoggysouls.task;
 
 import org.bukkit.Bukkit;
-import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitScheduler;
 import org.junit.jupiter.api.AfterEach;


### PR DESCRIPTION
🎯 **What:** The unused `org.bukkit.GameMode` import was removed from `paper/src/test/java/org/ssoggy/ssoggysouls/task/LimboCheckTaskTest.java`.
💡 **Why:** Having unused imports clutters the code and triggers code health warnings (like SonarCloud). Removing it improves readability and maintainability.
✅ **Verification:** I ran the test suite (`./gradlew :paper:test`) to confirm that everything still compiles and tests pass successfully.
✨ **Result:** A cleaner test class with no unused imports.

---
*PR created automatically by Jules for task [7243099027892170770](https://jules.google.com/task/7243099027892170770) started by @SSoggyTacoMan*