### PR TITLE
🧪 [Testing Improvement] Add tests for MySQLManager shutdown

### DIFF
--- a/common/src/test/java/org/ssoggy/ssoggysouls/database/MySQLManagerTest.java
+++ b/common/src/test/java/org/ssoggy/ssoggysouls/database/MySQLManagerTest.java
@@ -31,6 +31,7 @@ class MySQLManagerTest {
     private PreparedStatement preparedStatement;
     private ResultSet resultSet;
     private MySQLManager mySQLManager;
+    private PluginContext plugin;
     private final UUID testUuid = UUID.randomUUID();
 
     private static final String TEST_USER = "TestUser";
@@ -42,7 +43,7 @@ class MySQLManagerTest {
     @BeforeEach
     void setup() throws Exception {
         // Use Mockito only for our own interfaces (PluginContext)
-        PluginContext plugin = mock(PluginContext.class);
+        plugin = mock(PluginContext.class);
 
         // Use a real anonymous logger
         Logger logger = Logger.getAnonymousLogger();
@@ -381,5 +382,50 @@ class MySQLManagerTest {
         String version = mySQLManager.getPluginVersion("main");
 
         assertNull(version); // Graceful error handling: returns null
+    }
+
+    @Test
+    void testShutdownClosesDataSourceWhenOpen() throws Exception {
+        com.zaxxer.hikari.HikariDataSource hikariDataSource = mock(com.zaxxer.hikari.HikariDataSource.class);
+        when(hikariDataSource.isClosed()).thenReturn(false);
+
+        java.lang.reflect.Field field = MySQLManager.class.getDeclaredField("hikariDataSource");
+        field.setAccessible(true);
+        field.set(mySQLManager, hikariDataSource);
+
+        Logger mockLogger = mock(Logger.class);
+        when(plugin.getLogger()).thenReturn(mockLogger);
+
+        mySQLManager.shutdown();
+
+        verify(hikariDataSource).close();
+        verify(mockLogger).info("MySQL connection pool closed.");
+    }
+
+    @Test
+    void testShutdownDoesNotCloseDataSourceWhenAlreadyClosed() throws Exception {
+        com.zaxxer.hikari.HikariDataSource hikariDataSource = mock(com.zaxxer.hikari.HikariDataSource.class);
+        when(hikariDataSource.isClosed()).thenReturn(true);
+
+        java.lang.reflect.Field field = MySQLManager.class.getDeclaredField("hikariDataSource");
+        field.setAccessible(true);
+        field.set(mySQLManager, hikariDataSource);
+
+        Logger mockLogger = mock(Logger.class);
+        when(plugin.getLogger()).thenReturn(mockLogger);
+
+        mySQLManager.shutdown();
+
+        verify(hikariDataSource, never()).close();
+        verify(mockLogger, never()).info(anyString());
+    }
+
+    @Test
+    void testShutdownDoesNotThrowWhenDataSourceIsNull() throws Exception {
+        java.lang.reflect.Field field = MySQLManager.class.getDeclaredField("hikariDataSource");
+        field.setAccessible(true);
+        field.set(mySQLManager, null);
+
+        assertDoesNotThrow(() -> mySQLManager.shutdown());
     }
 }

--- a/common/src/test/java/org/ssoggy/ssoggysouls/database/MySQLManagerTest.java
+++ b/common/src/test/java/org/ssoggy/ssoggysouls/database/MySQLManagerTest.java
@@ -418,9 +418,7 @@ class MySQLManagerTest {
 
     @Test
     void testShutdownDoesNotThrowWhenDataSourceIsNull() throws Exception {
-        java.lang.reflect.Field field = MySQLManager.class.getDeclaredField("hikariDataSource");
-        field.setAccessible(true);
-        field.set(mySQLManager, null);
+        injectHikariDataSource(null);
 
         assertDoesNotThrow(() -> mySQLManager.shutdown());
     }

--- a/common/src/test/java/org/ssoggy/ssoggysouls/database/MySQLManagerTest.java
+++ b/common/src/test/java/org/ssoggy/ssoggysouls/database/MySQLManagerTest.java
@@ -389,9 +389,7 @@ class MySQLManagerTest {
         com.zaxxer.hikari.HikariDataSource hikariDataSource = mock(com.zaxxer.hikari.HikariDataSource.class);
         when(hikariDataSource.isClosed()).thenReturn(false);
 
-        java.lang.reflect.Field field = MySQLManager.class.getDeclaredField("hikariDataSource");
-        field.setAccessible(true);
-        field.set(mySQLManager, hikariDataSource);
+        injectHikariDataSource(hikariDataSource);
 
         Logger mockLogger = mock(Logger.class);
         when(plugin.getLogger()).thenReturn(mockLogger);

--- a/common/src/test/java/org/ssoggy/ssoggysouls/database/MySQLManagerTest.java
+++ b/common/src/test/java/org/ssoggy/ssoggysouls/database/MySQLManagerTest.java
@@ -405,9 +405,7 @@ class MySQLManagerTest {
         com.zaxxer.hikari.HikariDataSource hikariDataSource = mock(com.zaxxer.hikari.HikariDataSource.class);
         when(hikariDataSource.isClosed()).thenReturn(true);
 
-        java.lang.reflect.Field field = MySQLManager.class.getDeclaredField("hikariDataSource");
-        field.setAccessible(true);
-        field.set(mySQLManager, hikariDataSource);
+        injectHikariDataSource(hikariDataSource);
 
         Logger mockLogger = mock(Logger.class);
         when(plugin.getLogger()).thenReturn(mockLogger);


### PR DESCRIPTION
🎯 **What:** The `shutdown` method in `MySQLManager` was lacking test coverage. It is a straightforward cleanup method that checks the pool status and closes the Hikari data source.
📊 **Coverage:** Added test scenarios for an open data source (properly closed), an already closed data source (ignored), and a null data source (safely handled). Used reflection to inject a mocked `HikariDataSource` into the private field for the tests without actually initiating a real DB connection.
✨ **Result:** Test coverage for `MySQLManager` is now more comprehensive and includes its teardown functionality, improving reliability.

---
*PR created automatically by Jules for task [1592362129911755434](https://jules.google.com/task/1592362129911755434) started by @SSoggyTacoMan*