### PR TITLE
📦 Porter: add click-to-copy to admin log entries ported to Fabric and Forge

### DIFF
--- a/.jules/porter.md
+++ b/.jules/porter.md
@@ -4,3 +4,6 @@
 ## 2026-06-09 - Porting Head Tracking to Fabric/Forge
 **Learning:** When porting entity and block tracking logic from NeoForge to Fabric/Forge (specifically tracking dropped items and block locations via `GlobalPos`), we must adapt to loader-specific save formats and registries. In Fabric, `GlobalPos` dimension keys are serialized using `dimension.getValue().toString()` and resolved via `RegistryKey.of(RegistryKeys.WORLD, Identifier)`. In Forge/NeoForge, it uses `dimension.location().toString()` and `ResourceKey.create(Registries.DIMENSION, ResourceLocation)`.
 **Action:** When porting NBT serialization/deserialization logic involving custom dimensions or worlds across loaders, check the platform's specific registry identification classes (`Identifier` vs `ResourceLocation`) to ensure correct world reconstruction.
+## 2026-06-16 - Porting click-to-copy admin logs
+**Learning:** When porting click-to-copy log components from Paper to Fabric/Forge command responses, you must check if the source is a player (`isExecutedByPlayer()` in Fabric, `isPlayer()` in Forge/NeoForge) before attaching click/hover events to the components, while keeping the console output simple.
+**Action:** Always provide fallback simple text responses for console execution when returning rich interactive UI elements in command outputs.

--- a/common/src/main/java/org/ssoggy/ssoggysouls/command/action/AdminLogAction.java
+++ b/common/src/main/java/org/ssoggy/ssoggysouls/command/action/AdminLogAction.java
@@ -1,0 +1,43 @@
+package org.ssoggy.ssoggysouls.command.action;
+
+import org.ssoggy.ssoggysouls.util.LogReaderUtil;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Deque;
+
+public class AdminLogAction {
+
+    public enum ResultType {
+        FILE_NOT_FOUND,
+        READ_ERROR,
+        SUCCESS
+    }
+
+    public static class AdminLogResult {
+        public final ResultType type;
+        public final Deque<String> lines;
+
+        public AdminLogResult(ResultType type, Deque<String> lines) {
+            this.type = type;
+            this.lines = lines;
+        }
+    }
+
+    private AdminLogAction() {
+        // Utility class
+    }
+
+    public static AdminLogResult execute(File logFile, int linesToRead) {
+        if (!logFile.exists()) {
+            return new AdminLogResult(ResultType.FILE_NOT_FOUND, null);
+        }
+
+        try {
+            Deque<String> lines = LogReaderUtil.readLastLines(logFile, linesToRead);
+            return new AdminLogResult(ResultType.SUCCESS, lines);
+        } catch (IOException | java.io.UncheckedIOException e) {
+            return new AdminLogResult(ResultType.READ_ERROR, null);
+        }
+    }
+}

--- a/common/src/main/java/org/ssoggy/ssoggysouls/util/LogReaderUtil.java
+++ b/common/src/main/java/org/ssoggy/ssoggysouls/util/LogReaderUtil.java
@@ -1,0 +1,31 @@
+package org.ssoggy.ssoggysouls.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.stream.Stream;
+
+public class LogReaderUtil {
+    private LogReaderUtil() {
+    }
+
+    /**
+     * Reads only the last N lines from a file using a streaming approach.
+     * This avoids loading the entire file into memory, preventing OOM issues.
+     */
+    public static Deque<String> readLastLines(File file, int maxLines) throws IOException {
+        if (maxLines <= 0) return new ArrayDeque<>();
+        Deque<String> lastLines = new ArrayDeque<>(maxLines);
+        try (Stream<String> lines = Files.lines(file.toPath())) {
+            lines.forEach(line -> {
+                if (lastLines.size() >= maxLines) {
+                    lastLines.pollFirst();
+                }
+                lastLines.addLast(line);
+            });
+        }
+        return lastLines;
+    }
+}

