### PR TITLE
🧹 Remove unused Mod import in GhostBlockEvents

### DIFF
--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostBlockEvents.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostBlockEvents.java
@@ -17,7 +17,6 @@ import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.entity.player.EntityItemPickupEvent;
 import net.minecraftforge.event.level.BlockEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
 import org.ssoggy.ssoggysouls.SSoggySoulsMod;
 import org.ssoggy.ssoggysouls.database.DatabaseManager;
 import org.ssoggy.ssoggysouls.hrm.dlc.shared.DlcDeaths;


### PR DESCRIPTION
🎯 **What:** The unused `net.minecraftforge.fml.common.Mod` import was removed from `GhostBlockEvents.java`.
💡 **Why:** Having unused imports clutters the code and goes against code health and maintainability best practices. Removing it improves clarity.
✅ **Verification:** The project's full test suite was run (`./gradlew test`) and it passed successfully, confirming no functionality was broken. Code was also reviewed.
✨ **Result:** A cleaner file and resolved code health issue with no negative side effects.

---
*PR created automatically by Jules for task [1814245345518520431](https://jules.google.com/task/1814245345518520431) started by @SSoggyTacoMan*