### PR TITLE
🧪 Add error path test for revivePlayer

### DIFF
--- a/common/src/test/java/org/ssoggy/ssoggysouls/database/MySQLManagerTest.java
+++ b/common/src/test/java/org/ssoggy/ssoggysouls/database/MySQLManagerTest.java
@@ -197,6 +197,17 @@ class MySQLManagerTest {
     }
 
     @Test
+    void testRevivePlayerSQLException() throws SQLException {
+        when(preparedStatement.executeUpdate()).thenThrow(new SQLException(MOCK_DB_ERROR));
+
+        boolean result = mySQLManager.revivePlayer(testUuid, 3);
+
+        assertFalse(result);
+        verify(preparedStatement).setInt(1, 3);
+        verify(preparedStatement).setString(2, testUuid.toString());
+    }
+
+    @Test
     void testGetPlayerByNameFound() throws SQLException {
         when(preparedStatement.executeQuery()).thenReturn(resultSet);
         when(resultSet.next()).thenReturn(true);


### PR DESCRIPTION
🎯 **What:** The testing gap in `revivePlayer` error handling has been addressed. The test `testRevivePlayerSQLException` checks if a SQLException during executeUpdate is handled safely.
📊 **Coverage:** Covered the `catch (SQLException e)` block in `AbstractDatabaseManager.revivePlayer`.
✨ **Result:** Enhanced test coverage and ensured database failure results in an expected `false` return value rather than a crash or unhandled exception.

---
*PR created automatically by Jules for task [1479183452629650885](https://jules.google.com/task/1479183452629650885) started by @SSoggyTacoMan*