### PR TITLE
refactor(paper): 🎨 palette: interactive uuid copying

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -44,3 +44,6 @@
 ## 2024-05-10 - [Interactive CLI Log Copying]
 **Learning:** Displaying administrative logs or records in chat via the Paper module as legacy colored text makes it difficult for users to copy them.
 **Action:** When displaying administrative logs or records in chat, convert legacy colored text into a Kyori Adventure `Component` with a `clickEvent` (`copyToClipboard`) and a `hoverEvent` to allow frictionless copying of log entries without manual highlighting.
+## 2026-06-21 - [Interactive CLI UUID Copying]
+**Learning:** Displaying player UUIDs in chat as static text in administrative commands makes copying them difficult and error-prone.
+**Action:** Replace static UUID text with Kyori Adventure Components (`copyToClipboard` and `showText`) to allow server administrators to click and copy the UUID instantly.

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminCommand.java
@@ -585,7 +585,16 @@ public class AdminCommand implements CommandExecutor, TabCompleter {
     private void sendInfoHeader(CommandSender sender, PlayerData data) {
         sender.sendMessage(MessageUtil.colorize("&6&l══ Player Info ══"));
         sender.sendMessage(MessageUtil.colorize("&7Player: &f" + data.getUsername()));
-        sender.sendMessage(MessageUtil.colorize("&7UUID: &f" + data.getUuid()));
+
+        if (sender instanceof org.bukkit.entity.Player player) {
+            net.kyori.adventure.text.Component interactiveUuid = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacyAmpersand().deserialize("&7UUID: &f" + data.getUuid())
+                    .clickEvent(net.kyori.adventure.text.event.ClickEvent.copyToClipboard(data.getUuid().toString()))
+                    .hoverEvent(net.kyori.adventure.text.event.HoverEvent.showText(net.kyori.adventure.text.Component.text("Click to copy UUID", net.kyori.adventure.text.format.NamedTextColor.GRAY)));
+            player.sendMessage(interactiveUuid);
+        } else {
+            sender.sendMessage(MessageUtil.colorize("&7UUID: &f" + data.getUuid()));
+        }
+
         sender.sendMessage(MessageUtil.colorize("&7Lives: &e" + data.getLives()
                 + " &7/ &e" + plugin.getMaxLives()));
         sender.sendMessage(MessageUtil.colorize("&7Status: "

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminCommand.java
@@ -586,7 +586,7 @@ public class AdminCommand implements CommandExecutor, TabCompleter {
         sender.sendMessage(MessageUtil.colorize("&6&l══ Player Info ══"));
         sender.sendMessage(MessageUtil.colorize("&7Player: &f" + data.getUsername()));
 
-        if (sender instanceof org.bukkit.entity.Player player) {
+        if (sender instanceof Player player) {
             net.kyori.adventure.text.Component interactiveUuid = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacyAmpersand().deserialize("&7UUID: &f" + data.getUuid())
                     .clickEvent(net.kyori.adventure.text.event.ClickEvent.copyToClipboard(data.getUuid().toString()))
                     .hoverEvent(net.kyori.adventure.text.event.HoverEvent.showText(net.kyori.adventure.text.Component.text("Click to copy UUID", net.kyori.adventure.text.format.NamedTextColor.GRAY)));


### PR DESCRIPTION
💡 What: Replaced static UUID text in `/psadmin info` with an interactive clickable component.
🎯 Why: Admins frequently need to copy player UUIDs for debugging or config editing. Manual highlighting is tedious and error-prone.
📸 Before/After: Before, UUID was static text. Now it has a hover prompt and instantly copies to the clipboard.
♿ Accessibility: Reduces manual dexterity requirements for copying strings from chat.

---
*PR created automatically by Jules for task [4824671155912866573](https://jules.google.com/task/4824671155912866573) started by @SSoggyTacoMan*