### PR TITLE
🧹 refactor(forge): remove unused PlayerData import

### DIFF
--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java
@@ -33,7 +33,6 @@ import org.ssoggy.ssoggysouls.hrm.dlc.shared.DlcStat;
 import org.ssoggy.ssoggysouls.hrm.dlc.shared.DlcStats;
 import org.ssoggy.ssoggysouls.hrm.dlc.util.GhostState;
 import org.ssoggy.ssoggysouls.listener.ServerLifecycleListener;
-import org.ssoggy.ssoggysouls.model.PlayerData;
 import org.ssoggy.ssoggysouls.util.ConfigManager;
 import org.ssoggy.ssoggysouls.util.MessageUtil;
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `PlayerData` import from `forge/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java`.
💡 **Why:** To improve code health and maintainability by removing dead code, as flagged by the code health agent.
✅ **Verification:** Compiled the `forge` project with `./gradlew :forge:compileJava` to ensure no build errors were introduced.
✨ **Result:** Cleaned up code file without changing any behavior.

---
*PR created automatically by Jules for task [12673390638799472717](https://jules.google.com/task/12673390638799472717) started by @SSoggyTacoMan*