### PR TITLE
🧹 refactor(forge): remove unused Mod import in GhostModeEvents

### DIFF
--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java
@@ -13,7 +13,6 @@ import net.minecraftforge.event.entity.player.AttackEntityEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
 import org.ssoggy.ssoggysouls.SSoggySoulsMod;
 import org.ssoggy.ssoggysouls.database.DatabaseManager;
 import org.ssoggy.ssoggysouls.hrm.dlc.util.GhostState;


### PR DESCRIPTION
🎯 **What:** Removed the unused `net.minecraftforge.fml.common.Mod` import in `forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostModeEvents.java`.
💡 **Why:** To improve code health and maintainability as the import was not being used.
✅ **Verification:** Ran `./gradlew :forge:build -x test` and `./gradlew test` to ensure that removing the import didn't cause any compilation or test errors.
✨ **Result:** Cleaned up unused code.

---
*PR created automatically by Jules for task [9453898273024092967](https://jules.google.com/task/9453898273024092967) started by @SSoggyTacoMan*