### PR TITLE
refactor(paper): 🎨 palette: interactive admin logs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -41,3 +41,6 @@
 ## 2024-06-14 - [Interactive CLI Base Command Errors]
 **Learning:** When users execute base commands with complex sub-argument trees (like `/revivalconfig`) without any arguments, standard static usage errors force them to completely retype the command. In Brigadier, the `.executes()` block on the literal node itself is the perfect place to inject interactive recovery.
 **Action:** Replace static `sendResult(..., fail("..."))` calls in base command `.executes()` blocks with native interactive components (`MutableComponent.append()`) containing `.withClickEvent(SUGGEST_COMMAND)` to instantly provide users with a pre-filled chat bar.
+## 2026-06-15 - [Interactive Admin Logs]
+**Learning:** Administrative logs printed via legacy `sender.sendMessage()` using basic text formatting require manual highlight-and-copy actions, adding friction for admins triaging issues. By wrapping lines in Kyori components via `LegacyComponentSerializer`, click-to-copy interactions can be seamlessly injected.
+**Action:** When printing log lines or status strings to chat, convert them into `net.kyori.adventure.text.Component` objects with `.clickEvent(ClickEvent.copyToClipboard())` and `.hoverEvent()` to create zero-friction workflows.

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminLogCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminLogCommand.java
@@ -97,7 +97,11 @@ public class AdminLogCommand implements CommandExecutor {
             sender.sendMessage(MessageUtil.colorize("&7(Empty)"));
         } else {
             for (String line : lastLines) {
-                sender.sendMessage(MessageUtil.colorize(formatLogLine(line)));
+                String formatted = formatLogLine(line);
+                net.kyori.adventure.text.Component component = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacyAmpersand().deserialize(formatted)
+                        .clickEvent(net.kyori.adventure.text.event.ClickEvent.copyToClipboard(line))
+                        .hoverEvent(net.kyori.adventure.text.event.HoverEvent.showText(net.kyori.adventure.text.Component.text("Click to copy log entry", net.kyori.adventure.text.format.NamedTextColor.GRAY)));
+                sender.sendMessage(component);
             }
         }
         sender.sendMessage(MessageUtil.colorize("&6&l══════════════════════"));


### PR DESCRIPTION
💡 What: Converted legacy plain text admin log entries into interactive Kyori Adventure Components with copy-to-clipboard functionality.
🎯 Why: Allows frictionless copying of log entries by server administrators without manual highlighting, reducing friction.
📸 Before/After: Visual presentation is identical but text is clickable.
♿ Accessibility: Improved ease of copying for users navigating logs.

---
*PR created automatically by Jules for task [16815967169135732718](https://jules.google.com/task/16815967169135732718) started by @SSoggyTacoMan*