### PR TITLE
🎨 Palette: Interactive CLI Coordinate Copying for Death Messages

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -24,3 +24,6 @@
 ## 2026-05-29 - [Interactive CLI Coordinate Copying]
 **Learning:** Players frequently need to navigate to locations displayed in chat (like death locations in death messages), but manually transcribing coordinates is tedious and error-prone.
 **Action:** When displaying coordinates in chat via MiniMessage, wrap them in `<click:copy_to_clipboard:'X Y Z'>` and a `<hover>` prompt to allow instant, frictionless copying for players.
+## 2026-05-30 - [Interactive CLI Coordinate Copying]
+**Learning:** Players frequently need to navigate to locations displayed in chat (like death locations in death messages), but manually transcribing coordinates is tedious and error-prone.
+**Action:** When displaying coordinates in chat via MiniMessage, wrap them in `<click:copy_to_clipboard:'X Y Z'>` and a `<hover>` prompt to allow instant, frictionless copying for players.

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/HeadDropListener.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/HeadDropListener.java
@@ -75,9 +75,11 @@ public class HeadDropListener implements Listener {
 
     private void sendDeathLocationMessage(Player player, Location deathLoc, World world) {
         if (plugin.isHrmDeathLocationMsg()) {
-            player.sendRichMessage("<gray><italic>You died at " + deathLoc.getBlockX() + ", "
-                    + deathLoc.getBlockY() + ", " + deathLoc.getBlockZ()
-                    + " in " + world.getName() + "</italic></gray>");
+            String coords = deathLoc.getBlockX() + " " + deathLoc.getBlockY() + " " + deathLoc.getBlockZ();
+            player.sendRichMessage("<gray><italic>You died at <click:copy_to_clipboard:'" + coords + "'>"
+                    + "<hover:show_text:'<gray>Click to copy coordinates</gray>'>"
+                    + deathLoc.getBlockX() + ", " + deathLoc.getBlockY() + ", " + deathLoc.getBlockZ()
+                    + "</hover></click> in " + world.getName() + "</italic></gray>");
         }
     }
 


### PR DESCRIPTION
💡 What: Updated the `sendDeathLocationMessage` in `HeadDropListener.java` to use MiniMessage tags for interactive copying.
🎯 Why: Makes it easier for players to retrieve their death coordinates without manual transcription, improving UX and reducing errors.
📸 Before/After: Before: Plain text coordinates. After: Clickable coordinates with hover tooltip.
♿ Accessibility: Reduces cognitive load and typing effort for all players.

---
*PR created automatically by Jules for task [9803852518984779252](https://jules.google.com/task/9803852518984779252) started by @SSoggyTacoMan*