### PR TITLE
feat(paper): 🎨 Palette: Interactive coordinate copying in obituaries

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -17,3 +17,7 @@
 ## 2026-05-15 - [Interactive CLI Number Parsing Errors]
 **Learning:** Number parsing errors (e.g., NumberFormatException) in legacy command systems often default to static "Invalid number" messages. By refactoring methods like `parseIntOrError` to accept a base `suggestCmd`, these static errors can be upgraded to use `CommandUtil.sendInteractiveUsage`, allowing users to quickly correct invalid numeric inputs via a clickable chat component.
 **Action:** Always provide the base command context when catching input format errors to build actionable auto-fill error suggestions.
+
+## 2026-05-18 - [Interactive CLI Coordinate Copying]
+**Learning:** Players frequently need to share or navigate to coordinates displayed in chat (like death locations in obituaries), but manually transcribing them into waypoints or chat is tedious and error-prone.
+**Action:** When displaying coordinates in chat via MiniMessage, wrap them in `<click:copy_to_clipboard:'X Y Z'>` and a `<hover>` prompt to allow instant, frictionless copying.

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/ObituariesCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/ObituariesCommand.java
@@ -73,11 +73,16 @@ public class ObituariesCommand implements CommandExecutor, TabCompleter {
                     || (relationship == SOCIALENUM.TRUSTED && deathTime.isBefore(now.minusSeconds(trustedAfterMin * 60)))) {
                 String username = RPUtil.getUsernameFromCache(uuid);
                 Location deathLocation = deathDetails.getLeft();
-                deathListBuilder.append("\n<gold><bold>").append(username).append("</bold></gold><gray> has died at</gray><gold><bold>")
-                        .append(" X").append(deathLocation.getBlockX())
+                String coords = deathLocation.getBlockX() + " " + deathLocation.getBlockY() + " " + deathLocation.getBlockZ();
+                deathListBuilder.append("\n<gold><bold>").append(username).append("</bold></gold><gray> has died at </gray>")
+                        .append("<click:copy_to_clipboard:'").append(coords).append("'>")
+                        .append("<hover:show_text:'<gray>Click to copy coordinates</gray>'>")
+                        .append("<gold><bold>X").append(deathLocation.getBlockX())
                         .append(" Y").append(deathLocation.getBlockY())
                         .append(" Z").append(deathLocation.getBlockZ())
-                        .append("</bold></gold><gray> in the </gray><gold><bold>")
+                        .append("</bold></gold>")
+                        .append("</hover></click>")
+                        .append("<gray> in the </gray><gold><bold>")
                         .append(deathLocation.getWorld().getName()).append("</bold></gold>");
             }
         }


### PR DESCRIPTION
💡 What: Made coordinates in the `/obituaries` command clickable, allowing users to instantly copy them to their clipboard.
🎯 Why: Players frequently need to share or navigate to coordinates displayed in chat, but manually transcribing them is tedious and error-prone. This micro-UX improvement creates a frictionless recovery path.
📸 Before/After: N/A (Text interaction change)
♿ Accessibility: Reduces cognitive load and motor effort required to transcribe long coordinate strings.

---
*PR created automatically by Jules for task [10060247894113765662](https://jules.google.com/task/10060247894113765662) started by @SSoggyTacoMan*