### PR TITLE
⚡ Bolt: [eliminate stream alloc in config command]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -76,3 +76,6 @@
 ## 2024-05-23 - Avoid Enum.values() hidden allocations in frequent code
 **Learning:** Calling .values() on an enum in Java defensively clones the underlying array every single time. This causes hidden O(N) array allocations, which is especially wasteful during frequent operations like tick loops or Bukkit tab completions.
 **Action:** Cache the values in a `public static final List<EnumType> VALUES = Collections.unmodifiableList(Arrays.asList(values()));` field. Always add a basic unit test asserting the list size to satisfy SonarCloud's 0.0% coverage requirement for the new static initialization.
+## 2026-06-15 - [Avoid Stream.concat and map in config commands]
+**Learning:** Using `Stream.concat(set.stream(), Stream.of(value)).collect(Collectors.toSet())` or `.stream().map(Enum::name).toList()` in Bukkit command feedback and configuration setters creates unnecessary stream object wrappers and lambdas during command execution, increasing GC pressure for operations that can be done with simple list iteration or HashSet adds.
+**Action:** Use direct collection manipulation (`new HashSet<>(existing); set.add(value)`) and manual for-loops for mapping values to strings.

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/RPConfigCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/RPConfigCommand.java
@@ -136,7 +136,8 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
                         break;
                     }
 
-                    whoSet = Stream.concat(RPStatic.BLOCK_TAGS.getOrDefault(where, Set.of()).stream(), Stream.of(whoMat)).collect(Collectors.toSet());
+                    whoSet = new java.util.HashSet<>(RPStatic.BLOCK_TAGS.getOrDefault(where, Set.of()));
+                    whoSet.add(whoMat);
                     result.success = COMMANDOUTPUTENUM.valueOf(RPConfig.setBlockTag(where, whoSet));
                     whoName = whoMat.name();
                     result.message = "Added " + whoName + " to " + where;
@@ -225,7 +226,11 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
                     break;
                 }
                 result.success = COMMANDOUTPUTENUM.INFO;
-                result.message = "Contents inside of <aqua>" + args[1] + AQUA_LABEL_SUFFIX + RPStatic.BLOCK_TAGS.getOrDefault(args[1], Set.of()).stream().map(Enum::name).toList();
+                java.util.List<String> names = new java.util.ArrayList<>();
+                for (Material mat : RPStatic.BLOCK_TAGS.getOrDefault(args[1], Set.of())) {
+                    names.add(mat.name());
+                }
+                result.message = "Contents inside of <aqua>" + args[1] + AQUA_LABEL_SUFFIX + names;
                 break;
             case 3:
                 if (!Objects.equals(args[2], "reset")) {

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/RPConfigCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/RPConfigCommand.java
@@ -226,8 +226,9 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
                     break;
                 }
                 result.success = COMMANDOUTPUTENUM.INFO;
-                java.util.List<String> names = new java.util.ArrayList<>();
-                for (Material mat : RPStatic.BLOCK_TAGS.getOrDefault(args[1], Set.of())) {
+                Set<Material> materials = RPStatic.BLOCK_TAGS.getOrDefault(args[1], Set.of());
+                java.util.List<String> names = new java.util.ArrayList<>(materials.size());
+                for (Material mat : materials) {
                     names.add(mat.name());
                 }
                 result.message = "Contents inside of <aqua>" + args[1] + AQUA_LABEL_SUFFIX + names;


### PR DESCRIPTION
💡 What: Eliminated `Stream.concat` and `.stream().map().toList()` usages in `RPConfigCommand`.
🎯 Why: To reduce unnecessary temporary stream objects, lambdas, and collection allocations (GC pressure) during command execution.
📊 Impact: Eliminates N+1 stream allocations per config operation, executing commands slightly faster and with less memory footprint.
🔬 Measurement: Code inspection confirms `new HashSet<>` and a `for` loop have replaced the streams.

---
*PR created automatically by Jules for task [7556661566881717071](https://jules.google.com/task/7556661566881717071) started by @SSoggyTacoMan*