### PR TITLE
🧹 refactor(forge): remove unused Mod import

### DIFF
--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java
@@ -24,7 +24,6 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
 import org.ssoggy.ssoggysouls.SSoggySoulsMod;
 import org.ssoggy.ssoggysouls.database.DatabaseManager;
 import org.ssoggy.ssoggysouls.hrm.dlc.listener.GhostModeEvents;


### PR DESCRIPTION
🎯 **What:** Removed unused `net.minecraftforge.fml.common.Mod` import from `forge/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java`.
💡 **Why:** The import was unused, and removing it improves code maintainability and readability by keeping the imports relevant to the actual dependencies in the code.
✅ **Verification:** Verified by compiling the Forge module with `./gradlew :forge:build` and running tests with `./gradlew :forge:test` ensuring everything builds perfectly.
✨ **Result:** Cleaned up unused import, leading to slightly cleaner code.

---
*PR created automatically by Jules for task [233666263350604261](https://jules.google.com/task/233666263350604261) started by @SSoggyTacoMan*