### PR TITLE
📦 Porter: Optimize DlcNames to prevent redundant disk I/O ported to Paper

### DIFF
--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/GAMEMODESENUM.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/GAMEMODESENUM.java
@@ -88,8 +88,7 @@ public enum GAMEMODESENUM {
                 yield storage.hasValue(gmTable, uuid) ? (byte)1 : (byte)0;
             }
             default -> {
-                if (storage.hasValue(gmTable, uuid)) {
-                    storage.setValue(gmTable, uuid, null);
+                if (storage.setValueIfChanged(gmTable, uuid, null)) {
                     storage.saveConfig();
                 }
                 yield player.getGameMode() == gm.fallback ? (byte) 1 : (byte) 0;

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/BlockEvents.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/listener/BlockEvents.java
@@ -115,10 +115,12 @@ public class BlockEvents implements Listener {
                 RPStatic.DEAD_STORAGE.removeValue(uuidString, KEY_DEATHHOLDER);
                 RPStatic.DEAD_HOLDERS.remove(uuid);
                 RPStatic.DEAD_LOCATIONS.put(uuid, Pair.of(location, now));
-                RPStatic.DEAD_STORAGE.setValue(uuidString, KEY_DEATHPOS,
+                boolean changed = RPStatic.DEAD_STORAGE.setValueIfChanged(uuidString, KEY_DEATHPOS,
                         location.getBlockX() + "$" + location.getBlockY() + "$" + location.getBlockZ() + "$" + world.getName());
-                RPStatic.DEAD_STORAGE.setValue(uuidString, KEY_DEATHTIME, now.toString());
-                RPStatic.DEAD_STORAGE.saveConfig();
+                changed |= RPStatic.DEAD_STORAGE.setValueIfChanged(uuidString, KEY_DEATHTIME, now.toString());
+                if (changed) {
+                    RPStatic.DEAD_STORAGE.saveConfig();
+                }
             }, 1L);
 
         }


### PR DESCRIPTION
💡 What: Optimized DlcStorage redundant disk I/O
🔗 Origin: PR #310
🛠️ Translation: Ported `setValueIfChanged` disk IO check logic from `common/` (DlcNames) to equivalent areas in `paper/` (`BlockEvents` and `GAMEMODESENUM`) where `RPStorage` synchronously saves to disk.
🔬 Verification: Ran tests via `./gradlew test` to ensure no syntax errors.

---
*PR created automatically by Jules for task [973462536061130553](https://jules.google.com/task/973462536061130553) started by @SSoggyTacoMan*