### PR TITLE
📦 Porter: Interactive timer error ported to Fabric/Forge/NeoForge

### DIFF
--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
@@ -350,14 +350,14 @@ public final class DlcCommandRegistration {
         try {
             parsed = Integer.parseInt(value);
         } catch (NumberFormatException e) {
-            net.minecraft.text.Text base = net.minecraft.text.Text.literal("[RevivalPlus] Timer value must be a number. Click to fix: ")
-                    .formatted(net.minecraft.util.Formatting.RED);
-            net.minecraft.text.Text interactive = net.minecraft.text.Text.literal("/revivalconfig timer " + key + " ")
-                    .styled(style -> style.withColor(net.minecraft.util.Formatting.GRAY)
+            Text base = Text.literal("[RevivalPlus] Timer value must be a number. Click to fix: ")
+                    .formatted(Formatting.RED);
+            Text interactive = Text.literal("/revivalconfig timer " + key + " ")
+                    .styled(style -> style.withColor(Formatting.GRAY)
                             .withClickEvent(new net.minecraft.text.ClickEvent(net.minecraft.text.ClickEvent.Action.SUGGEST_COMMAND, "/revivalconfig timer " + key + " "))
-                            .withHoverEvent(new net.minecraft.text.HoverEvent(net.minecraft.text.HoverEvent.Action.SHOW_TEXT, net.minecraft.text.Text.literal("Click to auto-fill this command").formatted(net.minecraft.util.Formatting.GRAY)))
+                            .withHoverEvent(new net.minecraft.text.HoverEvent(net.minecraft.text.HoverEvent.Action.SHOW_TEXT, Text.literal("Click to auto-fill this command").formatted(Formatting.GRAY)))
                     );
-            source.sendMessage(base.copy().append(interactive));
+            source.sendMessage(base.append(interactive));
             return 0;
         }
         setTimer(key, parsed);

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
@@ -350,7 +350,14 @@ public final class DlcCommandRegistration {
         try {
             parsed = Integer.parseInt(value);
         } catch (NumberFormatException e) {
-            sendResult(source, DlcCommandResult.fail("Timer value must be a number."));
+            net.minecraft.text.Text base = net.minecraft.text.Text.literal("[RevivalPlus] Timer value must be a number. Click to fix: ")
+                    .formatted(net.minecraft.util.Formatting.RED);
+            net.minecraft.text.Text interactive = net.minecraft.text.Text.literal("/revivalconfig timer " + key + " ")
+                    .styled(style -> style.withColor(net.minecraft.util.Formatting.GRAY)
+                            .withClickEvent(new net.minecraft.text.ClickEvent(net.minecraft.text.ClickEvent.Action.SUGGEST_COMMAND, "/revivalconfig timer " + key + " "))
+                            .withHoverEvent(new net.minecraft.text.HoverEvent(net.minecraft.text.HoverEvent.Action.SHOW_TEXT, net.minecraft.text.Text.literal("Click to auto-fill this command").formatted(net.minecraft.util.Formatting.GRAY)))
+                    );
+            source.sendMessage(base.copy().append(interactive));
             return 0;
         }
         setTimer(key, parsed);

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
@@ -353,7 +353,15 @@ public final class DlcCommandRegistration {
         try {
             parsed = Integer.parseInt(value);
         } catch (NumberFormatException e) {
-            sendResult(source, DlcCommandResult.fail("Timer value must be a number."));
+            net.minecraft.network.chat.Component interactive = net.minecraft.network.chat.Component.literal("/revivalconfig timer " + key + " ")
+                    .withStyle(style -> style.withColor(net.minecraft.ChatFormatting.GRAY)
+                            .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/revivalconfig timer " + key + " "))
+                            .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, net.minecraft.network.chat.Component.literal("Click to auto-fill this command").withStyle(net.minecraft.ChatFormatting.GRAY)))
+                    );
+            net.minecraft.network.chat.MutableComponent mutableBase = net.minecraft.network.chat.Component.literal("[RevivalPlus] Timer value must be a number. Click to fix: ")
+                    .withStyle(net.minecraft.ChatFormatting.RED);
+            mutableBase.append(interactive);
+            source.sendSystemMessage(mutableBase);
             return 0;
         }
         setTimer(key, parsed);

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
@@ -353,15 +353,15 @@ public final class DlcCommandRegistration {
         try {
             parsed = Integer.parseInt(value);
         } catch (NumberFormatException e) {
-            net.minecraft.network.chat.Component interactive = net.minecraft.network.chat.Component.literal("/revivalconfig timer " + key + " ")
-                    .withStyle(style -> style.withColor(net.minecraft.ChatFormatting.GRAY)
-                            .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/revivalconfig timer " + key + " "))
-                            .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, net.minecraft.network.chat.Component.literal("Click to auto-fill this command").withStyle(net.minecraft.ChatFormatting.GRAY)))
+            Component interactive = Component.literal("/revivalconfig timer " + key + " ")
+                    .withStyle(style -> style.withColor(ChatFormatting.GRAY)
+                            .withClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/revivalconfig timer " + key + " "))
+                            .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal("Click to auto-fill this command").withStyle(ChatFormatting.GRAY)))
                     );
-            net.minecraft.network.chat.MutableComponent mutableBase = net.minecraft.network.chat.Component.literal("[RevivalPlus] Timer value must be a number. Click to fix: ")
-                    .withStyle(net.minecraft.ChatFormatting.RED);
-            mutableBase.append(interactive);
-            source.sendSystemMessage(mutableBase);
+            Component message = Component.literal("[RevivalPlus] Timer value must be a number. Click to fix: ")
+                    .withStyle(ChatFormatting.RED)
+                    .append(interactive);
+            source.sendSystemMessage(message);
             return 0;
         }
         setTimer(key, parsed);

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
@@ -353,7 +353,15 @@ public final class DlcCommandRegistration {
         try {
             parsed = Integer.parseInt(value);
         } catch (NumberFormatException e) {
-            sendResult(source, DlcCommandResult.fail("Timer value must be a number."));
+            net.minecraft.network.chat.Component interactive = net.minecraft.network.chat.Component.literal("/revivalconfig timer " + key + " ")
+                    .withStyle(style -> style.withColor(net.minecraft.ChatFormatting.GRAY)
+                            .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/revivalconfig timer " + key + " "))
+                            .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, net.minecraft.network.chat.Component.literal("Click to auto-fill this command").withStyle(net.minecraft.ChatFormatting.GRAY)))
+                    );
+            net.minecraft.network.chat.MutableComponent mutableBase = net.minecraft.network.chat.Component.literal("[RevivalPlus] Timer value must be a number. Click to fix: ")
+                    .withStyle(net.minecraft.ChatFormatting.RED);
+            mutableBase.append(interactive);
+            source.sendSystemMessage(mutableBase);
             return 0;
         }
         setTimer(key, parsed);

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
@@ -353,15 +353,15 @@ public final class DlcCommandRegistration {
         try {
             parsed = Integer.parseInt(value);
         } catch (NumberFormatException e) {
-            net.minecraft.network.chat.Component interactive = net.minecraft.network.chat.Component.literal("/revivalconfig timer " + key + " ")
-                    .withStyle(style -> style.withColor(net.minecraft.ChatFormatting.GRAY)
-                            .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/revivalconfig timer " + key + " "))
-                            .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, net.minecraft.network.chat.Component.literal("Click to auto-fill this command").withStyle(net.minecraft.ChatFormatting.GRAY)))
+            Component interactive = Component.literal("/revivalconfig timer " + key + " ")
+                    .withStyle(style -> style.withColor(ChatFormatting.GRAY)
+                            .withClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/revivalconfig timer " + key + " "))
+                            .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal("Click to auto-fill this command").withStyle(ChatFormatting.GRAY)))
                     );
