### PR TITLE
⚡ Bolt: Cache ghost mode state to avoid slow synchronized YAML I/O

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -76,3 +76,6 @@
 ## 2024-05-23 - Avoid Enum.values() hidden allocations in frequent code
 **Learning:** Calling .values() on an enum in Java defensively clones the underlying array every single time. This causes hidden O(N) array allocations, which is especially wasteful during frequent operations like tick loops or Bukkit tab completions.
 **Action:** Cache the values in a `public static final List<EnumType> VALUES = Collections.unmodifiableList(Arrays.asList(values()));` field. Always add a basic unit test asserting the list size to satisfy SonarCloud's 0.0% coverage requirement for the new static initialization.
+## 2024-05-24 - [Cache ghost mode state to avoid slow synchronized YAML I/O]
+**Learning:** Frequent calls to `storage.hasValue()` inside `getPlayerGameMode` create synchronized blocking during frequent game mode checks, slowing down operations.
+**Action:** Cache the ghost state of players in a `ConcurrentHashMap` upon entering/exiting ghost mode to avoid slow file I/O operations and blocking reads.

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/GAMEMODESENUM.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/enums/GAMEMODESENUM.java
@@ -40,6 +40,7 @@ public enum GAMEMODESENUM {
     private static final Map<Integer, GAMEMODESENUM> BY_ID = Maps.newHashMap(); // Required: enum-level lookup + persistent storage state
     private static final String gmTable; // NOSONAR: initialized in static block
     private static final RPStorage storage;
+    private static final java.util.Map<java.util.UUID, Boolean> GHOST_CACHE = new java.util.concurrent.ConcurrentHashMap<>();
 
 
     GAMEMODESENUM(final int id, GameMode def) {
@@ -54,7 +55,7 @@ public enum GAMEMODESENUM {
         return gm.fallback;
     }
     public static GAMEMODESENUM getPlayerGameMode(Player player) {
-        if (storage.hasValue(gmTable, player.getUniqueId().toString())) { // slow
+        if (GHOST_CACHE.computeIfAbsent(player.getUniqueId(), k -> storage.hasValue(gmTable, k.toString()))) { // cached to avoid slow synchronized YAML I/O
             return GAMEMODESENUM.GHOSTMODE;
         }
         return gmCast(player.getGameMode());
@@ -82,12 +83,14 @@ public enum GAMEMODESENUM {
         String uuid = player.getUniqueId().toString();
         return switch(gm) {
             case GHOSTMODE -> {
+                GHOST_CACHE.put(player.getUniqueId(), true);
                 if (storage.setValueIfChanged(gmTable, uuid, player.getName())) {
                     storage.saveConfig();
                 }
                 yield storage.hasValue(gmTable, uuid) ? (byte)1 : (byte)0;
             }
             default -> {
+                GHOST_CACHE.put(player.getUniqueId(), false);
                 if (storage.hasValue(gmTable, uuid)) {
                     storage.setValue(gmTable, uuid, null);
                     storage.saveConfig();


### PR DESCRIPTION
💡 What: Added a `ConcurrentHashMap` cache for ghost mode states in `GAMEMODESENUM`.
🎯 Why: Frequent calls to `storage.hasValue()` inside `getPlayerGameMode` create synchronized blocking reads from YAML configuration files.
📊 Impact: Eliminates synchronized blocking during frequent player state checks, reducing main thread overhead.
🔬 Measurement: Run a profiler or monitor tick times while many players are online and frequently checking their game mode.

---
*PR created automatically by Jules for task [2587724917790894026](https://jules.google.com/task/2587724917790894026) started by @SSoggyTacoMan*