### PR TITLE
refactor(common): 🎨 palette: add interactive name links to obituaries

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -62,3 +62,6 @@
 ## 2026-06-25 - [Interactive CLI Number Parsing Errors with RPCommandOutput] (Fabric CI Fix)
 **Learning:** When trying to update the legacy error markers to use Kyori Adventure MiniMessage components and applying hover/click styles in the Fabric implementation, calling `.styled(...)` directly on the interface `net.minecraft.text.Text` causes compilation errors because the modern Fabric API treats `Text` as immutable. You must call `.copy()` first to get a `MutableText`.
 **Action:** When porting chat interactivity or applying `.styled(...)` to an existing `Text` object in Fabric, always insert `.copy()` first.
+## 2026-07-10 - [Interactive CLI Name Linking]
+**Learning:** Players often want to take follow-up actions (like checking status) on users listed in chat output (like obituaries). By making usernames clickable with a suggest_command, we reduce the friction of typing out another command manually.
+**Action:** When displaying lists of players or events involving players in chat, wrap the usernames in a clickable component that suggests a logical follow-up command (e.g., /pstatus).

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
@@ -463,7 +463,9 @@ public final class DlcCommandRegistration {
         String username = DlcNames.getOrDefault(death.uuid(), death.username());
         String coords = death.x() + " " + death.y() + " " + death.z();
 
-        return Text.literal(username).styled(style -> style.withColor(Formatting.GOLD).withBold(true))
+        return Text.literal(username).styled(style -> style.withColor(Formatting.GOLD).withBold(true)
+                        .withClickEvent(new net.minecraft.text.ClickEvent(net.minecraft.text.ClickEvent.Action.SUGGEST_COMMAND, "/pstatus " + username))
+                        .withHoverEvent(new net.minecraft.text.HoverEvent(net.minecraft.text.HoverEvent.Action.SHOW_TEXT, Text.literal("Click to check player status").styled(s -> s.withColor(Formatting.GRAY)))))
                 .append(Text.literal(" has died at ").styled(style -> style.withColor(Formatting.GRAY).withBold(false)))
                 .append(Text.literal("X" + death.x() + " Y" + death.y() + " Z" + death.z()).styled(style -> style.withColor(Formatting.GOLD).withBold(true)
                         .withClickEvent(new net.minecraft.text.ClickEvent(net.minecraft.text.ClickEvent.Action.COPY_TO_CLIPBOARD, coords))

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
@@ -464,7 +464,9 @@ public final class DlcCommandRegistration {
         String username = DlcNames.getOrDefault(death.uuid(), death.username());
         String coords = death.x() + " " + death.y() + " " + death.z();
 
-        return Component.literal(username).withStyle(style -> style.withColor(ChatFormatting.GOLD).withBold(true))
+        return Component.literal(username).withStyle(style -> style.withColor(ChatFormatting.GOLD).withBold(true)
+                        .withClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/pstatus " + username))
+                        .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal("Click to check player status").withStyle(s -> s.withColor(ChatFormatting.GRAY)))))
                 .append(Component.literal(" has died at ").withStyle(style -> style.withColor(ChatFormatting.GRAY).withBold(false)))
                 .append(Component.literal("X" + death.x() + " Y" + death.y() + " Z" + death.z()).withStyle(style -> style.withColor(ChatFormatting.GOLD).withBold(true)
                         .withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, coords))

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/command/DlcCommandRegistration.java
@@ -464,7 +464,9 @@ public final class DlcCommandRegistration {
         String username = DlcNames.getOrDefault(death.uuid(), death.username());
         String coords = death.x() + " " + death.y() + " " + death.z();
 
-        return Component.literal(username).withStyle(style -> style.withColor(ChatFormatting.GOLD).withBold(true))
+        return Component.literal(username).withStyle(style -> style.withColor(ChatFormatting.GOLD).withBold(true)
+                        .withClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/pstatus " + username))
+                        .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal("Click to check player status").withStyle(s -> s.withColor(ChatFormatting.GRAY)))))
                 .append(Component.literal(" has died at ").withStyle(style -> style.withColor(ChatFormatting.GRAY).withBold(false)))
                 .append(Component.literal("X" + death.x() + " Y" + death.y() + " Z" + death.z()).withStyle(style -> style.withColor(ChatFormatting.GOLD).withBold(true)
                         .withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, coords))

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/ObituariesCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/ObituariesCommand.java
@@ -80,7 +80,11 @@ public class ObituariesCommand implements CommandExecutor, TabCompleter {
                 String username = RPUtil.getUsernameFromCache(uuid);
                 Location deathLocation = deathDetails.getLeft();
                 String coords = deathLocation.getBlockX() + " " + deathLocation.getBlockY() + " " + deathLocation.getBlockZ();
-                deathListBuilder.append("\n<gold><bold>").append(username).append("</bold></gold><gray> has died at </gray>")
+                deathListBuilder.append("\n<click:suggest_command:'/pstatus ").append(username).append("'>")
+                        .append("<hover:show_text:'<gray>Click to check player status</gray>'>")
+                        .append("<gold><bold>").append(username).append("</bold></gold>")
+                        .append("</hover></click>")
+                        .append("<gray> has died at </gray>")
                         .append("<click:copy_to_clipboard:'").append(coords).append("'>")
                         .append("<hover:show_text:'<gray>Click to copy coordinates</gray>'>")
                         .append("<gold><bold>X").append(deathLocation.getBlockX())

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/ObituariesCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/ObituariesCommand.java
@@ -80,9 +80,10 @@ public class ObituariesCommand implements CommandExecutor, TabCompleter {
                 String username = RPUtil.getUsernameFromCache(uuid);
                 Location deathLocation = deathDetails.getLeft();
                 String coords = deathLocation.getBlockX() + " " + deathLocation.getBlockY() + " " + deathLocation.getBlockZ();
-                deathListBuilder.append("\n<click:suggest_command:'/pstatus ").append(username).append("'>")
+                String escapedUsername = username != null ? net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().escapeTags(username) : "Unknown";
+                deathListBuilder.append("\n<click:suggest_command:'/pstatus ").append(escapedUsername).append("'>")
                         .append("<hover:show_text:'<gray>Click to check player status</gray>'>")
-                        .append("<gold><bold>").append(username).append("</bold></gold>")
+                        .append("<gold><bold>").append(escapedUsername).append("</bold></gold>")
                         .append("</hover></click>")
                         .append("<gray> has died at </gray>")
                         .append("<click:copy_to_clipboard:'").append(coords).append("'>")


### PR DESCRIPTION
This micro-UX improvement transforms static usernames in the "obituaries" command output into interactive, clickable elements. Clicking the username now pre-fills a `/pstatus <username>` command in the player's chat window, and hovering displays a helpful tooltip. This drastically reduces the friction of typing out follow-up commands, connecting the obituary feature seamlessly with player status checks. The implementation spans all four platform loaders for cross-platform parity.

---
*PR created automatically by Jules for task [9646848850309164999](https://jules.google.com/task/9646848850309164999) started by @SSoggyTacoMan*