### PR TITLE
🎨 Palette: Improve grace time formatting UX error

### DIFF
--- a/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminCommand.java
@@ -241,8 +241,9 @@ public class AdminCommand implements CommandExecutor, TabCompleter {
         long millis = TimeUtil.parseTimeToMillis(timeStr);
         
         if (millis < 0) {
-            sender.sendMessage(MessageUtil.colorize(
-                    "&cInvalid time format: " + timeStr + ". Use formats like: 1h30m, 2h, 90m"));
+            org.ssoggy.ssoggysouls.util.CommandUtil.sendInteractiveUsage(sender,
+                    "&cInvalid time format: " + timeStr + ". Use formats like: 1h30m, 2h, 90m",
+                    "/psadmin grace set " + data.getUsername() + " ");
             return;
         }
 

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminCommand.java
@@ -241,7 +241,7 @@ public class AdminCommand implements CommandExecutor, TabCompleter {
         long millis = TimeUtil.parseTimeToMillis(timeStr);
         
         if (millis < 0) {
-            org.ssoggy.ssoggysouls.util.CommandUtil.sendInteractiveUsage(sender,
+            CommandUtil.sendInteractiveUsage(sender,
                     "&cInvalid time format: " + timeStr + ". Use formats like: 1h30m, 2h, 90m",
                     "/psadmin grace set " + data.getUsername() + " ");
             return;


### PR DESCRIPTION
💡 **What**: Upgraded the static error message for invalid time formats in `/psadmin grace set` to an interactive chat component.
🎯 **Why**: When an admin mistypes a time format (like "1h 30m" instead of "1h30m"), they had to retype the entire command. This uses `sendInteractiveUsage` to let them click the error message and instantly auto-fill the base command back into their chat bar, massively reducing friction.
📸 **Before/After**: N/A (CLI logic change)
♿ **Accessibility**: Reduces repetitive typing for users navigating complex commands.

---
*PR created automatically by Jules for task [409421822922055798](https://jules.google.com/task/409421822922055798) started by @SSoggyTacoMan*