### PR TITLE
refactor(paper): 🎨 palette: interactive config command errors

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -59,3 +59,6 @@
 ## 2026-06-25 - [Interactive CLI Number Parsing Errors with RPCommandOutput]
 **Learning:** In the `RPConfigCommand` class, legacy error messages used static `>>...<<` markers which were not interactive. By swapping these out for a helper method that escapes `<` and `>` input and uses `<click:suggest_command:'...'><hover:show_text:'...'>...`, players can now click errors to have the command auto-filled in their chat bar, preventing them from needing to type it all out again.
 **Action:** Replace unescaped static error markers with Kyori Adventure MiniMessage clickable recovery paths when catching syntax or config-related argument failures.
+## 2026-06-25 - [Interactive CLI Number Parsing Errors with RPCommandOutput] (Fabric CI Fix)
+**Learning:** When trying to update the legacy error markers to use Kyori Adventure MiniMessage components and applying hover/click styles in the Fabric implementation, calling `.styled(...)` directly on the interface `net.minecraft.text.Text` causes compilation errors because the modern Fabric API treats `Text` as immutable. You must call `.copy()` first to get a `MutableText`.
+**Action:** When porting chat interactivity or applying `.styled(...)` to an existing `Text` object in Fabric, always insert `.copy()` first.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -56,3 +56,6 @@
 ## 2026-06-25 - [Interactive CLI Base Command Errors]
 **Learning:** When users execute base commands with sub-argument trees (like `/revive`) without any arguments, standard static usage errors force them to completely retype the command. In Brigadier, the `.executes()` block on the literal node itself is the perfect place to inject interactive recovery.
 **Action:** Replace static `sendFailure(...)` calls in base command `.executes()` blocks with native interactive components containing `SUGGEST_COMMAND` click events to instantly provide users with a pre-filled chat bar.
