### PR TITLE
🧹 [code health improvement] Remove unused Mod import in RevivalStructureListener

### DIFF
--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java
@@ -24,7 +24,6 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
 import net.neoforged.bus.api.SubscribeEvent;
-import net.neoforged.fml.common.Mod;
 import org.ssoggy.ssoggysouls.SSoggySoulsMod;
 import org.ssoggy.ssoggysouls.database.DatabaseManager;
 import org.ssoggy.ssoggysouls.hrm.dlc.listener.GhostModeEvents;


### PR DESCRIPTION
🎯 **What:** Removed unused `net.neoforged.fml.common.Mod` import from `RevivalStructureListener.java` in the neoforge module.
💡 **Why:** To improve code health by cleaning up unused dependencies, making the codebase cleaner and easier to maintain.
✅ **Verification:** Compiled using `./gradlew :neoforge:build` to confirm no compilation errors occurred as a result.
✨ **Result:** A cleaner `RevivalStructureListener` class without any unused imports.

---
*PR created automatically by Jules for task [7325819302180405070](https://jules.google.com/task/7325819302180405070) started by @SSoggyTacoMan*