### PR TITLE
⚡ bolt: remove redundant nested disk io in social command

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -64,3 +64,6 @@
 ## 2024-05-18 - [Eliminate redundant save when setting relations]
 **Learning:** Returning `void` from configuration setter functions in Bukkit commands causes redundant and synchronous I/O operations if the setting has not actually changed. Accumulating `boolean changed = function(...)` calls and wrapping the final save inside an `if(changed)` condition eliminates this problem.
 **Action:** Always return a boolean indicating whether a change actually occurred inside of config property setters. Then accumulate these into a single flag with `changed |= function(...)` in the caller.
+## 2026-06-22 - [Batch synchronized disk I/O when updating multiple states]
+**Learning:** When updating multiple states or configurations simultaneously, avoid calling synchronous disk write methods (e.g., `save()`) inside the individual helper or setter methods if they are called in a loop or sequential block. In `SocialCommand`, an inner save inside `tryRelationship()` resulted in redundant disk writes because the caller also saved the state.
+**Action:** Design helpers and setters to return a boolean indicating if a change occurred, accumulate the results in the caller, and perform exactly one `save()` operation at the end to eliminate redundant disk I/O.

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/SocialCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/SocialCommand.java
@@ -134,9 +134,10 @@ public class SocialCommand implements CommandExecutor, TabCompleter {
                 default:
                     break;
             }
-            if (changed) {
-                ctx.social.saveChanges();
-            }
+            // ⚡ Bolt: Eliminated redundant synchronized disk I/O here.
+            // When updating states, avoid calling synchronized save methods inside the individual
+            // property setters. The caller in onCommand() already accumulates the result and
+            // performs exactly one save() operation, preventing a duplicate write.
             return true;
         } catch (IllegalArgumentException ignore) {
             return false;


### PR DESCRIPTION
💡 What: Removed duplicate disk I/O in the SocialCommand when assigning trusts by eliminating the nested save in the helper method.
🎯 Why: `social.saveChanges()` was called both inside `tryRelationship` and directly afterwards in `onCommand`, causing two identical synchronous YAML writes during a single `/trust` command. Removing the nested call allows the caller to batch the synchronized disk I/O.
📊 Impact: Reduces synchronous disk writes by 50% for `/trust` and `/block` commands, lowering thread latency.
🔬 Measurement: Check if a `/trust` command triggers the `saveConfig` method only once instead of twice.

---
*PR created automatically by Jules for task [7273380399755909163](https://jules.google.com/task/7273380399755909163) started by @SSoggyTacoMan*