### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix DoS vulnerability in network payload decoding

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,3 +11,7 @@
 **Vulnerability:** Unsanitized user inputs (e.g., `sender`, `action` parameters) were passed directly to `PrintWriter.println()` and `Logger.info()` in `AdminLogger.java` across all module implementations (`paper`, `fabric`, `forge`, `neoforge`).
 **Learning:** This exposes the application to Log Forging (CRLF Injection), where a malicious user could supply inputs containing newline (`\n`) and carriage return (`\r`) characters to insert fake log entries, obscuring legitimate audit trails or tricking log parsing systems.
 **Prevention:** Always implement an input sanitization step—such as replacing `\n` and `\r` with an underscore `_`—before writing user-controlled strings to application or system logs.
+## 2026-05-28 - [Prevent DoS via unbounded array allocation in network payload]
+**Vulnerability:** In `ServerTransferUtil` across `fabric`, `forge`, and `neoforge` modules, `new byte[buf.readableBytes()]` was being called when decoding a custom network payload. A malicious client could send an extremely large payload length, causing the server to allocate a massive byte array and crash with an OutOfMemoryError.
+**Learning:** `buf.readableBytes()` is user-controlled input when decoding packets and must be explicitly validated against a sane maximum limit before being used for memory allocation.
+**Prevention:** Always enforce a strict maximum length (e.g., 1024 bytes) when reading variable-length data structures from network buffers before allocating memory.

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/util/ServerTransferUtil.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/util/ServerTransferUtil.java
@@ -44,7 +44,11 @@ public class ServerTransferUtil {
                 },
                 buf -> {
                     try {
-                        byte[] bytes = new byte[buf.readableBytes()];
+                        int length = buf.readableBytes();
+                        if (length > 1024) {
+                            throw new java.io.IOException("Payload too large: " + length);
+                        }
+                        byte[] bytes = new byte[length];
                         buf.readBytes(bytes);
                         java.io.DataInputStream dis = new java.io.DataInputStream(
                                 new java.io.ByteArrayInputStream(bytes));

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/util/ServerTransferUtil.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/util/ServerTransferUtil.java
@@ -66,7 +66,11 @@ public class ServerTransferUtil {
                 },
                 buf -> {
                     try {
-                        byte[] bytes = new byte[buf.readableBytes()];
+                        int length = buf.readableBytes();
+                        if (length > 1024) {
+                            throw new IOException("Payload too large: " + length);
+                        }
+                        byte[] bytes = new byte[length];
                         buf.readBytes(bytes);
                         DataInputStream dis = new DataInputStream(new ByteArrayInputStream(bytes));
                         dis.readUTF(); // Skip sub-channel name ("Connect")

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/util/ServerTransferUtil.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/util/ServerTransferUtil.java
@@ -52,7 +52,11 @@ public class ServerTransferUtil {
                 },
                 buf -> {
                     try {
-                        byte[] bytes = new byte[buf.readableBytes()];
+                        int length = buf.readableBytes();
+                        if (length > 1024) {
+                            throw new IOException("Payload too large: " + length);
+                        }
+                        byte[] bytes = new byte[length];
                         buf.readBytes(bytes);
                         DataInputStream dis = new DataInputStream(new ByteArrayInputStream(bytes));
                         dis.readUTF(); // Skip sub-channel name ("Connect")


### PR DESCRIPTION
💡 What: Added a 1024-byte length restriction when decoding the BungeeConnectPayload.
🎯 Why: To prevent a Denial of Service (DoS) vulnerability where a malicious client could send an extremely large payload size, causing the server to allocate massive arrays and crash with an OutOfMemoryError.
📸 Before/After: Before, `new byte[buf.readableBytes()]` blindly allocated memory. After, `buf.readableBytes()` is checked against 1024 before allocation.
♿ Accessibility: N/A

---
*PR created automatically by Jules for task [8784780984526158613](https://jules.google.com/task/8784780984526158613) started by @SSoggyTacoMan*