### PR TITLE
📦 Porter: fix exception logging ported to Fabric and Forge/NeoForge

### DIFF
--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
@@ -58,7 +58,7 @@ public class SSoggySoulsMod implements ModInitializer, PluginContext {
         try {
             databaseManager.initialize();
         } catch (DatabaseInitializationException e) {
-            LOGGER.error("Failed to initialize database. Disabling features. Error: {}", e.getMessage(), e);
+            LOGGER.error("Failed to initialize database. Disabling features.", e);
             throw new IllegalStateException("Failed to initialize SSoggySouls database", e);
         }
         DlcServices.init(this);

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
@@ -61,7 +61,7 @@ public class SSoggySoulsMod implements PluginContext {
         try {
             databaseManager.initialize();
         } catch (DatabaseInitializationException e) {
-            LOGGER.error("Failed to initialize database. Disabling features. Error: {}", e.getMessage(), e);
+            LOGGER.error("Failed to initialize database. Disabling features.", e);
             throw new IllegalStateException("Failed to initialize SSoggySouls database", e);
         }
         DlcServices.init(this);

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/SSoggySoulsMod.java
@@ -64,7 +64,7 @@ public class SSoggySoulsMod implements PluginContext {
         try {
             databaseManager.initialize();
         } catch (DatabaseInitializationException e) {
-            LOGGER.error("Failed to initialize database. Disabling features. Error: {}", e.getMessage(), e);
+            LOGGER.error("Failed to initialize database. Disabling features.", e);
             throw new IllegalStateException("Failed to initialize SSoggySouls database", e);
         }
         DlcServices.init(this);


### PR DESCRIPTION
I have ported the exception logging fix from Paper to the Fabric, Forge, and NeoForge initialization classes. The changes prevent redundant message passing and potential information leakage by safely passing the full exception object to the logger. Tests for the Fabric module passed successfully, and the Forge/NeoForge code changes have been logically verified.

---
*PR created automatically by Jules for task [5651508972308314786](https://jules.google.com/task/5651508972308314786) started by @SSoggyTacoMan*