### PR TITLE
⚡ Bolt: Cache enum values to prevent redundant array allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -70,3 +70,6 @@
 ## 2024-06-25 - [Cache `Enum.values()` safely and with tests]
 **Learning:** Exposing a `public static final EnumType[] VALUES = values();` triggers a SonarCloud maintainability violation (java:S2386) because arrays are mutable, allowing elements to be overwritten. Additionally, adding static fields to Enums triggers '0.0% Coverage on New Code' failures in CI.
 **Action:** When caching `Enum.values()`, use an immutable list: `public static final java.util.List<EnumType> VALUES = java.util.List.of(values());`. Always write a basic unit test verifying the cached list size to satisfy SonarCloud coverage requirements.
+## 2024-06-25 - [SonarCloud S2386 false positive with List.of]
+**Learning:** Even if `List.of()` is used (which returns an immutable list), SonarCloud's S2386 rule ("Mutable fields should not be public static") often fails to recognize it and still complains because the type is `List`, which exposes mutating interface methods.
+**Action:** When creating immutable collections to satisfy SonarCloud's S2386 rule for `public static final` fields, explicitly wrap the list with `Collections.unmodifiableList(...)` instead of or in addition to `List.of(...)` to guarantee the static analyzer acknowledges the immutability.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -67,3 +67,6 @@
 ## 2024-06-25 - [Cache `Enum.values()` to avoid redundant array allocations]
 **Learning:** In Java, calling `Enum.values()` defensively clones the underlying array on every invocation. When this is used inside frequently called utility methods (like `getEnumFromVal`) or frequently accessed data points like looping over stats or tab complete suggestions, it generates massive numbers of short-lived objects leading to significant Garbage Collection pressure and performance degradation.
 **Action:** Always pre-compute and cache the enum array using `public static final EnumType[] VALUES = values();` directly within the enum class, and then iterate or map over `.VALUES` instead of calling `.values()`.
+## 2024-06-25 - [Cache `Enum.values()` safely and with tests]
+**Learning:** Exposing a `public static final EnumType[] VALUES = values();` triggers a SonarCloud maintainability violation (java:S2386) because arrays are mutable, allowing elements to be overwritten. Additionally, adding static fields to Enums triggers '0.0% Coverage on New Code' failures in CI.
+**Action:** When caching `Enum.values()`, use an immutable list: `public static final java.util.List<EnumType> VALUES = java.util.List.of(values());`. Always write a basic unit test verifying the cached list size to satisfy SonarCloud coverage requirements.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -64,3 +64,6 @@
 ## 2024-05-18 - [Eliminate redundant save when setting relations]
 **Learning:** Returning `void` from configuration setter functions in Bukkit commands causes redundant and synchronous I/O operations if the setting has not actually changed. Accumulating `boolean changed = function(...)` calls and wrapping the final save inside an `if(changed)` condition eliminates this problem.
 **Action:** Always return a boolean indicating whether a change actually occurred inside of config property setters. Then accumulate these into a single flag with `changed |= function(...)` in the caller.
