### PR TITLE
🎨 Palette: Make RPConfigCommand timer validation errors interactive

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -29,3 +29,6 @@
 **Action:** When displaying coordinates in chat via MiniMessage, wrap them in `<click:copy_to_clipboard:'X Y Z'>` and a `<hover>` prompt to allow instant, frictionless copying for players.
 ## 2026-06-02 - [Configurable Console Error Messages]
 **Learning:** Hardcoding standard API error strings (like "Only players can use this command") breaks consistency for server administrators running commands via console.\n**Action:** When migrating hardcoded console-only rejection messages, always use MessageUtil.get("command-only-players") to allow localization.
+## 2026-06-03 - [Interactive CLI Number Parsing Errors with RPCommandOutput]
+**Learning:** In the `RPConfigCommand` class, number parsing errors (e.g., `NumberFormatException` when parsing timer values) fall back to static error messages. Since this command uses Kyori Adventure MiniMessage implicitly by resolving custom UI strings via `RPCommandOutput`, we can't use the standard `CommandUtil.sendInteractiveUsage` method, which assumes Legacy (`&`) codes and Bukkit CommandSender execution immediately.
+**Action:** Replace static error assignments in `RPCommandOutput.message` directly with MiniMessage-compatible `<click:suggest_command:...>` and `<hover:show_text:...>` components so that players can interactively recover from invalid timer setups without re-typing.

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/RPConfigCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/RPConfigCommand.java
@@ -87,7 +87,7 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
         result.details = "Supposed to do some crazy reload logic but it's not implemented yet."; //Optional
     }
 
-    private void executeTimerCMD(String who, String where, RPCommandOutput result) {
+    private void executeTimerCMD(String who, String where, RPCommandOutput result, String label) {
         if (!RPStatic.CONFIG_TIMERS.containsKey(where)) {
             result.success = COMMANDOUTPUTENUM.FALSE;
             result.message = "Invalid timer: " + where;
@@ -100,7 +100,7 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
             result.message = (status == 1) ? "Set " + where + " to " + whoInt : "Failed to update configuration.";
         } catch (NumberFormatException e) {
             result.success = COMMANDOUTPUTENUM.FALSE;
-            result.message = "Timer value must be a number.";
+            result.message = "Timer value must be a number. Click to fix: <click:suggest_command:'/" + label + " timer " + where + " '><hover:show_text:'<gray>Click to auto-fill this command</gray>'><gray>/" + label + " timer " + where + " </gray></hover></click>";
         }
     }
 
@@ -191,7 +191,7 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
             switch (option) {
                 case OPTIONCONFIGENUM.STRUCTURE -> handleStructure(args, result);
                 case OPTIONCONFIGENUM.GAMERULE -> handleGamerule(args, result);
-                case OPTIONCONFIGENUM.TIMER -> handleTimer(args, result);
+                case OPTIONCONFIGENUM.TIMER -> handleTimer(args, result, label);
                 case OPTIONCONFIGENUM.RELOAD -> executeReloadCMD(result);
                 default -> {
                     result.success = COMMANDOUTPUTENUM.FALSE;
@@ -264,7 +264,7 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
         }
     }
 
-    private void handleTimer(String[] args, RPCommandOutput result) {
+    private void handleTimer(String[] args, RPCommandOutput result, String label) {
         switch (args.length) {
             case 0, 1:
                 result.success = COMMANDOUTPUTENUM.FALSE;
@@ -281,7 +281,7 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
                 result.message = "<aqua>" + args[1] + AQUA_LABEL_SUFFIX + (RPStatic.CONFIG_TIMERS.get(args[1])).toString() + "s";
                 break;
             default:
-                executeTimerCMD(args[2], args[1], result);
+                executeTimerCMD(args[2], args[1], result, label);
                 break;
         }
     }


### PR DESCRIPTION
💡 What: Improved the `NumberFormatException` handling in the `RPConfigCommand` to use an interactive MiniMessage component instead of static text.
🎯 Why: When users try to change a revival setting using an invalid timer (like `/revivalconfig timer something foo`), instead of forcing them to manually retype the entire command string, they can simply click the new "Click to fix" error message in chat to auto-fill `/revivalconfig timer something ` in their chat bar, drastically reducing friction and making it easy to recover from typos.
📸 Before/After: Before, error was static text "Timer value must be a number." After, error includes an interactive component powered by Kyori Adventure tags.
♿ Accessibility: Increases playability for visually impaired or low-dexterity users by eliminating the need to manually re-type long command phrases after making a typo.

---
*PR created automatically by Jules for task [5543672657835769993](https://jules.google.com/task/5543672657835769993) started by @SSoggyTacoMan*