### PR TITLE
feat(paper): 🎨 Palette: make security block resolution message interactive

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -50,3 +50,6 @@
 ## 2024-06-22 - [Interactive CLI UUID Copying]
 **Learning:** Displaying player UUIDs in chat as legacy colored text makes copying difficult for admins.
 **Action:** Convert legacy colored text into a Kyori Adventure Component with a clickEvent (copyToClipboard) and hoverEvent.
+## 2024-06-25 - [Interactive CLI Security Recovery]
+**Learning:** Security error messages that provide resolution steps (like permission nodes or commands) as plain text force users to manually type them out, causing friction.
+**Action:** Replace plain text resolution steps in security block messages with interactive Kyori components (e.g., `suggestCommand` for `/deop`, `copyToClipboard` for permission nodes) to allow quick, single-click recovery.

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/util/PermissionUtil.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/util/PermissionUtil.java
@@ -65,16 +65,16 @@ public final class PermissionUtil {
      */
     public static void sendSecurityBlockMessage(CommandSender sender) {
         sender.sendMessage(MessageUtil.colorize("&cSecurity Error: On the Limbo server, OP status cannot be used to execute this command."));
-        if (sender instanceof org.bukkit.entity.Player player) {
+        if (sender instanceof Player player) {
             net.kyori.adventure.text.Component message = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacyAmpersand().deserialize("&7Either ")
                     .append(net.kyori.adventure.text.Component.text("/deop", net.kyori.adventure.text.format.NamedTextColor.YELLOW)
                             .clickEvent(net.kyori.adventure.text.event.ClickEvent.suggestCommand("/deop " + player.getName()))
                             .hoverEvent(net.kyori.adventure.text.event.HoverEvent.showText(net.kyori.adventure.text.Component.text("Click to prepare /deop", net.kyori.adventure.text.format.NamedTextColor.GRAY))))
-                    .append(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacyAmpersand().deserialize("&7 yourself on Limbo, ask an administrator to add you to the trusted admins list, or have them grant you the bypass permission "))
+                    .append(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacyAmpersand().deserialize("&7 yourself on Limbo, ask an administrator to add you to the trusted admins list, or have them grant you the bypass permission &e("))
                     .append(net.kyori.adventure.text.Component.text("ssoggysouls.bypass-limbo-op-security", net.kyori.adventure.text.format.NamedTextColor.YELLOW)
                             .clickEvent(net.kyori.adventure.text.event.ClickEvent.copyToClipboard("ssoggysouls.bypass-limbo-op-security"))
                             .hoverEvent(net.kyori.adventure.text.event.HoverEvent.showText(net.kyori.adventure.text.Component.text("Click to copy permission node", net.kyori.adventure.text.format.NamedTextColor.GRAY))))
-                    .append(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacyAmpersand().deserialize("&7."));
+                    .append(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacyAmpersand().deserialize("&e)&7."));
             player.sendMessage(message);
         } else {
             sender.sendMessage(MessageUtil.colorize("&7Either /deop yourself on Limbo, ask an administrator to add you to the trusted admins list, or have them grant you the bypass permission &e(ssoggysouls.bypass-limbo-op-security)&7."));

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/util/PermissionUtil.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/util/PermissionUtil.java
@@ -65,6 +65,19 @@ public final class PermissionUtil {
      */
     public static void sendSecurityBlockMessage(CommandSender sender) {
         sender.sendMessage(MessageUtil.colorize("&cSecurity Error: On the Limbo server, OP status cannot be used to execute this command."));
-        sender.sendMessage(MessageUtil.colorize("&7Either /deop yourself on Limbo, ask an administrator to add you to the trusted admins list, or have them grant you the bypass permission &e(ssoggysouls.bypass-limbo-op-security)&7."));
+        if (sender instanceof org.bukkit.entity.Player player) {
+            net.kyori.adventure.text.Component message = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacyAmpersand().deserialize("&7Either ")
+                    .append(net.kyori.adventure.text.Component.text("/deop", net.kyori.adventure.text.format.NamedTextColor.YELLOW)
+                            .clickEvent(net.kyori.adventure.text.event.ClickEvent.suggestCommand("/deop " + player.getName()))
+                            .hoverEvent(net.kyori.adventure.text.event.HoverEvent.showText(net.kyori.adventure.text.Component.text("Click to prepare /deop", net.kyori.adventure.text.format.NamedTextColor.GRAY))))
+                    .append(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacyAmpersand().deserialize("&7 yourself on Limbo, ask an administrator to add you to the trusted admins list, or have them grant you the bypass permission "))
+                    .append(net.kyori.adventure.text.Component.text("ssoggysouls.bypass-limbo-op-security", net.kyori.adventure.text.format.NamedTextColor.YELLOW)
+                            .clickEvent(net.kyori.adventure.text.event.ClickEvent.copyToClipboard("ssoggysouls.bypass-limbo-op-security"))
+                            .hoverEvent(net.kyori.adventure.text.event.HoverEvent.showText(net.kyori.adventure.text.Component.text("Click to copy permission node", net.kyori.adventure.text.format.NamedTextColor.GRAY))))
+                    .append(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacyAmpersand().deserialize("&7."));
+            player.sendMessage(message);
+        } else {
+            sender.sendMessage(MessageUtil.colorize("&7Either /deop yourself on Limbo, ask an administrator to add you to the trusted admins list, or have them grant you the bypass permission &e(ssoggysouls.bypass-limbo-op-security)&7."));
+        }
     }
 }


### PR DESCRIPTION
Converted the static security block error message in `PermissionUtil.java` to an interactive Kyori Adventure component. When users are blocked by Limbo OP Security, they can now click `/deop` to instantly pre-fill their chat bar, or click the bypass permission node to copy it directly to their clipboard, reducing friction for server administrators. Added an entry to `.jules/palette.md` documenting this UX enhancement pattern.

---
*PR created automatically by Jules for task [14336201955712318979](https://jules.google.com/task/14336201955712318979) started by @SSoggyTacoMan*