### PR TITLE
⚡ Async Disk I/O During Ticks in GhostBlockEvents

### DIFF
--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostBlockEvents.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostBlockEvents.java
@@ -138,7 +138,7 @@ public class GhostBlockEvents {
                     CompletableFuture.runAsync(() -> {
                         DlcDeaths.setHolder(ownerUuid, playerUuid);
                         DlcNames.cache(playerUuid, playerName);
-                    });
+                    }, IO_EXECUTOR);
                 }
             }
         }

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostBlockEvents.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostBlockEvents.java
@@ -132,8 +132,13 @@ public class GhostBlockEvents {
             if (stack.isOf(Items.PLAYER_HEAD)) {
                 ProfileComponent profile = stack.get(DataComponentTypes.PROFILE);
                 if (profile != null && profile.id().isPresent()) {
-                    DlcDeaths.setHolder(profile.id().get(), player.getUuid());
-                    DlcNames.cache(player.getUuid(), player.getName().getString());
+                    java.util.UUID ownerUuid = profile.id().get();
+                    java.util.UUID playerUuid = player.getUuid();
+                    String playerName = player.getName().getString();
+                    CompletableFuture.runAsync(() -> {
+                        DlcDeaths.setHolder(ownerUuid, playerUuid);
+                        DlcNames.cache(playerUuid, playerName);
+                    });
                 }
             }
         }

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostBlockEvents.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostBlockEvents.java
@@ -54,8 +54,12 @@ public class GhostBlockEvents {
         if (profile == null || profile.id().isEmpty()) return;
         UUID ownerUuid = profile.id().get();
 
-        DlcDeaths.setHolder(ownerUuid, player.getUUID());
-        DlcNames.cache(player.getUUID(), player.getScoreboardName());
+        UUID holderUuid = player.getUUID();
+        String holderName = player.getScoreboardName();
+        CompletableFuture.runAsync(() -> {
+            DlcDeaths.setHolder(ownerUuid, holderUuid);
+            DlcNames.cache(holderUuid, holderName);
+        });
     }
 
     @SubscribeEvent

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostBlockEvents.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostBlockEvents.java
@@ -59,7 +59,7 @@ public class GhostBlockEvents {
         CompletableFuture.runAsync(() -> {
             DlcDeaths.setHolder(ownerUuid, holderUuid);
             DlcNames.cache(holderUuid, holderName);
-        });
+        }, IO_EXECUTOR);
     }
 
     @SubscribeEvent

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostBlockEvents.java.orig
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostBlockEvents.java.orig
@@ -13,10 +13,11 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.SkullBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
-import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
-import net.neoforged.neoforge.event.entity.player.ItemEntityPickupEvent;
-import net.neoforged.neoforge.event.level.BlockEvent;
-import net.neoforged.bus.api.SubscribeEvent;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.event.entity.player.EntityItemPickupEvent;
+import net.minecraftforge.event.level.BlockEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import org.ssoggy.ssoggysouls.SSoggySoulsMod;
 import org.ssoggy.ssoggysouls.database.DatabaseManager;
 import org.ssoggy.ssoggysouls.hrm.dlc.shared.DlcDeaths;
 import org.ssoggy.ssoggysouls.hrm.dlc.shared.DlcNames;
@@ -37,30 +38,24 @@ public class GhostBlockEvents {
     }
 
     @SubscribeEvent
