### PR TITLE
⚡ Bolt: Optimize DlcNames to prevent redundant disk I/O

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -44,3 +44,8 @@
 ## 2026-06-03 - [Eliminated redundant synchronized disk I/O when updating state]
 **Learning:** Calling synchronized save methods (like `DlcStorage.save()`) during frequent events (e.g., ticking inventory checks for player heads) causes severe performance bottlenecks if the state hasn't actually changed. Overwriting the exact same value to disk redundantly stalls the main thread.
 **Action:** When updating state that triggers synchronized disk I/O operations, always verify that the state has actually changed (e.g., using `Objects.equals` or checking if the new value is different) before proceeding with the update to avoid redundant and expensive disk writes.
+
+## 2024-05-18 - Safe Disk Writes
+
+**Learning:** When performing optimizations to reduce synchronous disk I/O, you must be extremely careful to ensure the methods you intend to call actually exist on the target objects. An AI-generated automated code review correctly pointed out the risk of using a potentially non-existent method (`setValueIfChanged`).
+**Action:** Always verify the existence of methods via tools like `grep` before utilizing them. In this case, `setValueIfChanged` *was* verified to exist in `DlcStorage.java`, meaning the AI code reviewer's concern was a false positive, but the underlying lesson regarding verification remains critical.

--- a/common/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/shared/DlcNames.java
+++ b/common/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/shared/DlcNames.java
@@ -16,8 +16,9 @@ public final class DlcNames {
             return;
         }
 
-        DlcServices.usernameStorage().setValue(TABLE, uuid.toString(), username);
-        DlcServices.usernameStorage().save();
+        if (DlcServices.usernameStorage().setValueIfChanged(TABLE, uuid.toString(), username)) {
+            DlcServices.usernameStorage().save();
+        }
     }
 
     public static String get(UUID uuid) {


### PR DESCRIPTION
💡 What: Replaced `setValue` with `setValueIfChanged` in `DlcNames.cache()`.
🎯 Why: Prevents redundant, expensive synchronous disk writes to `usernamecache` every time a command evaluates an already-cached player.
📊 Impact: Reduces disk I/O overhead on event ticks.
🔬 Measurement: Run command-heavy actions, monitor I/O throughput.

---
*PR created automatically by Jules for task [10203963528354429462](https://jules.google.com/task/10203963528354429462) started by @SSoggyTacoMan*