### PR TITLE
🧹 refactor(forge): remove unused import

### DIFF
--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java
@@ -9,7 +9,6 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
-import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;


### PR DESCRIPTION
🎯 **What:** Removed the unused `InteractionHand` import in `RevivalStructureListener.java`.
💡 **Why:** This resolves a code health issue, keeping the import list clean and improving the maintainability and readability of the codebase.
✅ **Verification:** Verified by running compilation (`./gradlew :forge:compileJava`) and testing (`./gradlew :forge:test`) to ensure that removing the import had no adverse effects on the code.
✨ **Result:** The unused import has been successfully removed without affecting the functionality of the mod.

---
*PR created automatically by Jules for task [3393620762721418922](https://jules.google.com/task/3393620762721418922) started by @SSoggyTacoMan*