-    public static void onItemPickup(ItemEntityPickupEvent event) {
+    public static void onItemPickup(EntityItemPickupEvent event) {
         if (!org.ssoggy.ssoggysouls.util.ConfigManager.getConfig().isHrmEnabled()) return;
 
-        if (db == null || !(event.getPlayer() instanceof ServerPlayer player)) {
+        if (db == null || !(event.getEntity() instanceof ServerPlayer player)) {
             return;
         }
 
-        ItemStack stack = event.getItemEntity().getItem();
+        ItemStack stack = event.getItem().getItem();
         if (!stack.is(Items.PLAYER_HEAD)) {
             return;
         }
 
         ResolvableProfile profile = stack.get(DataComponents.PROFILE);
-        if (profile == null || profile.id().isEmpty()) {
-            return;
-        }
-
+        if (profile == null || profile.id().isEmpty()) return;
         UUID ownerUuid = profile.id().get();
-        UUID holderUuid = player.getUUID();
-        String holderName = player.getScoreboardName();
-        CompletableFuture.runAsync(() -> {
-            DlcDeaths.setHolder(ownerUuid, holderUuid);
-            DlcNames.cache(holderUuid, holderName);
-        });
+
+        DlcDeaths.setHolder(ownerUuid, player.getUUID());
+        DlcNames.cache(player.getUUID(), player.getScoreboardName());
     }
 
     @SubscribeEvent
@@ -73,7 +68,7 @@ public class GhostBlockEvents {
 
         Level world = (Level) event.getLevel();
         BlockState state = event.getState();
-        
+
         if ((state.is(Blocks.PLAYER_HEAD) || state.is(Blocks.PLAYER_WALL_HEAD))) {
             BlockEntity be = world.getBlockEntity(event.getPos());
             if (be instanceof SkullBlockEntity skull) {
@@ -86,7 +81,7 @@ public class GhostBlockEvents {
         ResolvableProfile profile = skull.getOwnerProfile();
         if (profile != null && profile.id().isPresent()) {
             UUID ownerUuid = profile.id().get();
-            
+
             CompletableFuture.runAsync(() -> {
                 PlayerData data = db.getPlayer(ownerUuid);
                 if (data != null && data.isDead()) {
@@ -124,7 +119,6 @@ public class GhostBlockEvents {
 
         ResolvableProfile profile = stack.get(DataComponents.PROFILE);
         if (profile == null || profile.id().isEmpty()) return;
-
         UUID ownerUuid = profile.id().get();
         BlockPos targetPos = event.getPos().relative(event.getFace());
 

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostBlockEvents.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostBlockEvents.java
@@ -60,7 +60,7 @@ public class GhostBlockEvents {
         CompletableFuture.runAsync(() -> {
             DlcDeaths.setHolder(ownerUuid, holderUuid);
             DlcNames.cache(holderUuid, holderName);
-        });
+        }, IO_EXECUTOR);
     }
 
     @SubscribeEvent

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostBlockEvents.java.orig
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/GhostBlockEvents.java.orig
@@ -55,12 +55,8 @@ public class GhostBlockEvents {
         }
 
         UUID ownerUuid = profile.id().get();
-        UUID holderUuid = player.getUUID();
-        String holderName = player.getScoreboardName();
-        CompletableFuture.runAsync(() -> {
-            DlcDeaths.setHolder(ownerUuid, holderUuid);
-            DlcNames.cache(holderUuid, holderName);
-        });
+        DlcDeaths.setHolder(ownerUuid, player.getUUID());
+        DlcNames.cache(player.getUUID(), player.getScoreboardName());
     }
 
     @SubscribeEvent
@@ -73,7 +69,7 @@ public class GhostBlockEvents {
 
         Level world = (Level) event.getLevel();
         BlockState state = event.getState();
-        
+
         if ((state.is(Blocks.PLAYER_HEAD) || state.is(Blocks.PLAYER_WALL_HEAD))) {
             BlockEntity be = world.getBlockEntity(event.getPos());
             if (be instanceof SkullBlockEntity skull) {
@@ -86,7 +82,7 @@ public class GhostBlockEvents {
         ResolvableProfile profile = skull.getOwnerProfile();
         if (profile != null && profile.id().isPresent()) {
             UUID ownerUuid = profile.id().get();
-            
+
             CompletableFuture.runAsync(() -> {
                 PlayerData data = db.getPlayer(ownerUuid);
                 if (data != null && data.isDead()) {


### PR DESCRIPTION
💡 **What:** Offloaded synchronous database operations (`DlcDeaths.setHolder` and `DlcNames.cache`) inside tick and pickup events to an asynchronous thread (`CompletableFuture.runAsync`) in the Fabric, Forge, and NeoForge loaders.
🎯 **Why:** Previously, iterating over a player's inventory during a tick to update the death holder generated synchronous disk I/O, which could severely delay the main server thread. This optimization prevents blocking operations during ticks.
📊 **Measured Improvement:** Moved heavy I/O operations from the main server thread to an async worker thread pool. This reduces tick times. No formal benchmark was added because the optimization moves simple file storage logic into an asynchronous completion stage.

---
*PR created automatically by Jules for task [6565390684380232](https://jules.google.com/task/6565390684380232) started by @SSoggyTacoMan*