### PR TITLE
🧹 [Code Health] Remove unused import IntegerArgumentType in DlcCommandRegistration

### DIFF
--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
@@ -1,7 +1,6 @@
 package org.ssoggy.ssoggysouls.hrm.dlc.command;
 
 import com.mojang.brigadier.CommandDispatcher;
-import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;


### PR DESCRIPTION
🎯 **What:** Removed unused import `IntegerArgumentType` from `DlcCommandRegistration.java`.
💡 **Why:** This improves the maintainability and readability of the file by ensuring no dead code or unnecessary dependencies exist.
✅ **Verification:** A test for the `forge` module was successful, ensuring no regressions.
✨ **Result:** A cleaner file conforming to code health standards.

---
*PR created automatically by Jules for task [16592095716280940403](https://jules.google.com/task/16592095716280940403) started by @SSoggyTacoMan*