### PR TITLE
📦 Porter: Localize DLC command execution error ported to Forge/Fabric/NeoForge

### DIFF
--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
@@ -26,6 +26,7 @@ import org.ssoggy.ssoggysouls.hrm.dlc.util.GhostState;
 import org.ssoggy.ssoggysouls.listener.MainServerListener;
 import org.ssoggy.ssoggysouls.model.PlayerData;
 import org.ssoggy.ssoggysouls.util.ConfigManager;
+import org.ssoggy.ssoggysouls.util.MessageUtil;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -141,7 +142,7 @@ public final class DlcCommandRegistration {
 
     private static int executeTrust(ServerCommandSource source, DatabaseManager db, String rawAction, String targetName) {
         if (!(source.getEntity() instanceof ServerPlayerEntity player)) {
-            sendResult(source, DlcCommandResult.fail("This command can only be run by a player."));
+            sendResult(source, DlcCommandResult.fail(MessageUtil.getRawString("admin-players-only")));
             return 0;
         }
 

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
@@ -142,7 +142,7 @@ public final class DlcCommandRegistration {
 
     private static int executeTrust(ServerCommandSource source, DatabaseManager db, String rawAction, String targetName) {
         if (!(source.getEntity() instanceof ServerPlayerEntity player)) {
-            sendResult(source, DlcCommandResult.fail(MessageUtil.getRawString("admin-players-only")));
+            sendResult(source, DlcCommandResult.fail(MessageUtil.getFormattedNoPrefix("admin-players-only")));
             return 0;
         }
 

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
@@ -25,6 +25,7 @@ import org.ssoggy.ssoggysouls.hrm.dlc.util.GhostState;
 import org.ssoggy.ssoggysouls.listener.ServerLifecycleListener;
 import org.ssoggy.ssoggysouls.model.PlayerData;
 import org.ssoggy.ssoggysouls.util.ConfigManager;
+import org.ssoggy.ssoggysouls.util.MessageUtil;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -140,7 +141,7 @@ public final class DlcCommandRegistration {
 
     private static int executeTrust(CommandSourceStack source, DatabaseManager db, String rawAction, String targetName) {
         if (!source.isPlayer()) {
-            sendResult(source, DlcCommandResult.fail("This command can only be run by a player."));
+            sendResult(source, DlcCommandResult.fail(MessageUtil.getRawString("admin-players-only")));
             return 0;
         }
 

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
@@ -141,7 +141,7 @@ public final class DlcCommandRegistration {
 
     private static int executeTrust(CommandSourceStack source, DatabaseManager db, String rawAction, String targetName) {
         if (!source.isPlayer()) {
-            sendResult(source, DlcCommandResult.fail(MessageUtil.getRawString("admin-players-only")));
+            sendResult(source, DlcCommandResult.fail(MessageUtil.getFormattedNoPrefix("admin-players-only")));
             return 0;
         }
 

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
@@ -26,6 +26,7 @@ import org.ssoggy.ssoggysouls.hrm.dlc.util.GhostState;
 import org.ssoggy.ssoggysouls.listener.ServerLifecycleListener;
 import org.ssoggy.ssoggysouls.model.PlayerData;
 import org.ssoggy.ssoggysouls.util.ConfigManager;
+import org.ssoggy.ssoggysouls.util.MessageUtil;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -141,7 +142,7 @@ public final class DlcCommandRegistration {
 
     private static int executeTrust(CommandSourceStack source, DatabaseManager db, String rawAction, String targetName) {
         if (!source.isPlayer()) {
-            sendResult(source, DlcCommandResult.fail("This command can only be run by a player."));
+            sendResult(source, DlcCommandResult.fail(MessageUtil.getRawString("admin-players-only")));
             return 0;
         }
 

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
@@ -142,7 +142,7 @@ public final class DlcCommandRegistration {
 
     private static int executeTrust(CommandSourceStack source, DatabaseManager db, String rawAction, String targetName) {
         if (!source.isPlayer()) {
-            sendResult(source, DlcCommandResult.fail(MessageUtil.getRawString("admin-players-only")));
+            sendResult(source, DlcCommandResult.fail(MessageUtil.getFormattedNoPrefix("admin-players-only")));
             return 0;
         }
 


### PR DESCRIPTION
Replaced the hardcoded string `"This command can only be run by a player."` with `MessageUtil.getRawString("admin-players-only")` in `DlcCommandRegistration.java` across Forge, Fabric, and NeoForge.

This ports the UI localization parity fix from the Paper module's `VisitLimboCommand` (commit 9ac17d956b60432a45c15ebc4a81275430e35a92) to the other mod platforms to prevent consistency and translation bugs.

---
*PR created automatically by Jules for task [12059935681791167574](https://jules.google.com/task/12059935681791167574) started by @SSoggyTacoMan*