### PR TITLE
⚡ Bolt: optimize tab completion performance for DLC commands

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -24,3 +24,7 @@
 ## 2024-05-24 - [Avoid Stream map allocation overhead on player names in Brigadier]
 **Learning:** In Fabric and Forge/NeoForge Brigadier command tab completions, doing `server.getPlayerList().stream().map(p -> p.getName())` inside `.suggests(...)` allocates a new stream and performs O(N) operations on every keystroke.
 **Action:** Use `server.getPlayerNames()` natively available on the server instance, which returns a `String[]`. This avoids the overhead of the Stream API entirely during tab-completion.
+
+## 2026-05-24 - [Avoid Stream map allocation overhead on player names in Paper]
+**Learning:** In Bukkit/Paper command tab completions, doing `Bukkit.getOnlinePlayers().stream().map(Player::getName)` allocates a new stream and performs O(N) operations on every single keystroke.
+**Action:** Use a direct loop to iterate over `Bukkit.getOnlinePlayers()` and add names to an `ArrayList` directly, filtering manually, to avoid the overhead of the Stream API entirely during highly frequent tab-completions.

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/GhostModeCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/GhostModeCommand.java
@@ -59,7 +59,7 @@ public class GhostModeCommand implements CommandExecutor, TabCompleter { // Lazy
     @Override
     public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args) {
         if (args.length < 2) {
-            return Bukkit.getOnlinePlayers().stream().map(Player::getName).toList();
+            return org.ssoggy.ssoggysouls.util.TabCompleteUtil.getOnlinePlayerNames(args.length > 0 ? args[0] : "");
         }
         return Collections.emptyList();
     }

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/ObituariesCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/ObituariesCommand.java
@@ -95,7 +95,10 @@ public class ObituariesCommand implements CommandExecutor, TabCompleter {
 
     @Override
     public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args) {
-        return org.ssoggy.ssoggysouls.util.TabCompleteUtil.getOnlinePlayerNames(args.length > 0 ? args[0] : "");
+        if (args.length < 2) {
+            return org.ssoggy.ssoggysouls.util.TabCompleteUtil.getOnlinePlayerNames(args.length > 0 ? args[0] : "");
+        }
+        return List.of();
     }
 
     private static long getObituaryDelayMinutes(FileConfiguration config, String key, long fallback) {

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/ObituariesCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/ObituariesCommand.java
@@ -29,7 +29,6 @@ import org.ssoggy.ssoggysouls.hrm.dlc.util.RPSocial;
 import org.ssoggy.ssoggysouls.hrm.dlc.util.RPStatic;
 import org.ssoggy.ssoggysouls.hrm.dlc.util.RPUtil;
 import org.ssoggy.ssoggysouls.hrm.dlc.util.Pair;
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/ObituariesCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/ObituariesCommand.java
@@ -96,7 +96,7 @@ public class ObituariesCommand implements CommandExecutor, TabCompleter {
 
     @Override
     public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args) {
-        return Bukkit.getOnlinePlayers().stream().map(Player::getName).toList();
+        return org.ssoggy.ssoggysouls.util.TabCompleteUtil.getOnlinePlayerNames(args.length > 0 ? args[0] : "");
     }
 
     private static long getObituaryDelayMinutes(FileConfiguration config, String key, long fallback) {

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/SocialCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/SocialCommand.java
@@ -206,7 +206,7 @@ public class SocialCommand implements CommandExecutor, TabCompleter {
         return switch (args.length) { // This is just preference
             case 0, 1 -> org.bukkit.util.StringUtil.copyPartialMatches(args.length > 0 ? args[0] : "", TRUST_ACTIONS, new java.util.ArrayList<>());
             case 2 ->
-                    Bukkit.getOnlinePlayers().stream().filter(x -> !x.getUniqueId().equals(sender instanceof Player p ? p.getUniqueId() : null)).map(Player::getName).toList();
+                    org.ssoggy.ssoggysouls.util.TabCompleteUtil.getOnlinePlayerNames(args[1], sender instanceof Player p ? p.getName() : null);
             default -> Collections.emptyList(); // Allowing unnecessary suggestions feels unfinished
         };
     }

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/SocialCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/SocialCommand.java
@@ -27,7 +27,6 @@ import org.ssoggy.ssoggysouls.hrm.dlc.enums.COMMANDOUTPUTENUM;
 import org.ssoggy.ssoggysouls.hrm.dlc.util.RPCommandOutput;
 import org.ssoggy.ssoggysouls.hrm.dlc.util.RPSocial;
 import org.ssoggy.ssoggysouls.hrm.dlc.util.RPUtil;
-import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/util/TabCompleteUtil.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/util/TabCompleteUtil.java
@@ -18,8 +18,22 @@ public final class TabCompleteUtil {
      * @return list of matching player names
      */
     public static List<String> getOnlinePlayerNames(String prefix) {
+        return getOnlinePlayerNames(prefix, null);
+    }
+
+    /**
+     * gets online player names matching the given prefix, excluding a specific name.
+     *
+     * @param prefix      the prefix to filter by (case-insensitive)
+     * @param excludeName a name to exclude from the results (case-insensitive), or null
+     * @return list of matching player names
+     */
+    public static List<String> getOnlinePlayerNames(String prefix, String excludeName) {
         List<String> names = new ArrayList<>();
         for (Player player : Bukkit.getOnlinePlayers()) {
+            if (excludeName != null && player.getName().equalsIgnoreCase(excludeName)) {
+                continue;
+            }
             if (player.getName().regionMatches(true, 0, prefix, 0, prefix.length())) {
                 names.add(player.getName());
             }


### PR DESCRIPTION
💡 What: Replaced Stream mapping in `SocialCommand`, `ObituariesCommand`, and `GhostModeCommand` tab completions with `TabCompleteUtil.getOnlinePlayerNames`. Added a method to exclude a specific player from suggestions.
🎯 Why: Using `.stream().map(Player::getName)` on `Bukkit.getOnlinePlayers()` inside tab complete methods causes unnecessary GC pressure and stream allocations on every keystroke. 
📊 Impact: Stream allocation avoidance during tab completion.
🔬 Measurement: Observe lower GC overhead when users spam tab-completions in these commands.

---
*PR created automatically by Jules for task [15109805345054786212](https://jules.google.com/task/15109805345054786212) started by @SSoggyTacoMan*