### PR TITLE
🧹 refactor(forge): remove unused import java.util.Optional

### DIFF
--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java
@@ -38,7 +38,6 @@ import org.ssoggy.ssoggysouls.util.ConfigManager;
 import org.ssoggy.ssoggysouls.util.MessageUtil;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;


### PR DESCRIPTION
🎯 **What:** Removed unused import `java.util.Optional` in `forge/src/main/java/org/ssoggy/ssoggysouls/hrm/RevivalStructureListener.java`.

💡 **Why:** `Optional` was imported but never used in the class, leaving dead code that clutters the codebase. Removing it improves code health and readability.

✅ **Verification:** Verified via manual review that `Optional` was indeed completely unused in `RevivalStructureListener.java`. Ran `./gradlew build` and `./gradlew test`, with successful results indicating that the removal was safe and didn't break any functionality.

✨ **Result:** Cleaned up unused import, leaving the codebase slightly cleaner and marginally smaller.

---
*PR created automatically by Jules for task [4845959251620256983](https://jules.google.com/task/4845959251620256983) started by @SSoggyTacoMan*