### PR TITLE
🎨 Palette: Interactive Log Copying in AdminLogCommand

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -41,3 +41,6 @@
 ## 2024-06-14 - [Interactive CLI Base Command Errors]
 **Learning:** When users execute base commands with complex sub-argument trees (like `/revivalconfig`) without any arguments, standard static usage errors force them to completely retype the command. In Brigadier, the `.executes()` block on the literal node itself is the perfect place to inject interactive recovery.
 **Action:** Replace static `sendResult(..., fail("..."))` calls in base command `.executes()` blocks with native interactive components (`MutableComponent.append()`) containing `.withClickEvent(SUGGEST_COMMAND)` to instantly provide users with a pre-filled chat bar.
+## 2024-05-10 - [Interactive CLI Log Copying]
+**Learning:** Displaying administrative logs or records in chat via the Paper module as legacy colored text makes it difficult for users to copy them.
+**Action:** When displaying administrative logs or records in chat, convert legacy colored text into a Kyori Adventure `Component` with a `clickEvent` (`copyToClipboard`) and a `hoverEvent` to allow frictionless copying of log entries without manual highlighting.

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminLogCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminLogCommand.java
@@ -97,14 +97,14 @@ public class AdminLogCommand implements CommandExecutor {
             sender.sendMessage(MessageUtil.colorize("&7(Empty)"));
         } else {
             for (String line : lastLines) {
-                String formattedLine = MessageUtil.colorize(formatLogLine(line));
+                String rawFormatted = formatLogLine(line);
                 if (sender instanceof org.bukkit.entity.Player player) {
-                    net.kyori.adventure.text.Component interactiveLine = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(formattedLine)
+                    net.kyori.adventure.text.Component interactiveLine = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacyAmpersand().deserialize(rawFormatted)
                             .clickEvent(net.kyori.adventure.text.event.ClickEvent.copyToClipboard(line))
                             .hoverEvent(net.kyori.adventure.text.event.HoverEvent.showText(net.kyori.adventure.text.Component.text("Click to copy log entry", net.kyori.adventure.text.format.NamedTextColor.GRAY)));
                     player.sendMessage(interactiveLine);
                 } else {
-                    sender.sendMessage(formattedLine);
+                    sender.sendMessage(MessageUtil.colorize(rawFormatted));
                 }
             }
         }

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminLogCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminLogCommand.java
@@ -97,7 +97,15 @@ public class AdminLogCommand implements CommandExecutor {
             sender.sendMessage(MessageUtil.colorize("&7(Empty)"));
         } else {
             for (String line : lastLines) {
-                sender.sendMessage(MessageUtil.colorize(formatLogLine(line)));
+                String formattedLine = MessageUtil.colorize(formatLogLine(line));
+                if (sender instanceof org.bukkit.entity.Player player) {
+                    net.kyori.adventure.text.Component interactiveLine = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(formattedLine)
+                            .clickEvent(net.kyori.adventure.text.event.ClickEvent.copyToClipboard(line))
+                            .hoverEvent(net.kyori.adventure.text.event.HoverEvent.showText(net.kyori.adventure.text.Component.text("Click to copy log entry", net.kyori.adventure.text.format.NamedTextColor.GRAY)));
+                    player.sendMessage(interactiveLine);
+                } else {
+                    sender.sendMessage(formattedLine);
+                }
             }
         }
         sender.sendMessage(MessageUtil.colorize("&6&l══════════════════════"));


### PR DESCRIPTION
💡 What: Added click-to-copy functionality to the `/adminlog` command output.
🎯 Why: To reduce friction and errors for server admins needing to copy or share log details.
📸 Before/After: Before: static text in chat. After: rich text with hover tooltips and instant clipboard copying.
♿ Accessibility: Eliminates the need for precise mouse highlighting to extract data from the chat interface.

---
*PR created automatically by Jules for task [13279705112198210679](https://jules.google.com/task/13279705112198210679) started by @SSoggyTacoMan*