+## 2024-06-25 - [Cache `Enum.values()` to avoid redundant array allocations]
+**Learning:** In Java, calling `Enum.values()` defensively clones the underlying array on every invocation. When this is used inside frequently called utility methods (like `getEnumFromVal`) or frequently accessed data points like looping over stats or tab complete suggestions, it generates massive numbers of short-lived objects leading to significant Garbage Collection pressure and performance degradation.
+**Action:** Always pre-compute and cache the enum array using `public static final EnumType[] VALUES = values();` directly within the enum class, and then iterate or map over `.VALUES` instead of calling `.values()`.

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/RPConfigCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/RPConfigCommand.java
@@ -44,8 +44,8 @@ import org.jspecify.annotations.Nullable;
 @SuppressWarnings("java:S3776") // Cognitive complexity is irreducible due to deeply nested sub-command switch logic
 public class RPConfigCommand implements CommandExecutor, TabCompleter {
     // ⚡ Bolt: Cache enum string mappings to avoid redundant O(N) array allocations on every tab complete
-    private static final List<String> OPTION_CONFIGS = Arrays.stream(OPTIONCONFIGENUM.values()).map(x -> x.id.toLowerCase(java.util.Locale.ROOT)).toList();
-    private static final List<String> OPTION_EDITS = Arrays.stream(OPTIONEDITENUM.values()).map(x -> x.id).toList();
+    private static final List<String> OPTION_CONFIGS = Arrays.stream(OPTIONCONFIGENUM.VALUES).map(x -> x.id.toLowerCase(java.util.Locale.ROOT)).toList();
+    private static final List<String> OPTION_EDITS = Arrays.stream(OPTIONEDITENUM.VALUES).map(x -> x.id).toList();
 
     private static final String OPT_STRUCTURE = "STRUCTURE";
     private static final String OPT_GAMERULE = "GAMERULE";

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/RPConfigCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/RPConfigCommand.java
@@ -44,8 +44,8 @@ import org.jspecify.annotations.Nullable;
 @SuppressWarnings("java:S3776") // Cognitive complexity is irreducible due to deeply nested sub-command switch logic
 public class RPConfigCommand implements CommandExecutor, TabCompleter {
     // ⚡ Bolt: Cache enum string mappings to avoid redundant O(N) array allocations on every tab complete
-    private static final List<String> OPTION_CONFIGS = Arrays.stream(OPTIONCONFIGENUM.VALUES).map(x -> x.id.toLowerCase(java.util.Locale.ROOT)).toList();
-    private static final List<String> OPTION_EDITS = Arrays.stream(OPTIONEDITENUM.VALUES).map(x -> x.id).toList();
+    private static final List<String> OPTION_CONFIGS = OPTIONCONFIGENUM.VALUES.stream().map(x -> x.id.toLowerCase(java.util.Locale.ROOT)).toList();
+    private static final List<String> OPTION_EDITS = OPTIONEDITENUM.VALUES.stream().map(x -> x.id).toList();
 
     private static final String OPT_STRUCTURE = "STRUCTURE";
     private static final String OPT_GAMERULE = "GAMERULE";

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/SocialCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/SocialCommand.java
@@ -40,7 +40,7 @@ import java.util.*;
 
 public class SocialCommand implements CommandExecutor, TabCompleter {
     // ⚡ Bolt: Cache enum string mappings to avoid redundant O(N) array allocations and .toLowerCase() calls on every tab complete
-    private static final List<String> TRUST_ACTIONS = Arrays.stream(TRUSTENUM.values()).map(x -> x.name().toLowerCase(Locale.ROOT)).toList();
+    private static final List<String> TRUST_ACTIONS = Arrays.stream(TRUSTENUM.VALUES).map(x -> x.name().toLowerCase(Locale.ROOT)).toList();
 
     public void executeFail(CommandSender cmdSender, RPCommandOutput cmdOutput) {
         cmdOutput.success = COMMANDOUTPUTENUM.FALSE;

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/SocialCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/SocialCommand.java
@@ -40,7 +40,7 @@ import java.util.*;
 
 public class SocialCommand implements CommandExecutor, TabCompleter {
     // ⚡ Bolt: Cache enum string mappings to avoid redundant O(N) array allocations and .toLowerCase() calls on every tab complete
-    private static final List<String> TRUST_ACTIONS = Arrays.stream(TRUSTENUM.VALUES).map(x -> x.name().toLowerCase(Locale.ROOT)).toList();
+    private static final List<String> TRUST_ACTIONS = TRUSTENUM.VALUES.stream().map(x -> x.name().toLowerCase(Locale.ROOT)).toList();
 
     public void executeFail(CommandSender cmdSender, RPCommandOutput cmdOutput) {
         cmdOutput.success = COMMANDOUTPUTENUM.FALSE;

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/OPTIONCONFIGENUM.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/OPTIONCONFIGENUM.java
@@ -26,7 +26,7 @@ public enum OPTIONCONFIGENUM {
     TIMER("TIMER", (byte)3),
     RELOAD("RELOAD", (byte)0);
 
-    public static final java.util.List<OPTIONCONFIGENUM> VALUES = java.util.List.of(values());
+    public static final java.util.List<OPTIONCONFIGENUM> VALUES = java.util.Collections.unmodifiableList(java.util.Arrays.asList(values()));
 
     public final String id;
     public final byte index;

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/OPTIONCONFIGENUM.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/OPTIONCONFIGENUM.java
@@ -26,6 +26,8 @@ public enum OPTIONCONFIGENUM {
     TIMER("TIMER", (byte)3),
     RELOAD("RELOAD", (byte)0);
 
+    public static final OPTIONCONFIGENUM[] VALUES = values();
+
     public final String id;
     public final byte index;
 
@@ -35,7 +37,7 @@ public enum OPTIONCONFIGENUM {
     }
 
     public static byte getIndex(String opt) {
-        for (OPTIONCONFIGENUM n : OPTIONCONFIGENUM.values()) {
+        for (OPTIONCONFIGENUM n : VALUES) {
             if (Objects.equals(n.id, opt)) {
                 return n.index;
             }
@@ -44,7 +46,7 @@ public enum OPTIONCONFIGENUM {
     }
 
     public static OPTIONCONFIGENUM getEnumFromVal(String opt) {
-        for (OPTIONCONFIGENUM n : OPTIONCONFIGENUM.values()) {
+        for (OPTIONCONFIGENUM n : VALUES) {
             if (Objects.equals(n.id, opt)) {
                 return n;
             }
@@ -53,7 +55,7 @@ public enum OPTIONCONFIGENUM {
     }
 
     public static String getValue(byte i) {
-        for (OPTIONCONFIGENUM n : OPTIONCONFIGENUM.values()) {
+        for (OPTIONCONFIGENUM n : VALUES) {
             if (n.index == i) {
                 return n.id;
             }

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/OPTIONCONFIGENUM.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/OPTIONCONFIGENUM.java
@@ -26,7 +26,7 @@ public enum OPTIONCONFIGENUM {
     TIMER("TIMER", (byte)3),
     RELOAD("RELOAD", (byte)0);
 
-    public static final OPTIONCONFIGENUM[] VALUES = values();
+    public static final java.util.List<OPTIONCONFIGENUM> VALUES = java.util.List.of(values());
 
     public final String id;
     public final byte index;

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/OPTIONEDITENUM.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/OPTIONEDITENUM.java
@@ -25,7 +25,7 @@ public enum OPTIONEDITENUM {
     REMOVE("remove", (byte)1),
     RESET("reset", (byte)2);
 
-    public static final OPTIONEDITENUM[] VALUES = values();
+    public static final java.util.List<OPTIONEDITENUM> VALUES = java.util.List.of(values());
 
     public final String id;
     public final byte index;

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/OPTIONEDITENUM.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/OPTIONEDITENUM.java
@@ -25,6 +25,8 @@ public enum OPTIONEDITENUM {
     REMOVE("remove", (byte)1),
     RESET("reset", (byte)2);
 
+    public static final OPTIONEDITENUM[] VALUES = values();
+
     public final String id;
     public final byte index;
 
@@ -34,7 +36,7 @@ public enum OPTIONEDITENUM {
     }
 
     public static byte getIndex(String opt) {
-        for (OPTIONEDITENUM n : OPTIONEDITENUM.values()) {
+        for (OPTIONEDITENUM n : VALUES) {
             if (Objects.equals(n.id, opt)) {
                 return n.index;
             }
@@ -43,7 +45,7 @@ public enum OPTIONEDITENUM {
     }
 
     public static OPTIONEDITENUM getEnumFromVal(String opt) {
-        for (OPTIONEDITENUM n : OPTIONEDITENUM.values()) {
+        for (OPTIONEDITENUM n : VALUES) {
             if (Objects.equals(n.id, opt)) {
                 return n;
             }
@@ -52,7 +54,7 @@ public enum OPTIONEDITENUM {
     }
 
     public static String getValue(byte i) {
-        for (OPTIONEDITENUM n : OPTIONEDITENUM.values()) {
+        for (OPTIONEDITENUM n : VALUES) {
             if (n.index == i) {
                 return n.id;
             }

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/OPTIONEDITENUM.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/OPTIONEDITENUM.java
@@ -25,7 +25,7 @@ public enum OPTIONEDITENUM {
     REMOVE("remove", (byte)1),
     RESET("reset", (byte)2);
 
-    public static final java.util.List<OPTIONEDITENUM> VALUES = java.util.List.of(values());
+    public static final java.util.List<OPTIONEDITENUM> VALUES = java.util.Collections.unmodifiableList(java.util.Arrays.asList(values()));
 
     public final String id;
     public final byte index;

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/STATSENUM.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/STATSENUM.java
@@ -28,5 +28,7 @@ public enum STATSENUM {
     FRIEND_COUNT,
     BOUNTY_CLAIMED,
     BOUNTY_PLACED,
-    TOTAL_BOUNTY,
+    TOTAL_BOUNTY;
+
+    public static final STATSENUM[] VALUES = values();
 }

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/STATSENUM.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/STATSENUM.java
@@ -30,5 +30,5 @@ public enum STATSENUM {
     BOUNTY_PLACED,
     TOTAL_BOUNTY;
 
-    public static final STATSENUM[] VALUES = values();
+    public static final java.util.List<STATSENUM> VALUES = java.util.List.of(values());
 }

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/STATSENUM.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/STATSENUM.java
@@ -30,5 +30,5 @@ public enum STATSENUM {
     BOUNTY_PLACED,
     TOTAL_BOUNTY;
 
-    public static final java.util.List<STATSENUM> VALUES = java.util.List.of(values());
+    public static final java.util.List<STATSENUM> VALUES = java.util.Collections.unmodifiableList(java.util.Arrays.asList(values()));
 }

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/TRUSTENUM.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/TRUSTENUM.java
@@ -24,5 +24,5 @@ public enum TRUSTENUM {
     INFO,
     BLOCK;
 
-    public static final java.util.List<TRUSTENUM> VALUES = java.util.List.of(values());
+    public static final java.util.List<TRUSTENUM> VALUES = java.util.Collections.unmodifiableList(java.util.Arrays.asList(values()));
 }

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/TRUSTENUM.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/TRUSTENUM.java
@@ -24,5 +24,5 @@ public enum TRUSTENUM {
     INFO,
     BLOCK;
 
-    public static final TRUSTENUM[] VALUES = values();
+    public static final java.util.List<TRUSTENUM> VALUES = java.util.List.of(values());
 }

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/TRUSTENUM.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/TRUSTENUM.java
@@ -22,5 +22,7 @@ public enum TRUSTENUM {
     GRANT,
     REVOKE,
     INFO,
-    BLOCK
+    BLOCK;
+
+    public static final TRUSTENUM[] VALUES = values();
 }

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPStats.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/util/RPStats.java
@@ -34,7 +34,7 @@ public class RPStats {
 
     public Map<STATSENUM, String> getAllStats() {
         Map<STATSENUM, String> map = new EnumMap<>(STATSENUM.class);
-        for (STATSENUM num : STATSENUM.values())
+        for (STATSENUM num : STATSENUM.VALUES)
             map.put(num, this.storage.getValue(this.table, num.name()));
         return map;
     }

--- a/paper/src/test/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/OPTIONCONFIGENUMTest.java
+++ b/paper/src/test/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/OPTIONCONFIGENUMTest.java
@@ -1,0 +1,21 @@
+package org.ssoggy.ssoggysouls.hrm.dlc.enums;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class OPTIONCONFIGENUMTest {
+    @Test
+    void testValuesCached() {
+        assertEquals(OPTIONCONFIGENUM.values().length, OPTIONCONFIGENUM.VALUES.size());
+    }
+    @Test
+    void testUtilityMethods() {
+        assertEquals(OPTIONCONFIGENUM.STRUCTURE.index, OPTIONCONFIGENUM.getIndex(OPTIONCONFIGENUM.STRUCTURE.id));
+        assertEquals(OPTIONCONFIGENUM.STRUCTURE, OPTIONCONFIGENUM.getEnumFromVal(OPTIONCONFIGENUM.STRUCTURE.id));
+        assertEquals(OPTIONCONFIGENUM.STRUCTURE.id, OPTIONCONFIGENUM.getValue(OPTIONCONFIGENUM.STRUCTURE.index));
+        assertEquals((byte)-1, OPTIONCONFIGENUM.getIndex("UNKNOWN"));
+        assertNull(OPTIONCONFIGENUM.getEnumFromVal("UNKNOWN"));
+        assertEquals("", OPTIONCONFIGENUM.getValue((byte) -5));
+    }
+}

--- a/paper/src/test/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/OPTIONEDITENUMTest.java
+++ b/paper/src/test/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/OPTIONEDITENUMTest.java
@@ -1,0 +1,21 @@
+package org.ssoggy.ssoggysouls.hrm.dlc.enums;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class OPTIONEDITENUMTest {
+    @Test
+    void testValuesCached() {
+        assertEquals(OPTIONEDITENUM.values().length, OPTIONEDITENUM.VALUES.size());
+    }
+    @Test
+    void testUtilityMethods() {
+        assertEquals(OPTIONEDITENUM.ADD.index, OPTIONEDITENUM.getIndex(OPTIONEDITENUM.ADD.id));
+        assertEquals(OPTIONEDITENUM.ADD, OPTIONEDITENUM.getEnumFromVal(OPTIONEDITENUM.ADD.id));
+        assertEquals(OPTIONEDITENUM.ADD.id, OPTIONEDITENUM.getValue(OPTIONEDITENUM.ADD.index));
+        assertEquals((byte)-1, OPTIONEDITENUM.getIndex("UNKNOWN"));
+        assertNull(OPTIONEDITENUM.getEnumFromVal("UNKNOWN"));
+        assertEquals("", OPTIONEDITENUM.getValue((byte) -5));
+    }
+}

--- a/paper/src/test/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/STATSENUMTest.java
+++ b/paper/src/test/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/STATSENUMTest.java
@@ -1,0 +1,11 @@
+package org.ssoggy.ssoggysouls.hrm.dlc.enums;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class STATSENUMTest {
+    @Test
+    void testValuesCached() {
+        assertEquals(STATSENUM.values().length, STATSENUM.VALUES.size());
+    }
+}

--- a/paper/src/test/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/TRUSTENUMTest.java
+++ b/paper/src/test/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/TRUSTENUMTest.java
@@ -1,0 +1,11 @@
+package org.ssoggy.ssoggysouls.hrm.dlc.enums;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TRUSTENUMTest {
+    @Test
+    void testValuesCached() {
+        assertEquals(TRUSTENUM.values().length, TRUSTENUM.VALUES.size());
+    }
+}


### PR DESCRIPTION
💡 What: Cached the `values()` array in `STATSENUM`, `OPTIONEDITENUM`, `OPTIONCONFIGENUM`, and `TRUSTENUM`. Replaced usage of `.values()` with `.VALUES`.
🎯 Why: Calling `Enum.values()` creates a new array every single time it's invoked. This can cause unnecessary garbage collection pressure, particularly when iterating over Enums frequently in tab completions or stat gathering.
📊 Impact: Reduces memory allocations and GC overhead by eliminating array instantiations.
🔬 Measurement: Profiling allocation during command completion or stat viewing will show 0 arrays created by these specific Enums.

---
*PR created automatically by Jules for task [17236683298921016736](https://jules.google.com/task/17236683298921016736) started by @SSoggyTacoMan*