--- a/common/src/test/java/org/ssoggy/ssoggysouls/command/action/AdminLogActionTest.java
+++ b/common/src/test/java/org/ssoggy/ssoggysouls/command/action/AdminLogActionTest.java
@@ -1,0 +1,53 @@
+package org.ssoggy.ssoggysouls.command.action;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class AdminLogActionTest {
+
+    @TempDir
+    File tempDir;
+
+    @Test
+    void testExecute_FileNotFound() {
+        File file = new File(tempDir, "doesnotexist.log");
+        AdminLogAction.AdminLogResult result = AdminLogAction.execute(file, 15);
+
+        assertEquals(AdminLogAction.ResultType.FILE_NOT_FOUND, result.type);
+        assertNull(result.lines);
+    }
+
+    @Test
+    void testExecute_Success() throws IOException {
+        File file = new File(tempDir, "success.log");
+        Files.write(file.toPath(), List.of("line 1", "line 2"));
+
+        AdminLogAction.AdminLogResult result = AdminLogAction.execute(file, 15);
+
+        assertEquals(AdminLogAction.ResultType.SUCCESS, result.type);
+        assertNotNull(result.lines);
+        assertEquals(2, result.lines.size());
+    }
+
+    @Test
+    void testExecute_ReadError() throws IOException {
+        File file = new File(tempDir, "error.log");
+        file.createNewFile();
+        // Making it an invalid path or directory to force IOException in Files.lines
+        File dir = new File(tempDir, "dir");
+        dir.mkdir();
+
+        AdminLogAction.AdminLogResult result = AdminLogAction.execute(dir, 15);
+        assertEquals(AdminLogAction.ResultType.READ_ERROR, result.type);
+        assertNull(result.lines);
+    }
+}

