### PR TITLE
🧹 [Code Health] Remove unused Mod import in ExtraLifeManager

### DIFF
--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/ExtraLifeManager.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/ExtraLifeManager.java
@@ -13,7 +13,6 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.item.component.CustomData;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
 import org.ssoggy.ssoggysouls.SSoggySoulsMod;
 import org.ssoggy.ssoggysouls.database.DatabaseManager;
 import org.ssoggy.ssoggysouls.model.PlayerData;


### PR DESCRIPTION
🎯 **What:** Removed unused import `net.minecraftforge.fml.common.Mod` from `forge/src/main/java/org/ssoggy/ssoggysouls/hrm/ExtraLifeManager.java`.
💡 **Why:** To improve code health, maintainability, and readability by removing an unused import that wasn't providing any value.
✅ **Verification:** Ran `./gradlew :forge:build` and `./gradlew :forge:test` to confirm the change successfully compiled and all tests pass without errors.
✨ **Result:** A cleaner and more concise file, with no change in functionality.

---
*PR created automatically by Jules for task [11104765668958860870](https://jules.google.com/task/11104765668958860870) started by @SSoggyTacoMan*