### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Empty Database Password Allowance

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -19,3 +19,7 @@
 **Vulnerability:** In `CommandRegistration.java` across `fabric`, `forge`, and `neoforge` modules, if an `IOException` occurred when reading the admin log file, the exception message (which includes the absolute file path) was concatenated and sent directly to the command sender. This exposes internal server directory structures to users.
 **Learning:** Sending raw exception messages (like `e.getMessage()`) to user-facing outputs can leak sensitive information such as absolute file paths, database schemas, or infrastructure details.
 **Prevention:** Catch the exception, log the full exception details safely to the server console (using `LOGGER.error`), and send only a generic error message (e.g., "Error reading admin log. Check console for details.") back to the user.
+## 2024-03-20 - [Hardcoded Database Password Exposure]
+**Vulnerability:** MySQL configuration defaults with empty or default passwords in code/documentation.
+**Learning:** Default configurations can lead to insecure deployments if users don't change them.
+**Prevention:** Ensure configurations force explicit password setup or use environment variables, and avoid hardcoding fallback passwords.

--- a/common/src/main/java/org/ssoggy/ssoggysouls/database/MySQLManager.java
+++ b/common/src/main/java/org/ssoggy/ssoggysouls/database/MySQLManager.java
@@ -49,7 +49,8 @@ public class MySQLManager extends AbstractDatabaseManager {
             String user = plugin.getConfigString("database.username", "minecraft");
             String pass = plugin.getConfigString("database.password", "");
             if (pass.isEmpty()) {
-                plugin.getLogger().log(Level.WARNING, "Database password is empty. Running MySQL without a password is highly insecure in production environments.");
+                plugin.getLogger().log(Level.SEVERE, "Database password cannot be empty. Running MySQL without a password is not allowed.");
+                throw new DatabaseInitializationException("MySQL database password is empty in config.");
             }
             int poolSize = plugin.getConfigInt("database.pool-size", 5);
             String configuredTableName = plugin.getConfigString("database.table-name", "hardcore_players");


### PR DESCRIPTION
## 🛡️ Sentinel: [CRITICAL] Fix Empty Database Password Allowance

🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The plugin previously allowed MySQL initialization to proceed with an empty password, logging only a soft warning. This allowed potentially insecure configurations in production environments.
🎯 **Impact:** If unaddressed, this misconfiguration could lead to database exposure, allowing unauthorized access or modification to the hardcore lives and player data.
🔧 **Fix:** Upgraded the empty password check in `MySQLManager` from a `WARNING` log to a `SEVERE` log and enforced it by throwing a `DatabaseInitializationException`. This ensures the plugin fails securely and prevents startup when configured with an insecure database password.
✅ **Verification:** Running the server with `database.type: mysql` and an empty `database.password` will now halt the initialization instead of silently allowing it. All tests successfully run and pass.

---
*PR created automatically by Jules for task [10771231641984992096](https://jules.google.com/task/10771231641984992096) started by @SSoggyTacoMan*