### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Information Disclosure in Error Messages

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -15,3 +15,7 @@
 **Vulnerability:** In `ServerTransferUtil` across `fabric`, `forge`, and `neoforge` modules, `new byte[buf.readableBytes()]` was being called when decoding a custom network payload. A malicious client could send an extremely large payload length, causing the server to allocate a massive byte array and crash with an OutOfMemoryError.
 **Learning:** `buf.readableBytes()` is user-controlled input when decoding packets and must be explicitly validated against a sane maximum limit before being used for memory allocation.
 **Prevention:** Always enforce a strict maximum length (e.g., 1024 bytes) when reading variable-length data structures from network buffers before allocating memory.
+## 2026-06-10 - [Prevent sensitive file path exposure in error messages]
+**Vulnerability:** In `CommandRegistration.java` across `fabric`, `forge`, and `neoforge` modules, if an `IOException` occurred when reading the admin log file, the exception message (which includes the absolute file path) was concatenated and sent directly to the command sender. This exposes internal server directory structures to users.
+**Learning:** Sending raw exception messages (like `e.getMessage()`) to user-facing outputs can leak sensitive information such as absolute file paths, database schemas, or infrastructure details.
+**Prevention:** Catch the exception, log the full exception details safely to the server console (using `LOGGER.error`), and send only a generic error message (e.g., "Error reading admin log. Check console for details.") back to the user.

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -226,7 +226,8 @@ public class CommandRegistration {
                             }
                         });
                     } catch (java.io.IOException e) {
-                        source.getServer().execute(() -> source.sendError(net.minecraft.text.Text.literal("Error reading admin log: " + e.getMessage())));
+                        SSoggySoulsMod.LOGGER.error("Error reading admin log", e);
+                        source.getServer().execute(() -> source.sendError(net.minecraft.text.Text.literal("Error reading admin log. Check console for details.")));
                     }
                 });
 

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -227,7 +227,7 @@ public class CommandRegistration {
                         });
                     } catch (java.io.IOException e) {
                         SSoggySoulsMod.LOGGER.error("Error reading admin log", e);
-                        source.getServer().execute(() -> source.sendError(net.minecraft.text.Text.literal("Error reading admin log. Check console for details.")));
+                        source.getServer().execute(() -> source.sendError(MessageUtil.get("admin-log-read-error")));
                     }
                 });
 

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -246,7 +246,8 @@ public class CommandRegistration {
                             }
                         });
                     } catch (java.io.IOException e) {
-                        source.getServer().execute(() -> source.sendFailure(Component.literal("Error reading admin log: " + e.getMessage())));
+                        SSoggySoulsMod.LOGGER.error("Error reading admin log", e);
+                        source.getServer().execute(() -> source.sendFailure(Component.literal("Error reading admin log. Check console for details.")));
                     }
                 });
 

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -247,7 +247,7 @@ public class CommandRegistration {
                         });
                     } catch (java.io.IOException e) {
                         SSoggySoulsMod.LOGGER.error("Error reading admin log", e);
-                        source.getServer().execute(() -> source.sendFailure(Component.literal("Error reading admin log. Check console for details.")));
+                        source.getServer().execute(() -> source.sendFailure(MessageUtil.get("admin-log-read-error")));
                     }
                 });
 

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -247,7 +247,8 @@ public class CommandRegistration {
                             }
                         });
                     } catch (java.io.IOException e) {
-                        source.getServer().execute(() -> source.sendFailure(Component.literal("Error reading admin log: " + e.getMessage())));
+                        SSoggySoulsMod.LOGGER.error("Error reading admin log", e);
+                        source.getServer().execute(() -> source.sendFailure(Component.literal("Error reading admin log. Check console for details.")));
                     }
                 });
 

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -248,7 +248,7 @@ public class CommandRegistration {
                         });
                     } catch (java.io.IOException e) {
                         SSoggySoulsMod.LOGGER.error("Error reading admin log", e);
-                        source.getServer().execute(() -> source.sendFailure(Component.literal("Error reading admin log. Check console for details.")));
+                        source.getServer().execute(() -> source.sendFailure(MessageUtil.get("admin-log-read-error")));
                     }
                 });
 


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix Information Disclosure in Error Messages

🚨 **Severity**: MEDIUM
💡 **Vulnerability**: Information Disclosure. When the `/adminlog` command encounters an `IOException` while trying to read the log file, it sends the raw exception message (`e.getMessage()`) directly to the user's chat. `IOException` messages often include the absolute file path of the server file system (e.g., `/home/pterodactyl/server/config/ssoggysouls/admin.log`), which leaks sensitive internal server infrastructure details.
🎯 **Impact**: Malicious users with the `adminlog` permission could gain knowledge of the exact folder structure and username of the machine hosting the Minecraft server.
🔧 **Fix**: Updated `CommandRegistration.java` in the Fabric, Forge, and NeoForge modules. The exception is now safely logged to the server console via `SSoggySoulsMod.LOGGER.error()`, while a generic, safe error message is sent to the user's chat.
✅ **Verification**: Run `./gradlew :common:cleanTest :common:test` to verify code compiles and tests pass. Tested via code review and manual inspection. Added critical learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [7741394308067363660](https://jules.google.com/task/7741394308067363660) started by @SSoggyTacoMan*