### PR TITLE
chore(forge): rephrase reobf comment to prevent false positive fixme

### DIFF
--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -32,7 +32,7 @@ minecraft {
     // Simply re-run your setup task after changing the mappings to update your workspace.
     mappings channel: mapping_channel, version: mapping_version
     
-    // Tell FG to not automtically create the reobf tasks, as we now use Official mappings at runtime, If you don't use them at dev time then you'll have to fix your reobf yourself.
+    // Tell FG to not automatically create the reobf tasks, as we now use Official mappings at runtime. If you don't use them at dev time then you'll have to configure your reobf yourself.
     reobf = false
 
     // When true, this property will have all Eclipse/IntelliJ IDEA run configurations run the "prepareX" task for the given run configuration before launching the game.


### PR DESCRIPTION
- Changes 'fix your reobf' to 'configure your reobf' in `forge/build.gradle`.
- Fixes typo 'automtically' to 'automatically'.
- Prevents issue scanners from flagging the line as an actionable task.

---
*PR created automatically by Jules for task [16981262618972986622](https://jules.google.com/task/16981262618972986622) started by @SSoggyTacoMan*