### PR TITLE
⚡ Bolt: Prevent redundant synchronous disk I/O for ghost head tracking

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -38,3 +38,6 @@
 ## 2026-05-26 - [Avoided O(N) stream and ArrayList allocation on Tab Completion in RPConfigCommand]
 **Learning:** Returning a `new ArrayList<>(Map.keySet())` or chaining `.stream().map(Enum::name).toList()` on every tab complete keystroke causes redundant object instantiation and high GC overhead.
 **Action:** Utility methods like `TabCompleteUtil.filterStartsWith` should accept `Iterable<String>` instead of `List<String>`, allowing allocation-free filtering directly against sets, and avoiding inline `.stream()` maps where a manual for-loop with `String.regionMatches()` can perform the operation completely allocation-free.
+## 2026-06-03 - [Eliminated redundant synchronized disk I/O when updating state]
+**Learning:** Calling synchronized save methods (like `DlcStorage.save()`) during frequent events (e.g., ticking inventory checks for player heads) causes severe performance bottlenecks if the state hasn't actually changed. Overwriting the exact same value to disk redundantly stalls the main thread.
+**Action:** When updating state that triggers synchronized disk I/O operations, always verify that the state has actually changed (e.g., using `Objects.equals`) before proceeding with the update to avoid redundant and expensive disk writes.

--- a/common/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/shared/DlcDeaths.java
+++ b/common/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/shared/DlcDeaths.java
@@ -6,6 +6,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 public final class DlcDeaths {
@@ -90,6 +91,10 @@ public final class DlcDeaths {
     public static void setHolder(UUID deadUuid, UUID holderUuid) {
         DlcDeathRecord deathRecord = DEATHS.get(deadUuid);
         if (deathRecord != null) {
+            // Early return to prevent redundant map updates and unnecessary disk I/O save() calls
+            if (Objects.equals(deathRecord.holder(), holderUuid)) {
+                return;
+            }
             DEATHS.put(deadUuid, deathRecord.withHolder(holderUuid));
         }
         if (holderUuid == null) {

--- a/common/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/shared/DlcDeaths.java
+++ b/common/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/shared/DlcDeaths.java
@@ -90,13 +90,13 @@ public final class DlcDeaths {
 
     public static void setHolder(UUID deadUuid, UUID holderUuid) {
         DlcDeathRecord deathRecord = DEATHS.get(deadUuid);
-        if (deathRecord != null) {
-            // Early return to prevent redundant map updates and unnecessary disk I/O save() calls
-            if (Objects.equals(deathRecord.holder(), holderUuid)) {
-                return;
-            }
-            DEATHS.put(deadUuid, deathRecord.withHolder(holderUuid));
+        if (deathRecord == null) {
+            return;
         }
+        if (Objects.equals(deathRecord.holder(), holderUuid)) {
+            return;
+        }
+        DEATHS.put(deadUuid, deathRecord.withHolder(holderUuid));
         if (holderUuid == null) {
             DlcServices.deathStorage().removeValue(deadUuid.toString(), KEY_HOLDER);
         } else {


### PR DESCRIPTION
💡 What: Added an early return in `DlcDeaths.setHolder` to skip redundant state updates and disk saves when the head holder hasn't changed.
🎯 Why: `checkPlayerInventoryForHeads` fires every second and calls `setHolder` for every player head in a player's inventory, causing massive amounts of redundant synchronous disk I/O as it overwrites `deaths.properties` continuously.
📊 Impact: Eliminates O(N) disk I/O operations per second, saving significant main-thread latency and disk wear when players hold ghost heads.
🔬 Measurement: Check disk write frequency during Ghost Mode when holding player heads. Performance profile should show near-zero I/O overhead compared to continuous `FileOutputStream` spikes.

---
*PR created automatically by Jules for task [17465116827200214974](https://jules.google.com/task/17465116827200214974) started by @SSoggyTacoMan*