### PR TITLE
📦 Porter: obituaries command alias ported to Paper

### DIFF
--- a/.jules/porter.md
+++ b/.jules/porter.md
@@ -10,3 +10,6 @@
 ## 2026-07-03 - Interactive Security Block Parity
 **Learning:** When porting interactive command responses across platforms, explicitly check if the command source is a player (`isExecutedByPlayer()` in Fabric, `isPlayer()` in Forge/NeoForge) before attaching rich text events (e.g. click/hover), providing a simple fallback text for console execution.
 **Action:** Always verify command source context for interactive parity to prevent exceptions on headless environments.
+## 2026-07-11 - Command Aliases
+**Learning:** In Bukkit/Paper, command aliases must be declaratively defined in the `plugin.yml` configuration using the `aliases: [alias_name]` property under the root command definition, rather than duplicating the Java executor registration as is done in Forge, NeoForge, and Fabric environments.
+**Action:** When porting command aliases from mod loaders to Paper, directly edit `plugin.yml` instead of modifying Java command registration logic.

--- a/paper/src/main/resources/plugin.yml
+++ b/paper/src/main/resources/plugin.yml
@@ -76,6 +76,7 @@ commands:
     description: Shows the avaliable public death locations on the server.
     permission: 'bukkit.command.plugins'
     usage: /deathlist [target:player]
+    aliases: [obituaries]
   
   ghostmode:
     description: Updates player gamemode to ghostmode.


### PR DESCRIPTION
This PR adds the `obituaries` alias to the `deathlist` command in the `paper` module's `plugin.yml`, achieving feature parity with the `forge`, `neoforge`, and `fabric` modules from PR #353.

---
*PR created automatically by Jules for task [9568518002186100565](https://jules.google.com/task/9568518002186100565) started by @SSoggyTacoMan*