### PR TITLE
🧪 Add tests for DatabaseInitializationException

### DIFF
--- a/common/src/test/java/org/ssoggy/ssoggysouls/database/DatabaseInitializationExceptionTest.java
+++ b/common/src/test/java/org/ssoggy/ssoggysouls/database/DatabaseInitializationExceptionTest.java
@@ -1,0 +1,26 @@
+package org.ssoggy.ssoggysouls.database;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class DatabaseInitializationExceptionTest {
+
+    @Test
+    void testConstructorWithMessage() {
+        String expectedMessage = "Database connection failed";
+        DatabaseInitializationException exception = new DatabaseInitializationException(expectedMessage);
+
+        assertEquals(expectedMessage, exception.getMessage());
+        assertNull(exception.getCause());
+    }
+
+    @Test
+    void testConstructorWithMessageAndCause() {
+        String expectedMessage = "Database connection failed";
+        Throwable expectedCause = new RuntimeException("Underlying failure");
+        DatabaseInitializationException exception = new DatabaseInitializationException(expectedMessage, expectedCause);
+
+        assertEquals(expectedMessage, exception.getMessage());
+        assertEquals(expectedCause, exception.getCause());
+    }
+}


### PR DESCRIPTION
🎯 **What:** Adds missing error path unit tests for `DatabaseInitializationException` constructors.
📊 **Coverage:** Specifically tests both `DatabaseInitializationException(String)` and `DatabaseInitializationException(String, Throwable)` to verify the message and cause are correctly propagated to the exception superclass.
✨ **Result:** Enhanced test coverage ensures robust exception state retention, catching regressions before runtime initialization failures.

---
*PR created automatically by Jules for task [18167874798888518642](https://jules.google.com/task/18167874798888518642) started by @SSoggyTacoMan*