### PR TITLE
🎨 Palette: Localize VisitLimboCommand error message

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -22,4 +22,4 @@
 **Action:** Always use `sendInteractiveUsage` with the base command when failing bounds checks or limit constraints on command arguments, rather than regular `sendMessage`.
 ## 2026-05-15 - [Localization in CLI Commands]
 **Learning:** Hardcoded strings in commands (like error messages for console execution) cause inconsistent UX and prevent server owners from localizing the text via config files.
-**Action:** Always replace static text messages with `MessageUtil.get("config-key")` (or the equivalent translation mechanism for the platform) to ensure all user and console-facing text is customizable and consistent.
+**Action:** Always replace static text messages with localized keys (e.g., using `MessageUtil.get("config-key")` for general feedback or `CommandUtil.sendInteractiveUsage()` for usage errors) to ensure all user and console-facing text is customizable and consistent.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -20,3 +20,6 @@
 ## 2026-05-15 - [Interactive CLI Limit Constraints]
 **Learning:** Similarly to parsing errors, logical constraints and bound limits (like `< 0` or `> maxLives` or line limits) traditionally send dead-end static messages. Using `sendInteractiveUsage` for these limit constraint errors provides the same recovery path benefits, letting the user simply click and change the number without retyping the base command.
 **Action:** Always use `sendInteractiveUsage` with the base command when failing bounds checks or limit constraints on command arguments, rather than regular `sendMessage`.
+## 2026-05-15 - [Localization in CLI Commands]
+**Learning:** Hardcoded strings in commands (like error messages for console execution) cause inconsistent UX and prevent server owners from localizing the text via config files.
+**Action:** Always replace static text messages with `MessageUtil.get("config-key")` (or the equivalent translation mechanism for the platform) to ensure all user and console-facing text is customizable and consistent.

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/command/VisitLimboCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/command/VisitLimboCommand.java
@@ -24,7 +24,7 @@ public class VisitLimboCommand implements CommandExecutor {
         if (sender instanceof Player player) {
             handleVisit(player);
         } else if (sender != null) {
-            sender.sendMessage("Only players can use this command.");
+            sender.sendMessage(MessageUtil.get("command-only-players"));
         }
         return true;
     }


### PR DESCRIPTION
💡 What: Replaced hardcoded "Only players can use this command." with localizable message `MessageUtil.get("command-only-players")` in VisitLimboCommand.
🎯 Why: Ensure consistency with LeaveLimboCommand and allow server admins to configure the message via `config.yml`.
📸 Before/After: Console users see localizable error.
♿ Accessibility: N/A

---
*PR created automatically by Jules for task [7346924187311835471](https://jules.google.com/task/7346924187311835471) started by @SSoggyTacoMan*