### PR TITLE
🧪 [testing improvement] Add test coverage for SQLiteManager.savePlayer

### DIFF
--- a/common/src/test/java/org/ssoggy/ssoggysouls/database/SQLiteManagerTest.java
+++ b/common/src/test/java/org/ssoggy/ssoggysouls/database/SQLiteManagerTest.java
@@ -95,7 +95,7 @@ class SQLiteManagerTest {
         sqliteManager.savePlayer(data);
 
         // Update data
-        PlayerData updatedData = new PlayerData(testUuid, "NewUser", 1, true, 1000L, 2500L, 3500L, 4500L);
+        PlayerData updatedData = new PlayerData(testUuid, "NewUser", 1, true, 9999L, 2500L, 3500L, 4500L);
         sqliteManager.savePlayer(updatedData);
 
         // Verify upsert

--- a/common/src/test/java/org/ssoggy/ssoggysouls/database/SQLiteManagerTest.java
+++ b/common/src/test/java/org/ssoggy/ssoggysouls/database/SQLiteManagerTest.java
@@ -1,0 +1,117 @@
+package org.ssoggy.ssoggysouls.database;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.ssoggy.ssoggysouls.PluginContext;
+import org.ssoggy.ssoggysouls.model.PlayerData;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.UUID;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class SQLiteManagerTest {
+
+    private SQLiteManager sqliteManager;
+    private PluginContext mockPlugin;
+    private File tempDir;
+    private final UUID testUuid = UUID.randomUUID();
+    private static final String TEST_USER = "TestUser";
+
+    @BeforeEach
+    void setUp() throws Exception {
+        tempDir = Files.createTempDirectory("sqlite-test").toFile();
+        mockPlugin = mock(PluginContext.class);
+
+        Logger logger = Logger.getAnonymousLogger();
+        logger.setLevel(java.util.logging.Level.OFF);
+        when(mockPlugin.getLogger()).thenReturn(logger);
+
+        when(mockPlugin.getConfigString("database.table-name", "hardcore_players"))
+                .thenReturn("hardcore_players");
+        when(mockPlugin.getConfigInt("database.max-pool-size", 1)).thenReturn(1);
+        when(mockPlugin.getDataFolder()).thenReturn(tempDir);
+        when(mockPlugin.getDefaultLives()).thenReturn(3);
+
+        sqliteManager = new SQLiteManager(mockPlugin);
+        sqliteManager.initialize();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (sqliteManager != null) {
+            sqliteManager.shutdown();
+        }
+        deleteDirectory(tempDir);
+    }
+
+    private void deleteDirectory(File file) {
+        if (file.isDirectory()) {
+            File[] entries = file.listFiles();
+            if (entries != null) {
+                for (File entry : entries) {
+                    deleteDirectory(entry);
+                }
+            }
+        }
+        file.delete();
+    }
+
+    @Test
+    void testSavePlayerInsert() throws SQLException {
+        PlayerData data = new PlayerData(testUuid, TEST_USER, 3, false, 1000L, 2000L, 3000L, 4000L);
+        sqliteManager.savePlayer(data);
+
+        // Verify insertion
+        try (Connection conn = sqliteManager.getDataSource().getConnection();
+             PreparedStatement ps = conn.prepareStatement("SELECT * FROM hardcore_players WHERE uuid = ?")) {
+            ps.setString(1, testUuid.toString());
+            try (ResultSet rs = ps.executeQuery()) {
+                assertTrue(rs.next(), "Player should be found in database");
+                assertEquals(TEST_USER, rs.getString("username"));
+                assertEquals(3, rs.getInt("lives"));
+                assertFalse(rs.getBoolean("is_dead"));
+                assertEquals(1000L, rs.getLong("first_join"));
+                assertEquals(2000L, rs.getLong("last_death"));
+                assertEquals(3000L, rs.getLong("last_seen"));
+                assertEquals(4000L, rs.getLong("grace_until"));
+            }
+        }
+    }
+
+    @Test
+    void testSavePlayerUpsert() throws SQLException {
+        // Insert initial data
+        PlayerData data = new PlayerData(testUuid, TEST_USER, 3, false, 1000L, 2000L, 3000L, 4000L);
+        sqliteManager.savePlayer(data);
+
+        // Update data
+        PlayerData updatedData = new PlayerData(testUuid, "NewUser", 1, true, 1000L, 2500L, 3500L, 4500L);
+        sqliteManager.savePlayer(updatedData);
+
+        // Verify upsert
+        try (Connection conn = sqliteManager.getDataSource().getConnection();
+             PreparedStatement ps = conn.prepareStatement("SELECT * FROM hardcore_players WHERE uuid = ?")) {
+            ps.setString(1, testUuid.toString());
+            try (ResultSet rs = ps.executeQuery()) {
+                assertTrue(rs.next(), "Player should be found in database");
+                assertEquals("NewUser", rs.getString("username"));
+                assertEquals(1, rs.getInt("lives"));
+                assertTrue(rs.getBoolean("is_dead"));
+                assertEquals(1000L, rs.getLong("first_join")); // ON CONFLICT DO UPDATE shouldn't update first_join (not in SET clause)
+                assertEquals(2500L, rs.getLong("last_death"));
+                assertEquals(3500L, rs.getLong("last_seen"));
+                assertEquals(4500L, rs.getLong("grace_until"));
+            }
+        }
+    }
+}

--- a/common/src/test/java/org/ssoggy/ssoggysouls/database/SQLiteManagerTest.java
+++ b/common/src/test/java/org/ssoggy/ssoggysouls/database/SQLiteManagerTest.java
@@ -22,7 +22,8 @@ class SQLiteManagerTest {
 
     private SQLiteManager sqliteManager;
     private PluginContext mockPlugin;
-    private File tempDir;
+    @org.junit.jupiter.api.io.TempDir
+    File tempDir;
     private final UUID testUuid = UUID.randomUUID();
     private static final String TEST_USER = "TestUser";
 

--- a/common/src/test/java/org/ssoggy/ssoggysouls/database/SQLiteManagerTest.java
+++ b/common/src/test/java/org/ssoggy/ssoggysouls/database/SQLiteManagerTest.java
@@ -7,7 +7,6 @@ import org.ssoggy.ssoggysouls.PluginContext;
 import org.ssoggy.ssoggysouls.model.PlayerData;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.sql.Connection;
 import java.sql.PreparedStatement;


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `savePlayer` method in `SQLiteManager.java` contains SQLite-specific `ON CONFLICT DO UPDATE` upsert logic that was completely untested, representing a critical testing gap for data integrity.

📊 **Coverage:** What scenarios are now tested
A new test suite (`SQLiteManagerTest.java`) has been added using a real temporary SQLite database. It covers:
*   Initial insertion of a new player record.
*   Upserting an existing player record to verify that dynamic fields (like `last_seen`, `is_dead`) update properly.
*   Verifying that the `first_join` field remains unchanged during an upsert, as it's correctly omitted from the `DO UPDATE SET` clause.

✨ **Result:** The improvement in test coverage
Test coverage for the `SQLiteManager` is dramatically improved. Real integration testing guarantees that syntax errors in the complex raw SQLite query are caught during the build process, preventing runtime crashes.

---
*PR created automatically by Jules for task [366270393953008001](https://jules.google.com/task/366270393953008001) started by @SSoggyTacoMan*