+## 2026-06-25 - [Interactive CLI Number Parsing Errors with RPCommandOutput]
+**Learning:** In the `RPConfigCommand` class, legacy error messages used static `>>...<<` markers which were not interactive. By swapping these out for a helper method that escapes `<` and `>` input and uses `<click:suggest_command:'...'><hover:show_text:'...'>...`, players can now click errors to have the command auto-filled in their chat bar, preventing them from needing to type it all out again.
+**Action:** Replace unescaped static error markers with Kyori Adventure MiniMessage clickable recovery paths when catching syntax or config-related argument failures.

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -96,10 +96,10 @@ public class CommandRegistration {
             // Require op level 2 or higher for now (since no permissions api is installed yet)
             .requires(source -> source.hasPermissionLevel(2))
             .executes(context -> {
-                context.getSource().sendError(MessageUtil.get("usage-revive")
+                context.getSource().sendError(MessageUtil.get("usage-revive").copy()
                     .styled(s -> s.withColor(net.minecraft.util.Formatting.RED)
                         .withClickEvent(new net.minecraft.text.ClickEvent(net.minecraft.text.ClickEvent.Action.SUGGEST_COMMAND, "/revive "))
-                        .withHoverEvent(new net.minecraft.text.HoverEvent(net.minecraft.text.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").styled(h -> h.withColor(net.minecraft.util.Formatting.GRAY))))));
+                        .withHoverEvent(new net.minecraft.text.HoverEvent(net.minecraft.text.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().styled(h -> h.withColor(net.minecraft.util.Formatting.GRAY))))));
                 return 0;
             })
             .then(CommandManager.argument(PLAYER, StringArgumentType.word())
@@ -163,10 +163,10 @@ public class CommandRegistration {
         dispatcher.register(CommandManager.literal("psetlives")
             .requires(source -> source.hasPermissionLevel(2))
             .executes(context -> {
-                context.getSource().sendError(MessageUtil.get("usage-psetlives")
+                context.getSource().sendError(MessageUtil.get("usage-psetlives").copy()
                     .styled(s -> s.withColor(net.minecraft.util.Formatting.RED)
                         .withClickEvent(new net.minecraft.text.ClickEvent(net.minecraft.text.ClickEvent.Action.SUGGEST_COMMAND, "/psetlives "))
-                        .withHoverEvent(new net.minecraft.text.HoverEvent(net.minecraft.text.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").styled(h -> h.withColor(net.minecraft.util.Formatting.GRAY))))));
+                        .withHoverEvent(new net.minecraft.text.HoverEvent(net.minecraft.text.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().styled(h -> h.withColor(net.minecraft.util.Formatting.GRAY))))));
                 return 0;
             })
             .then(CommandManager.argument(PLAYER, StringArgumentType.word())
@@ -174,10 +174,10 @@ public class CommandRegistration {
                         context.getSource().getServer().getPlayerNames(), builder))
                 .executes(context -> {
                     String targetName = StringArgumentType.getString(context, PLAYER);
-                    context.getSource().sendError(MessageUtil.get("usage-psetlives-player", PLAYER, targetName)
+                    context.getSource().sendError(MessageUtil.get("usage-psetlives-player", PLAYER, targetName).copy()
                         .styled(s -> s.withColor(net.minecraft.util.Formatting.RED)
                             .withClickEvent(new net.minecraft.text.ClickEvent(net.minecraft.text.ClickEvent.Action.SUGGEST_COMMAND, "/psetlives " + targetName + " "))
-                            .withHoverEvent(new net.minecraft.text.HoverEvent(net.minecraft.text.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").styled(h -> h.withColor(net.minecraft.util.Formatting.GRAY))))));
+                            .withHoverEvent(new net.minecraft.text.HoverEvent(net.minecraft.text.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().styled(h -> h.withColor(net.minecraft.util.Formatting.GRAY))))));
                     return 0;
                 })
                 .then(CommandManager.argument(LIVES, IntegerArgumentType.integer(0))
@@ -247,18 +247,18 @@ public class CommandRegistration {
                                 source.sendError(MessageUtil.get("admin-log-read-error"));
                             }
                             case SUCCESS -> {
-                                source.sendMessage(net.minecraft.text.Text.literal("--- Recent Admin Logs ---").styled(s -> s.withColor(net.minecraft.util.Formatting.RED).withBold(true)));
+                                source.sendMessage(net.minecraft.text.Text.literal("--- Recent Admin Logs ---").copy().styled(s -> s.withColor(net.minecraft.util.Formatting.RED).withBold(true)));
                                 if (source.isExecutedByPlayer()) {
                                     for (String line : result.lines) {
-                                        source.sendMessage(net.minecraft.text.Text.literal(line).styled(s ->
+                                        source.sendMessage(net.minecraft.text.Text.literal(line).copy().styled(s ->
                                             s.withColor(net.minecraft.util.Formatting.GRAY)
                                              .withClickEvent(new net.minecraft.text.ClickEvent(net.minecraft.text.ClickEvent.Action.COPY_TO_CLIPBOARD, line))
-                                             .withHoverEvent(new net.minecraft.text.HoverEvent(net.minecraft.text.HoverEvent.Action.SHOW_TEXT, net.minecraft.text.Text.literal("Click to copy log entry").styled(h -> h.withColor(net.minecraft.util.Formatting.GRAY))))
+                                             .withHoverEvent(new net.minecraft.text.HoverEvent(net.minecraft.text.HoverEvent.Action.SHOW_TEXT, net.minecraft.text.Text.literal("Click to copy log entry").copy().styled(h -> h.withColor(net.minecraft.util.Formatting.GRAY))))
                                         ));
                                     }
                                 } else {
                                     for (String line : result.lines) {
-                                        source.sendMessage(net.minecraft.text.Text.literal(line).styled(s -> s.withColor(net.minecraft.util.Formatting.GRAY)));
+                                        source.sendMessage(net.minecraft.text.Text.literal(line).copy().styled(s -> s.withColor(net.minecraft.util.Formatting.GRAY)));
                                     }
                                 }
                             }

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/RPConfigCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/RPConfigCommand.java
@@ -55,8 +55,8 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
     private static final String AQUA_LABEL_SUFFIX = ":</aqua> ";
 
     private static String buildErrorComponent(String baseCommand, String invalidArg) {
-        String safeBase = baseCommand.replace("<", "\\<").replace(">", "\\>");
-        String safeInvalid = invalidArg.replace("<", "\\<").replace(">", "\\>");
+        String safeBase = net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().escapeTags(baseCommand);
+        String safeInvalid = net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().escapeTags(invalidArg);
 
         return "<click:suggest_command:'" + baseCommand + "'><hover:show_text:'<gray>Click to auto-fill this command</gray>'>" +
                safeBase + " >><red>" + safeInvalid + "</red><<</hover></click>";

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/RPConfigCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/RPConfigCommand.java
@@ -52,10 +52,15 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
     private static final String OPT_TIMER = "TIMER";
     private static final String OPT_RELOAD = "RELOAD";
     private static final String CMD_PREFIX = "/revivalconfig ";
-    private static final String ERR_MARKER_OPEN = " >>";
-    private static final String ERR_MARKER_CLOSE = "<<";
-    private static final String ERR_MARKER_EMPTY = " >><<";
     private static final String AQUA_LABEL_SUFFIX = ":</aqua> ";
+
+    private static String buildErrorComponent(String baseCommand, String invalidArg) {
+        String safeBase = baseCommand.replace("<", "\\<").replace(">", "\\>");
+        String safeInvalid = invalidArg.replace("<", "\\<").replace(">", "\\>");
+
+        return "<click:suggest_command:'" + baseCommand + "'><hover:show_text:'<gray>Click to auto-fill this command</gray>'>" +
+               safeBase + " >><red>" + safeInvalid + "</red><<</hover></click>";
+    }
 
     private static final List<String> LIST_BOOLEAN = List.of("true", "false");
     // Optimization: Pre-compute and cache block materials to prevent O(N) array allocation
@@ -202,7 +207,7 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
                 case OPTIONCONFIGENUM.RELOAD -> executeReloadCMD(result);
                 default -> {
                     result.success = COMMANDOUTPUTENUM.FALSE;
-                    result.message = "<red>Command Failed: " + CMD_PREFIX + ">>" + plOpt1 + "<</red>";
+                    result.message = buildErrorComponent(CMD_PREFIX, plOpt1);
                     cmdSender.sendRichMessage(result.toString());
                     return true;
                 }
@@ -223,12 +228,12 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
         switch (args.length) {
             case 0, 1:
                 result.success = COMMANDOUTPUTENUM.FALSE;
-                result.message = CMD_PREFIX + (args.length > 0 ? args[0] : "") + ERR_MARKER_EMPTY;
+                result.message = buildErrorComponent(CMD_PREFIX + (args.length > 0 ? args[0] + " " : ""), "");
                 break;
             case 2:
                 if (!RPStatic.BLOCK_TAGS.containsKey(args[1])) {
                     result.success = COMMANDOUTPUTENUM.FALSE;
-                    result.message = CMD_PREFIX + args[0] + ERR_MARKER_OPEN + args[1] + ERR_MARKER_CLOSE;
+                    result.message = buildErrorComponent(CMD_PREFIX + args[0] + " ", args[1]);
                     break;
                 }
                 result.success = COMMANDOUTPUTENUM.INFO;
@@ -242,7 +247,7 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
             case 3:
                 if (!Objects.equals(args[2], "reset")) {
                     result.success = COMMANDOUTPUTENUM.FALSE;
-                    result.message = CMD_PREFIX + args[0] + " " + args[1] + ERR_MARKER_OPEN + args[2] + ERR_MARKER_CLOSE;
+                    result.message = buildErrorComponent(CMD_PREFIX + args[0] + " " + args[1] + " ", args[2]);
                     break;
                 }
                 // reset action has exactly 3 args, so no material argument is available
@@ -258,13 +263,13 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
         switch (args.length) {
             case 0, 1:
                 result.success = COMMANDOUTPUTENUM.FALSE;
-                result.message = CMD_PREFIX + (args.length > 0 ? args[0] : "") + ERR_MARKER_EMPTY;
+                result.message = buildErrorComponent(CMD_PREFIX + (args.length > 0 ? args[0] + " " : ""), "");
                 result.details = "Command is incomplete."; // Optional
                 break;
             case 2:
                 if (!RPStatic.CONFIG_RULES.containsKey(args[1])) {
                     result.success = COMMANDOUTPUTENUM.FALSE;
-                    result.message = CMD_PREFIX + args[0] + ERR_MARKER_OPEN + args[1] + ERR_MARKER_CLOSE;
+                    result.message = buildErrorComponent(CMD_PREFIX + args[0] + " ", args[1]);
                     break;
                 }
                 result.success = COMMANDOUTPUTENUM.INFO;
@@ -280,13 +285,13 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
         switch (args.length) {
             case 0, 1:
                 result.success = COMMANDOUTPUTENUM.FALSE;
-                result.message = CMD_PREFIX + (args.length > 0 ? args[0] : "") + ERR_MARKER_EMPTY;
+                result.message = buildErrorComponent(CMD_PREFIX + (args.length > 0 ? args[0] + " " : ""), "");
                 result.details = "Command is incomplete."; // Optional
                 break;
             case 2:
                 if (!RPStatic.CONFIG_TIMERS.containsKey(args[1])) {
                     result.success = COMMANDOUTPUTENUM.FALSE;
-                    result.message = CMD_PREFIX + args[0] + ERR_MARKER_OPEN + args[1] + ERR_MARKER_CLOSE;
+                    result.message = buildErrorComponent(CMD_PREFIX + args[0] + " ", args[1]);
                     break;
                 }
                 result.success = COMMANDOUTPUTENUM.INFO;


### PR DESCRIPTION
Replaced static unescaped error markers (>> <<) in `RPConfigCommand` with Kyori Adventure MiniMessage interactive components (`<click:suggest_command:...><hover:show_text:...>`). This allows administrators to quickly click configuration syntax errors to auto-fill the command in their chat bar and fix their mistakes, significantly reducing user friction and typing overhead.

Also implemented escaping of literal `<` and `>` brackets to prevent ComponentParseException from strict MiniMessage parsers.

---
*PR created automatically by Jules for task [24022134411869313](https://jules.google.com/task/24022134411869313) started by @SSoggyTacoMan*