-            net.minecraft.network.chat.MutableComponent mutableBase = net.minecraft.network.chat.Component.literal("[RevivalPlus] Timer value must be a number. Click to fix: ")
-                    .withStyle(net.minecraft.ChatFormatting.RED);
-            mutableBase.append(interactive);
-            source.sendSystemMessage(mutableBase);
+            Component message = Component.literal("[RevivalPlus] Timer value must be a number. Click to fix: ")
+                    .withStyle(ChatFormatting.RED)
+                    .append(interactive);
+            source.sendSystemMessage(message);
             return 0;
         }
         setTimer(key, parsed);


### PR DESCRIPTION
* 💡 What: The RPConfigTimer command now returns an interactive error message when users input invalid number formats, allowing them to click and auto-fill the command prefix for easier correction.
* 🔗 Origin: Ported from Paper PR #306 (commit 5745707d).
* 🛠️ Translation: Replaced the static string in `DlcCommandRegistration.executeTimerConfig` with natively built `Component`/`Text` objects with `ClickEvent` and `HoverEvent`.
* 🔬 Verification: Test `/revivalconfig timer revive-resistance-ticks hello` on Forge, NeoForge, and Fabric.

---
*PR created automatically by Jules for task [9593381198530693245](https://jules.google.com/task/9593381198530693245) started by @SSoggyTacoMan*