### PR TITLE
🎨 Palette: Add interactive UUID copying to admin info command

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -44,3 +44,6 @@
 ## 2024-05-10 - [Interactive CLI Log Copying]
 **Learning:** Displaying administrative logs or records in chat via the Paper module as legacy colored text makes it difficult for users to copy them.
 **Action:** When displaying administrative logs or records in chat, convert legacy colored text into a Kyori Adventure `Component` with a `clickEvent` (`copyToClipboard`) and a `hoverEvent` to allow frictionless copying of log entries without manual highlighting.
+## 2024-06-22 - [Interactive CLI UUID Copying]
+**Learning:** Displaying player UUIDs in chat as legacy colored text makes copying difficult for admins.
+**Action:** Convert legacy colored text into a Kyori Adventure Component with a clickEvent (copyToClipboard) and hoverEvent.

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminCommand.java
@@ -585,7 +585,17 @@ public class AdminCommand implements CommandExecutor, TabCompleter {
     private void sendInfoHeader(CommandSender sender, PlayerData data) {
         sender.sendMessage(MessageUtil.colorize("&6&l══ Player Info ══"));
         sender.sendMessage(MessageUtil.colorize("&7Player: &f" + data.getUsername()));
-        sender.sendMessage(MessageUtil.colorize("&7UUID: &f" + data.getUuid()));
+
+        if (sender instanceof Player player) {
+            net.kyori.adventure.text.Component uuidComponent = net.kyori.adventure.text.Component.text("UUID: ", net.kyori.adventure.text.format.NamedTextColor.GRAY)
+                .append(net.kyori.adventure.text.Component.text(data.getUuid().toString(), net.kyori.adventure.text.format.NamedTextColor.WHITE))
+                .clickEvent(net.kyori.adventure.text.event.ClickEvent.copyToClipboard(data.getUuid().toString()))
+                .hoverEvent(net.kyori.adventure.text.event.HoverEvent.showText(net.kyori.adventure.text.Component.text("Click to copy UUID", net.kyori.adventure.text.format.NamedTextColor.GRAY)));
+            player.sendMessage(uuidComponent);
+        } else {
+            sender.sendMessage(MessageUtil.colorize("&7UUID: &f" + data.getUuid()));
+        }
+
         sender.sendMessage(MessageUtil.colorize("&7Lives: &e" + data.getLives()
                 + " &7/ &e" + plugin.getMaxLives()));
         sender.sendMessage(MessageUtil.colorize("&7Status: "

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminCommand.java
@@ -587,9 +587,10 @@ public class AdminCommand implements CommandExecutor, TabCompleter {
         sender.sendMessage(MessageUtil.colorize("&7Player: &f" + data.getUsername()));
 
         if (sender instanceof Player player) {
+            String uuidStr = data.getUuid().toString();
             net.kyori.adventure.text.Component uuidComponent = net.kyori.adventure.text.Component.text("UUID: ", net.kyori.adventure.text.format.NamedTextColor.GRAY)
-                .append(net.kyori.adventure.text.Component.text(data.getUuid().toString(), net.kyori.adventure.text.format.NamedTextColor.WHITE))
-                .clickEvent(net.kyori.adventure.text.event.ClickEvent.copyToClipboard(data.getUuid().toString()))
+                .append(net.kyori.adventure.text.Component.text(uuidStr, net.kyori.adventure.text.format.NamedTextColor.WHITE))
+                .clickEvent(net.kyori.adventure.text.event.ClickEvent.copyToClipboard(uuidStr))
                 .hoverEvent(net.kyori.adventure.text.event.HoverEvent.showText(net.kyori.adventure.text.Component.text("Click to copy UUID", net.kyori.adventure.text.format.NamedTextColor.GRAY)));
             player.sendMessage(uuidComponent);
         } else {


### PR DESCRIPTION
💡 What: Made the UUID in the `/psadmin info` command clickable for players to copy to their clipboard.
🎯 Why: Admins often need to copy UUIDs for administrative tasks, and manual transcription is error-prone and tedious.
📸 Before/After: Before, UUID was static text. Now, it has a hover prompt and copies on click.
♿ Accessibility: Reduces friction and manual typing, making the CLI more accessible.

---
*PR created automatically by Jules for task [17682603040676802911](https://jules.google.com/task/17682603040676802911) started by @SSoggyTacoMan*