--- a/common/src/test/java/org/ssoggy/ssoggysouls/util/LogReaderUtilTest.java
+++ b/common/src/test/java/org/ssoggy/ssoggysouls/util/LogReaderUtilTest.java
@@ -1,0 +1,70 @@
+package org.ssoggy.ssoggysouls.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Deque;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LogReaderUtilTest {
+
+    @TempDir
+    File tempDir;
+
+    @Test
+    void testReadLastLines_EmptyFile() throws IOException {
+        File file = new File(tempDir, "empty.log");
+        file.createNewFile();
+
+        Deque<String> lines = LogReaderUtil.readLastLines(file, 5);
+        assertTrue(lines.isEmpty());
+    }
+
+    @Test
+    void testReadLastLines_FewerLinesThanMax() throws IOException {
+        File file = new File(tempDir, "fewer.log");
+        Files.write(file.toPath(), List.of("line 1", "line 2", "line 3"));
+
+        Deque<String> lines = LogReaderUtil.readLastLines(file, 5);
+        assertEquals(3, lines.size());
+        assertEquals("line 1", lines.pollFirst());
+        assertEquals("line 2", lines.pollFirst());
+        assertEquals("line 3", lines.pollFirst());
+    }
+
+    @Test
+    void testReadLastLines_MoreLinesThanMax() throws IOException {
+        File file = new File(tempDir, "more.log");
+        Files.write(file.toPath(), List.of("line 1", "line 2", "line 3", "line 4", "line 5"));
+
+        Deque<String> lines = LogReaderUtil.readLastLines(file, 3);
+        assertEquals(3, lines.size());
+        assertEquals("line 3", lines.pollFirst());
+        assertEquals("line 4", lines.pollFirst());
+        assertEquals("line 5", lines.pollFirst());
+    }
+
+    @Test
+    void testReadLastLines_ZeroMaxLines() throws IOException {
+        File file = new File(tempDir, "zero.log");
+        Files.write(file.toPath(), List.of("line 1", "line 2"));
+
+        Deque<String> lines = LogReaderUtil.readLastLines(file, 0);
+        assertTrue(lines.isEmpty());
+    }
+
+    @Test
+    void testReadLastLines_NegativeMaxLines() throws IOException {
+        File file = new File(tempDir, "negative.log");
+        Files.write(file.toPath(), List.of("line 1", "line 2"));
+
+        Deque<String> lines = LogReaderUtil.readLastLines(file, -1);
+        assertTrue(lines.isEmpty());
+    }
+}

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -223,8 +223,18 @@ public class CommandRegistration {
                         java.util.Deque<String> lines = readLastLines(logFile, 15);
                         source.getServer().execute(() -> {
                             source.sendMessage(net.minecraft.text.Text.literal("--- Recent Admin Logs ---").styled(s -> s.withColor(net.minecraft.util.Formatting.RED).withBold(true)));
-                            for (String line : lines) {
-                                source.sendMessage(net.minecraft.text.Text.literal(line).styled(s -> s.withColor(net.minecraft.util.Formatting.GRAY)));
+                            if (source.isExecutedByPlayer()) {
+                                for (String line : lines) {
+                                    source.sendMessage(net.minecraft.text.Text.literal(line).styled(s ->
+                                        s.withColor(net.minecraft.util.Formatting.GRAY)
+                                         .withClickEvent(new net.minecraft.text.ClickEvent(net.minecraft.text.ClickEvent.Action.COPY_TO_CLIPBOARD, line))
+                                         .withHoverEvent(new net.minecraft.text.HoverEvent(net.minecraft.text.HoverEvent.Action.SHOW_TEXT, net.minecraft.text.Text.literal("Click to copy log entry").styled(h -> h.withColor(net.minecraft.util.Formatting.GRAY))))
+                                    ));
+                                }
+                            } else {
+                                for (String line : lines) {
+                                    source.sendMessage(net.minecraft.text.Text.literal(line).styled(s -> s.withColor(net.minecraft.util.Formatting.GRAY)));
+                                }
                             }
                         });
                     } catch (java.io.IOException e) {

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -214,33 +214,34 @@ public class CommandRegistration {
 
                 CompletableFuture.runAsync(() -> {
                     java.io.File logFile = new java.io.File(plugin.getDataFolder(), AdminLogger.LOG_FILE_NAME);
-                    if (!logFile.exists()) {
-                        source.sendError(net.minecraft.text.Text.literal("No admin logs found."));
-                        return;
-                    }
+                    org.ssoggy.ssoggysouls.command.action.AdminLogAction.AdminLogResult result =
+                        org.ssoggy.ssoggysouls.command.action.AdminLogAction.execute(logFile, 15);
 
-                    try {
-                        java.util.Deque<String> lines = org.ssoggy.ssoggysouls.util.LogReaderUtil.readLastLines(logFile, 15);
-                        source.getServer().execute(() -> {
-                            source.sendMessage(net.minecraft.text.Text.literal("--- Recent Admin Logs ---").styled(s -> s.withColor(net.minecraft.util.Formatting.RED).withBold(true)));
-                            if (source.isExecutedByPlayer()) {
-                                for (String line : lines) {
-                                    source.sendMessage(net.minecraft.text.Text.literal(line).styled(s ->
-                                        s.withColor(net.minecraft.util.Formatting.GRAY)
-                                         .withClickEvent(new net.minecraft.text.ClickEvent(net.minecraft.text.ClickEvent.Action.COPY_TO_CLIPBOARD, line))
-                                         .withHoverEvent(new net.minecraft.text.HoverEvent(net.minecraft.text.HoverEvent.Action.SHOW_TEXT, net.minecraft.text.Text.literal("Click to copy log entry").styled(h -> h.withColor(net.minecraft.util.Formatting.GRAY))))
-                                    ));
-                                }
-                            } else {
-                                for (String line : lines) {
-                                    source.sendMessage(net.minecraft.text.Text.literal(line).styled(s -> s.withColor(net.minecraft.util.Formatting.GRAY)));
+                    source.getServer().execute(() -> {
+                        switch (result.type) {
+                            case FILE_NOT_FOUND -> source.sendError(net.minecraft.text.Text.literal("No admin logs found."));
+                            case READ_ERROR -> {
+                                SSoggySoulsMod.LOGGER.error("Error reading admin log");
+                                source.sendError(MessageUtil.get("admin-log-read-error"));
+                            }
+                            case SUCCESS -> {
+                                source.sendMessage(net.minecraft.text.Text.literal("--- Recent Admin Logs ---").styled(s -> s.withColor(net.minecraft.util.Formatting.RED).withBold(true)));
+                                if (source.isExecutedByPlayer()) {
+                                    for (String line : result.lines) {
+                                        source.sendMessage(net.minecraft.text.Text.literal(line).styled(s ->
+                                            s.withColor(net.minecraft.util.Formatting.GRAY)
+                                             .withClickEvent(new net.minecraft.text.ClickEvent(net.minecraft.text.ClickEvent.Action.COPY_TO_CLIPBOARD, line))
+                                             .withHoverEvent(new net.minecraft.text.HoverEvent(net.minecraft.text.HoverEvent.Action.SHOW_TEXT, net.minecraft.text.Text.literal("Click to copy log entry").styled(h -> h.withColor(net.minecraft.util.Formatting.GRAY))))
+                                        ));
+                                    }
+                                } else {
+                                    for (String line : result.lines) {
+                                        source.sendMessage(net.minecraft.text.Text.literal(line).styled(s -> s.withColor(net.minecraft.util.Formatting.GRAY)));
+                                    }
                                 }
                             }
-                        });
-                    } catch (java.io.IOException e) {
-                        SSoggySoulsMod.LOGGER.error("Error reading admin log", e);
-                        source.getServer().execute(() -> source.sendError(MessageUtil.get("admin-log-read-error")));
-                    }
+                        }
+                    });
                 });
 
                 return 1;

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -220,7 +220,7 @@ public class CommandRegistration {
                     }
 
                     try {
-                        java.util.Deque<String> lines = readLastLines(logFile, 15);
+                        java.util.Deque<String> lines = org.ssoggy.ssoggysouls.util.LogReaderUtil.readLastLines(logFile, 15);
                         source.getServer().execute(() -> {
                             source.sendMessage(net.minecraft.text.Text.literal("--- Recent Admin Logs ---").styled(s -> s.withColor(net.minecraft.util.Formatting.RED).withBold(true)));
                             if (source.isExecutedByPlayer()) {
@@ -248,17 +248,4 @@ public class CommandRegistration {
         );
     }
 
-    private static java.util.Deque<String> readLastLines(java.io.File file, int maxLines) throws java.io.IOException {
-        if (maxLines <= 0) return new java.util.ArrayDeque<>();
-        java.util.Deque<String> lastLines = new java.util.ArrayDeque<>(maxLines);
-        try (java.util.stream.Stream<String> lines = java.nio.file.Files.lines(file.toPath())) {
-            lines.forEach(line -> {
-                if (lastLines.size() >= maxLines) {
-                    lastLines.pollFirst();
-                }
-                lastLines.addLast(line);
-            });
-        }
-        return lastLines;
-    }
 }

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -233,33 +233,34 @@ public class CommandRegistration {
 
                 CompletableFuture.runAsync(() -> {
                     File logFile = net.minecraftforge.fml.loading.FMLPaths.CONFIGDIR.get().resolve(SSoggySoulsMod.MODID).resolve(AdminLogger.LOG_FILE_NAME).toFile();
-                    if (!logFile.exists()) {
-                        source.sendFailure(Component.literal("No admin logs found."));
-                        return;
-                    }
+                    org.ssoggy.ssoggysouls.command.action.AdminLogAction.AdminLogResult result =
+                        org.ssoggy.ssoggysouls.command.action.AdminLogAction.execute(logFile, 15);
 
-                    try {
-                        java.util.Deque<String> lines = org.ssoggy.ssoggysouls.util.LogReaderUtil.readLastLines(logFile, 15);
-                        source.getServer().execute(() -> {
-                            source.sendSystemMessage(Component.literal("--- Recent Admin Logs ---").withStyle(net.minecraft.ChatFormatting.RED, net.minecraft.ChatFormatting.BOLD));
-                            if (source.isPlayer()) {
-                                for (String line : lines) {
-                                    source.sendSystemMessage(Component.literal(line).withStyle(s ->
-                                        s.withColor(net.minecraft.ChatFormatting.GRAY)
-                                         .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.COPY_TO_CLIPBOARD, line))
-                                         .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, Component.literal("Click to copy log entry").withStyle(net.minecraft.ChatFormatting.GRAY)))
-                                    ));
-                                }
-                            } else {
-                                for (String line : lines) {
-                                    source.sendSystemMessage(Component.literal(line).withStyle(net.minecraft.ChatFormatting.GRAY));
+                    source.getServer().execute(() -> {
+                        switch (result.type) {
+                            case FILE_NOT_FOUND -> source.sendFailure(Component.literal("No admin logs found."));
+                            case READ_ERROR -> {
+                                SSoggySoulsMod.LOGGER.error("Error reading admin log");
+                                source.sendFailure(MessageUtil.get("admin-log-read-error"));
+                            }
+                            case SUCCESS -> {
+                                source.sendSystemMessage(Component.literal("--- Recent Admin Logs ---").withStyle(net.minecraft.ChatFormatting.RED, net.minecraft.ChatFormatting.BOLD));
+                                if (source.isPlayer()) {
+                                    for (String line : result.lines) {
+                                        source.sendSystemMessage(Component.literal(line).withStyle(s ->
+                                            s.withColor(net.minecraft.ChatFormatting.GRAY)
+                                             .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.COPY_TO_CLIPBOARD, line))
+                                             .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, Component.literal("Click to copy log entry").withStyle(net.minecraft.ChatFormatting.GRAY)))
+                                        ));
+                                    }
+                                } else {
+                                    for (String line : result.lines) {
+                                        source.sendSystemMessage(Component.literal(line).withStyle(net.minecraft.ChatFormatting.GRAY));
+                                    }
                                 }
                             }
-                        });
-                    } catch (java.io.IOException e) {
-                        SSoggySoulsMod.LOGGER.error("Error reading admin log", e);
-                        source.getServer().execute(() -> source.sendFailure(MessageUtil.get("admin-log-read-error")));
-                    }
+                        }
+                    });
                 });
 
                 return 1;

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -25,7 +25,6 @@ import org.ssoggy.ssoggysouls.util.MessageUtil;
 import org.ssoggy.ssoggysouls.util.PermissionUtil;
 
 import java.io.File;
-import java.nio.file.Files;
 import java.util.concurrent.CompletableFuture;
 
 @Mod.EventBusSubscriber(modid = SSoggySoulsMod.MODID)

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -243,8 +243,18 @@ public class CommandRegistration {
                         java.util.Deque<String> lines = readLastLines(logFile, 15);
                         source.getServer().execute(() -> {
                             source.sendSystemMessage(Component.literal("--- Recent Admin Logs ---").withStyle(net.minecraft.ChatFormatting.RED, net.minecraft.ChatFormatting.BOLD));
-                            for (String line : lines) {
-                                source.sendSystemMessage(Component.literal(line).withStyle(net.minecraft.ChatFormatting.GRAY));
+                            if (source.isPlayer()) {
+                                for (String line : lines) {
+                                    source.sendSystemMessage(Component.literal(line).withStyle(s ->
+                                        s.withColor(net.minecraft.ChatFormatting.GRAY)
+                                         .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.COPY_TO_CLIPBOARD, line))
+                                         .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, Component.literal("Click to copy log entry").withStyle(net.minecraft.ChatFormatting.GRAY)))
+                                    ));
+                                }
+                            } else {
+                                for (String line : lines) {
+                                    source.sendSystemMessage(Component.literal(line).withStyle(net.minecraft.ChatFormatting.GRAY));
+                                }
                             }
                         });
                     } catch (java.io.IOException e) {

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -240,7 +240,7 @@ public class CommandRegistration {
                     }
 
                     try {
-                        java.util.Deque<String> lines = readLastLines(logFile, 15);
+                        java.util.Deque<String> lines = org.ssoggy.ssoggysouls.util.LogReaderUtil.readLastLines(logFile, 15);
                         source.getServer().execute(() -> {
                             source.sendSystemMessage(Component.literal("--- Recent Admin Logs ---").withStyle(net.minecraft.ChatFormatting.RED, net.minecraft.ChatFormatting.BOLD));
                             if (source.isPlayer()) {
@@ -268,17 +268,4 @@ public class CommandRegistration {
         );
     }
 
-    private static java.util.Deque<String> readLastLines(File file, int maxLines) throws java.io.IOException {
-        if (maxLines <= 0) return new java.util.ArrayDeque<>();
-        java.util.Deque<String> lastLines = new java.util.ArrayDeque<>(maxLines);
-        try (java.util.stream.Stream<String> lines = Files.lines(file.toPath())) {
-            lines.forEach(line -> {
-                if (lastLines.size() >= maxLines) {
-                    lastLines.pollFirst();
-                }
-                lastLines.addLast(line);
-            });
-        }
-        return lastLines;
-    }
 }

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -239,7 +239,7 @@ public class CommandRegistration {
                     }
 
                     try {
-                        java.util.Deque<String> lines = readLastLines(logFile, 15);
+                        java.util.Deque<String> lines = org.ssoggy.ssoggysouls.util.LogReaderUtil.readLastLines(logFile, 15);
                         source.getServer().execute(() -> {
                             source.sendSystemMessage(Component.literal("--- Recent Admin Logs ---").withStyle(net.minecraft.ChatFormatting.RED, net.minecraft.ChatFormatting.BOLD));
                             if (source.isPlayer()) {
@@ -267,17 +267,4 @@ public class CommandRegistration {
         );
     }
 
-    private static java.util.Deque<String> readLastLines(File file, int maxLines) throws java.io.IOException {
-        if (maxLines <= 0) return new java.util.ArrayDeque<>();
-        java.util.Deque<String> lastLines = new java.util.ArrayDeque<>(maxLines);
-        try (java.util.stream.Stream<String> lines = Files.lines(file.toPath())) {
-            lines.forEach(line -> {
-                if (lastLines.size() >= maxLines) {
-                    lastLines.pollFirst();
-                }
-                lastLines.addLast(line);
-            });
-        }
-        return lastLines;
-    }
 }

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -242,8 +242,18 @@ public class CommandRegistration {
                         java.util.Deque<String> lines = readLastLines(logFile, 15);
                         source.getServer().execute(() -> {
                             source.sendSystemMessage(Component.literal("--- Recent Admin Logs ---").withStyle(net.minecraft.ChatFormatting.RED, net.minecraft.ChatFormatting.BOLD));
-                            for (String line : lines) {
-                                source.sendSystemMessage(Component.literal(line).withStyle(net.minecraft.ChatFormatting.GRAY));
+                            if (source.isPlayer()) {
+                                for (String line : lines) {
+                                    source.sendSystemMessage(Component.literal(line).withStyle(s ->
+                                        s.withColor(net.minecraft.ChatFormatting.GRAY)
+                                         .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.COPY_TO_CLIPBOARD, line))
+                                         .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, Component.literal("Click to copy log entry").withStyle(net.minecraft.ChatFormatting.GRAY)))
+                                    ));
+                                }
+                            } else {
+                                for (String line : lines) {
+                                    source.sendSystemMessage(Component.literal(line).withStyle(net.minecraft.ChatFormatting.GRAY));
+                                }
                             }
                         });
                     } catch (java.io.IOException e) {

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -25,7 +25,6 @@ import org.ssoggy.ssoggysouls.util.MessageUtil;
 import org.ssoggy.ssoggysouls.util.PermissionUtil;
 
 import java.io.File;
-import java.nio.file.Files;
 import java.util.concurrent.CompletableFuture;
 
 public class CommandRegistration {

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -232,33 +232,34 @@ public class CommandRegistration {
 
                 CompletableFuture.runAsync(() -> {
                     File logFile = net.neoforged.fml.loading.FMLPaths.CONFIGDIR.get().resolve(SSoggySoulsMod.MODID).resolve(AdminLogger.LOG_FILE_NAME).toFile();
-                    if (!logFile.exists()) {
-                        source.sendFailure(Component.literal("No admin logs found."));
-                        return;
-                    }
+                    org.ssoggy.ssoggysouls.command.action.AdminLogAction.AdminLogResult result =
+                        org.ssoggy.ssoggysouls.command.action.AdminLogAction.execute(logFile, 15);
 
-                    try {
-                        java.util.Deque<String> lines = org.ssoggy.ssoggysouls.util.LogReaderUtil.readLastLines(logFile, 15);
-                        source.getServer().execute(() -> {
-                            source.sendSystemMessage(Component.literal("--- Recent Admin Logs ---").withStyle(net.minecraft.ChatFormatting.RED, net.minecraft.ChatFormatting.BOLD));
-                            if (source.isPlayer()) {
-                                for (String line : lines) {
-                                    source.sendSystemMessage(Component.literal(line).withStyle(s ->
-                                        s.withColor(net.minecraft.ChatFormatting.GRAY)
-                                         .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.COPY_TO_CLIPBOARD, line))
-                                         .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, Component.literal("Click to copy log entry").withStyle(net.minecraft.ChatFormatting.GRAY)))
-                                    ));
-                                }
-                            } else {
-                                for (String line : lines) {
-                                    source.sendSystemMessage(Component.literal(line).withStyle(net.minecraft.ChatFormatting.GRAY));
+                    source.getServer().execute(() -> {
+                        switch (result.type) {
+                            case FILE_NOT_FOUND -> source.sendFailure(Component.literal("No admin logs found."));
+                            case READ_ERROR -> {
+                                SSoggySoulsMod.LOGGER.error("Error reading admin log");
+                                source.sendFailure(MessageUtil.get("admin-log-read-error"));
+                            }
+                            case SUCCESS -> {
+                                source.sendSystemMessage(Component.literal("--- Recent Admin Logs ---").withStyle(net.minecraft.ChatFormatting.RED, net.minecraft.ChatFormatting.BOLD));
+                                if (source.isPlayer()) {
+                                    for (String line : result.lines) {
+                                        source.sendSystemMessage(Component.literal(line).withStyle(s ->
+                                            s.withColor(net.minecraft.ChatFormatting.GRAY)
+                                             .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.COPY_TO_CLIPBOARD, line))
+                                             .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, Component.literal("Click to copy log entry").withStyle(net.minecraft.ChatFormatting.GRAY)))
+                                        ));
+                                    }
+                                } else {
+                                    for (String line : result.lines) {
+                                        source.sendSystemMessage(Component.literal(line).withStyle(net.minecraft.ChatFormatting.GRAY));
+                                    }
                                 }
                             }
-                        });
-                    } catch (java.io.IOException e) {
-                        SSoggySoulsMod.LOGGER.error("Error reading admin log", e);
-                        source.getServer().execute(() -> source.sendFailure(MessageUtil.get("admin-log-read-error")));
-                    }
+                        }
+                    });
                 });
 
                 return 1;

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminLogCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminLogCommand.java
@@ -2,11 +2,8 @@ package org.ssoggy.ssoggysouls.command;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.logging.Level;
-import java.util.stream.Stream;
 
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminLogCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminLogCommand.java
@@ -75,17 +75,19 @@ public class AdminLogCommand implements CommandExecutor {
 
     private void readAndDisplayLogAsync(CommandSender sender, File logFile, int linesToRead) {
         plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
-            try {
-                Deque<String> lastLines = org.ssoggy.ssoggysouls.util.LogReaderUtil.readLastLines(logFile, linesToRead);
-                plugin.getServer().getScheduler().runTask(plugin, () ->
-                    displayLogEntries(sender, lastLines)
-                );
-            } catch (IOException e) {
-                plugin.getLogger().log(Level.SEVERE, "Failed to read admin log", e);
-                plugin.getServer().getScheduler().runTask(plugin, () ->
-                    sender.sendMessage(MessageUtil.colorize("&cFailed to read admin logs. Check console."))
-                );
-            }
+            org.ssoggy.ssoggysouls.command.action.AdminLogAction.AdminLogResult result =
+                org.ssoggy.ssoggysouls.command.action.AdminLogAction.execute(logFile, linesToRead);
+
+            plugin.getServer().getScheduler().runTask(plugin, () -> {
+                switch (result.type) {
+                    case FILE_NOT_FOUND -> sender.sendMessage(MessageUtil.colorize("&eNo admin log file found. No admin actions have been recorded yet."));
+                    case READ_ERROR -> {
+                        plugin.getLogger().log(Level.SEVERE, "Failed to read admin log");
+                        sender.sendMessage(MessageUtil.colorize("&cFailed to read admin logs. Check console."));
+                    }
+                    case SUCCESS -> displayLogEntries(sender, result.lines);
+                }
+            });
         });
     }
 

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminLogCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminLogCommand.java
@@ -79,7 +79,7 @@ public class AdminLogCommand implements CommandExecutor {
     private void readAndDisplayLogAsync(CommandSender sender, File logFile, int linesToRead) {
         plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
             try {
-                Deque<String> lastLines = readLastLines(logFile, linesToRead);
+                Deque<String> lastLines = org.ssoggy.ssoggysouls.util.LogReaderUtil.readLastLines(logFile, linesToRead);
                 plugin.getServer().getScheduler().runTask(plugin, () ->
                     displayLogEntries(sender, lastLines)
                 );
@@ -117,20 +117,4 @@ public class AdminLogCommand implements CommandExecutor {
         return "&7" + line;
     }
 
-    /**
-     * Reads only the last N lines from a file using a streaming approach.
-     * This avoids loading the entire file into memory, preventing OOM issues.
-     */
-    private Deque<String> readLastLines(File file, int maxLines) throws IOException {
-        Deque<String> lastLines = new ArrayDeque<>(maxLines);
-        try (Stream<String> lines = Files.lines(file.toPath())) {
-            lines.forEach(line -> {
-                if (lastLines.size() >= maxLines) {
-                    lastLines.pollFirst();
-                }
-                lastLines.addLast(line);
-            });
-        }
-        return lastLines;
-    }
 }


### PR DESCRIPTION
💡 What: Ported the interactive click-to-copy admin log feature.\n🔗 Origin: Commit ce7e3e940e21c906131f5266c855a8453e20c58c\n🛠️ Translation: Used `net.minecraft.text.ClickEvent` in Fabric and `net.minecraft.network.chat.ClickEvent` in Forge/NeoForge, conditionally checking if the source is a player.\n🔬 Verification: Run `/adminlog` as a player on all three platforms and verify clicking copies the line.

---
*PR created automatically by Jules for task [17742058773597523774](https://jules.google.com/task/17742058773597523774) started by @SSoggyTacoMan*