### PR TITLE
🧪 [testing improvement] test DeathStatusCache get method

### DIFF
--- a/common/src/test/java/org/ssoggy/ssoggysouls/database/DeathStatusCacheTest.java
+++ b/common/src/test/java/org/ssoggy/ssoggysouls/database/DeathStatusCacheTest.java
@@ -1,0 +1,66 @@
+package org.ssoggy.ssoggysouls.database;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DeathStatusCacheTest {
+
+    private DeathStatusCache cache;
+    private final UUID testUuid = UUID.randomUUID();
+
+    @BeforeEach
+    void setUp() {
+        cache = new DeathStatusCache();
+    }
+
+    @Test
+    void testGetNullUuid() {
+        assertNull(cache.get(null));
+    }
+
+    @Test
+    void testGetUnknownUuid() {
+        assertNull(cache.get(testUuid));
+    }
+
+    @Test
+    void testGetKnownUuidDead() {
+        cache.put(testUuid, true);
+        Boolean result = cache.get(testUuid);
+        assertNotNull(result);
+        assertTrue(result);
+    }
+
+    @Test
+    void testGetKnownUuidAlive() {
+        cache.put(testUuid, false);
+        Boolean result = cache.get(testUuid);
+        assertNotNull(result);
+        assertFalse(result);
+    }
+
+    @Test
+    void testGetExpiredUuid() throws Exception {
+        cache.put(testUuid, true);
+
+        // Use reflection to forcefully expire the cache entry to avoid Thread.sleep(2000)
+        Field cacheField = DeathStatusCache.class.getDeclaredField("cache");
+        cacheField.setAccessible(true);
+        Map<?, ?> internalCache = (Map<?, ?>) cacheField.get(cache);
+
+        Object entry = internalCache.get(testUuid);
+        Field timestampField = entry.getClass().getDeclaredField("timestamp");
+        timestampField.setAccessible(true);
+
+        // Set timestamp to 3000ms in the past
+        timestampField.set(entry, System.currentTimeMillis() - 3000);
+
+        assertNull(cache.get(testUuid));
+    }
+}


### PR DESCRIPTION
🎯 **What:** The `get` method of `DeathStatusCache` in the `common` module was completely untested, leading to a gap in coverage for core caching logic.
📊 **Coverage:** The new `DeathStatusCacheTest` class now comprehensively covers:
  * Retrieving with a `null` UUID.
  * Retrieving with an unknown (non-existent) UUID.
  * Retrieving a known UUID that is marked as dead.
  * Retrieving a known UUID that is marked as alive.
  * Retrieving an expired UUID (simulated using reflection to avoid slow `Thread.sleep` calls).
✨ **Result:** Test coverage for `DeathStatusCache.get` is now complete, providing a safety net for future refactoring of this time-sensitive component.

---
*PR created automatically by Jules for task [8630144098717710340](https://jules.google.com/task/8630144098717710340) started by @SSoggyTacoMan*