### PR TITLE
🧹 [refactor(neoforge)] Remove unused InteractionHand import

### DIFF
--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java
@@ -9,7 +9,6 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
-import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;


### PR DESCRIPTION
🎯 **What:** The unused `net.minecraft.world.InteractionHand` import was removed from `neoforge/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java`.
💡 **Why:** This improves the maintainability and cleanliness of the code by removing unnecessary dependencies and satisfying static analysis tools.
✅ **Verification:** I successfully compiled the `neoforge` module and ran the tests. The `InteractionHand` usage was verified to only be in the import statement via `grep`.
✨ **Result:** A cleaner class with no dead imports, ensuring better code health.

---
*PR created automatically by Jules for task [9614127291029627502](https://jules.google.com/task/9614127291029627502) started by @SSoggyTacoMan*