### PR TITLE
feat(common): 📦 porter: interactive admin logs ported to fabric and forge

### DIFF
--- a/.jules/porter.md
+++ b/.jules/porter.md
@@ -13,3 +13,6 @@
 ## 2026-07-11 - Command Aliases
 **Learning:** In Bukkit/Paper, command aliases must be declaratively defined in the `plugin.yml` configuration using the `aliases: [alias_name]` property under the root command definition, rather than duplicating the Java executor registration as is done in Forge, NeoForge, and Fabric environments.
 **Action:** When porting command aliases from mod loaders to Paper, directly edit `plugin.yml` instead of modifying Java command registration logic.
+## 2026-07-15 - Interactive Admin Logs Component Styling in Forge/NeoForge
+**Learning:** When generating interactive UI elements in Forge/NeoForge, `Component.literal()` returns a `MutableComponent`. If wrapping strings through a utility method like `colorizeComponent`, ensure the utility explicitly returns `MutableComponent` so that interactive styling (e.g., `.withStyle(HoverEvent...)`) can be applied securely.
+**Action:** When porting interactive text components from Fabric to Forge/NeoForge, explicitly update any intermediary formatting methods to return `MutableComponent` rather than the immutable `Component` interface.

--- a/common/src/main/java/org/ssoggy/ssoggysouls/command/action/AdminLogAction.java
+++ b/common/src/main/java/org/ssoggy/ssoggysouls/command/action/AdminLogAction.java
@@ -40,4 +40,17 @@ public class AdminLogAction {
             return new AdminLogResult(ResultType.READ_ERROR, null);
         }
     }
+
+    public static String formatLogLine(String line) {
+        if (!line.contains("ADMIN ACTION - ")) {
+            return "&7" + line;
+        }
+        String[] parts = line.split("ADMIN ACTION - ", 2);
+        String timestamp = parts[0].replace("[", "&8[").replace("]", "&8]");
+        String[] detailParts = parts[1].split(":", 2);
+        if (detailParts.length == 2) {
+            return timestamp + " &c" + detailParts[0].trim() + " &7- &e" + detailParts[1].trim();
+        }
+        return "&7" + line;
+    }
 }

--- a/common/src/test/java/org/ssoggy/ssoggysouls/command/action/AdminLogActionTest.java
+++ b/common/src/test/java/org/ssoggy/ssoggysouls/command/action/AdminLogActionTest.java
@@ -50,4 +50,19 @@ class AdminLogActionTest {
         assertEquals(AdminLogAction.ResultType.READ_ERROR, result.type);
         assertNull(result.lines);
     }
+
+    @Test
+    void testFormatLogLine() {
+        // Standard matching line
+        String result = AdminLogAction.formatLogLine("[12:34:56] ADMIN ACTION - TEST_ACTION : Test detail");
+        assertEquals("&8[12:34:56&8]  &cTEST_ACTION &7- &eTest detail", result);
+
+        // Missing details (no colon)
+        String noColon = AdminLogAction.formatLogLine("[12:34:56] ADMIN ACTION - TEST_ACTION");
+        assertEquals("&7[12:34:56] ADMIN ACTION - TEST_ACTION", noColon);
+
+        // Not an admin action
+        String notAction = AdminLogAction.formatLogLine("[12:34:56] SYSTEM - Startup");
+        assertEquals("&7[12:34:56] SYSTEM - Startup", notAction);
+    }
 }

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -247,20 +247,26 @@ public class CommandRegistration {
                                 source.sendError(MessageUtil.get("admin-log-read-error"));
                             }
                             case SUCCESS -> {
-                                source.sendMessage(net.minecraft.text.Text.literal("--- Recent Admin Logs ---").copy().styled(s -> s.withColor(net.minecraft.util.Formatting.RED).withBold(true)));
-                                if (source.isExecutedByPlayer()) {
-                                    for (String line : result.lines) {
-                                        source.sendMessage(net.minecraft.text.Text.literal(line).copy().styled(s ->
-                                            s.withColor(net.minecraft.util.Formatting.GRAY)
-                                             .withClickEvent(new net.minecraft.text.ClickEvent(net.minecraft.text.ClickEvent.Action.COPY_TO_CLIPBOARD, line))
-                                             .withHoverEvent(new net.minecraft.text.HoverEvent(net.minecraft.text.HoverEvent.Action.SHOW_TEXT, net.minecraft.text.Text.literal("Click to copy log entry").copy().styled(h -> h.withColor(net.minecraft.util.Formatting.GRAY))))
-                                        ));
-                                    }
+                                source.sendMessage(MessageUtil.colorizeText("&6&l══ Admin Action Log ══").copy());
+                                if (result.lines.isEmpty()) {
+                                    source.sendMessage(MessageUtil.colorizeText("&7(Empty)").copy());
                                 } else {
-                                    for (String line : result.lines) {
-                                        source.sendMessage(net.minecraft.text.Text.literal(line).copy().styled(s -> s.withColor(net.minecraft.util.Formatting.GRAY)));
+                                    if (source.isExecutedByPlayer()) {
+                                        for (String line : result.lines) {
+                                            String formatted = org.ssoggy.ssoggysouls.command.action.AdminLogAction.formatLogLine(line);
+                                            source.sendMessage(MessageUtil.colorizeText(formatted).copy().styled(s ->
+                                                 s.withClickEvent(new net.minecraft.text.ClickEvent(net.minecraft.text.ClickEvent.Action.COPY_TO_CLIPBOARD, line))
+                                                 .withHoverEvent(new net.minecraft.text.HoverEvent(net.minecraft.text.HoverEvent.Action.SHOW_TEXT, net.minecraft.text.Text.literal("Click to copy log entry").copy().styled(h -> h.withColor(net.minecraft.util.Formatting.GRAY))))
+                                            ));
+                                        }
+                                    } else {
+                                        for (String line : result.lines) {
+                                            String formatted = org.ssoggy.ssoggysouls.command.action.AdminLogAction.formatLogLine(line);
+                                            source.sendMessage(MessageUtil.colorizeText(formatted).copy());
+                                        }
                                     }
                                 }
+                                source.sendMessage(MessageUtil.colorizeText("&6&l══════════════════════").copy());
                             }
                         }
                     });

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -251,19 +251,16 @@ public class CommandRegistration {
                                 if (result.lines.isEmpty()) {
                                     source.sendMessage(MessageUtil.colorizeText("&7(Empty)").copy());
                                 } else {
-                                    if (source.isExecutedByPlayer()) {
-                                        for (String line : result.lines) {
-                                            String formatted = org.ssoggy.ssoggysouls.command.action.AdminLogAction.formatLogLine(line);
-                                            source.sendMessage(MessageUtil.colorizeText(formatted).copy().styled(s ->
-                                                 s.withClickEvent(new net.minecraft.text.ClickEvent(net.minecraft.text.ClickEvent.Action.COPY_TO_CLIPBOARD, line))
-                                                 .withHoverEvent(new net.minecraft.text.HoverEvent(net.minecraft.text.HoverEvent.Action.SHOW_TEXT, net.minecraft.text.Text.literal("Click to copy log entry").copy().styled(h -> h.withColor(net.minecraft.util.Formatting.GRAY))))
-                                            ));
+                                    for (String line : result.lines) {
+                                        String formatted = org.ssoggy.ssoggysouls.command.action.AdminLogAction.formatLogLine(line);
+                                        net.minecraft.text.MutableText component = MessageUtil.colorizeText(formatted).copy();
+                                        if (source.isExecutedByPlayer()) {
+                                            component = component.styled(s ->
+                                                s.withClickEvent(new net.minecraft.text.ClickEvent(net.minecraft.text.ClickEvent.Action.COPY_TO_CLIPBOARD, line))
+                                                .withHoverEvent(new net.minecraft.text.HoverEvent(net.minecraft.text.HoverEvent.Action.SHOW_TEXT, net.minecraft.text.Text.literal("Click to copy log entry").copy().styled(h -> h.withColor(net.minecraft.util.Formatting.GRAY))))
+                                            );
                                         }
-                                    } else {
-                                        for (String line : result.lines) {
-                                            String formatted = org.ssoggy.ssoggysouls.command.action.AdminLogAction.formatLogLine(line);
-                                            source.sendMessage(MessageUtil.colorizeText(formatted).copy());
-                                        }
+                                        source.sendMessage(component);
                                     }
                                 }
                                 source.sendMessage(MessageUtil.colorizeText("&6&l══════════════════════").copy());

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -266,20 +266,26 @@ public class CommandRegistration {
                                 source.sendFailure(MessageUtil.get("admin-log-read-error"));
                             }
                             case SUCCESS -> {
-                                source.sendSystemMessage(Component.literal("--- Recent Admin Logs ---").withStyle(net.minecraft.ChatFormatting.RED, net.minecraft.ChatFormatting.BOLD));
-                                if (source.isPlayer()) {
-                                    for (String line : result.lines) {
-                                        source.sendSystemMessage(Component.literal(line).withStyle(s ->
-                                            s.withColor(net.minecraft.ChatFormatting.GRAY)
-                                             .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.COPY_TO_CLIPBOARD, line))
-                                             .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, Component.literal("Click to copy log entry").withStyle(net.minecraft.ChatFormatting.GRAY)))
-                                        ));
-                                    }
+                                source.sendSystemMessage(MessageUtil.colorizeComponent("&6&l══ Admin Action Log ══"));
+                                if (result.lines.isEmpty()) {
+                                    source.sendSystemMessage(MessageUtil.colorizeComponent("&7(Empty)"));
                                 } else {
-                                    for (String line : result.lines) {
-                                        source.sendSystemMessage(Component.literal(line).withStyle(net.minecraft.ChatFormatting.GRAY));
+                                    if (source.isPlayer()) {
+                                        for (String line : result.lines) {
+                                            String formatted = org.ssoggy.ssoggysouls.command.action.AdminLogAction.formatLogLine(line);
+                                            source.sendSystemMessage(MessageUtil.colorizeComponent(formatted).withStyle(s ->
+                                                 s.withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.COPY_TO_CLIPBOARD, line))
+                                                 .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, Component.literal("Click to copy log entry").withStyle(net.minecraft.ChatFormatting.GRAY)))
+                                            ));
+                                        }
+                                    } else {
+                                        for (String line : result.lines) {
+                                            String formatted = org.ssoggy.ssoggysouls.command.action.AdminLogAction.formatLogLine(line);
+                                            source.sendSystemMessage(MessageUtil.colorizeComponent(formatted));
+                                        }
                                     }
                                 }
+                                source.sendSystemMessage(MessageUtil.colorizeComponent("&6&l══════════════════════"));
                             }
                         }
                     });

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -270,19 +270,16 @@ public class CommandRegistration {
                                 if (result.lines.isEmpty()) {
                                     source.sendSystemMessage(MessageUtil.colorizeComponent("&7(Empty)"));
                                 } else {
-                                    if (source.isPlayer()) {
-                                        for (String line : result.lines) {
-                                            String formatted = org.ssoggy.ssoggysouls.command.action.AdminLogAction.formatLogLine(line);
-                                            source.sendSystemMessage(MessageUtil.colorizeComponent(formatted).withStyle(s ->
+                                    for (String line : result.lines) {
+                                        String formatted = org.ssoggy.ssoggysouls.command.action.AdminLogAction.formatLogLine(line);
+                                        net.minecraft.network.chat.MutableComponent component = MessageUtil.colorizeComponent(formatted);
+                                        if (source.isPlayer()) {
+                                            component = component.withStyle(s ->
                                                  s.withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.COPY_TO_CLIPBOARD, line))
                                                  .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, Component.literal("Click to copy log entry").withStyle(net.minecraft.ChatFormatting.GRAY)))
-                                            ));
+                                            );
                                         }
-                                    } else {
-                                        for (String line : result.lines) {
-                                            String formatted = org.ssoggy.ssoggysouls.command.action.AdminLogAction.formatLogLine(line);
-                                            source.sendSystemMessage(MessageUtil.colorizeComponent(formatted));
-                                        }
+                                        source.sendSystemMessage(component);
                                     }
                                 }
                                 source.sendSystemMessage(MessageUtil.colorizeComponent("&6&l══════════════════════"));

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/util/MessageUtil.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/util/MessageUtil.java
@@ -1,6 +1,7 @@
 package org.ssoggy.ssoggysouls.util;
 
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
 
 /**
  * Forge-specific MessageUtil.
@@ -24,16 +25,16 @@ public final class MessageUtil extends MessageHelper {
         return getRaw(key, replacements);
     }
 
-    public static Component get(String key, Object... replacements) {
+    public static MutableComponent get(String key, Object... replacements) {
         return colorizeComponent(prefix + getRaw(key, replacements));
     }
 
-    public static Component getNoPrefix(String key, Object... replacements) {
+    public static MutableComponent getNoPrefix(String key, Object... replacements) {
         return colorizeComponent(getRaw(key, replacements));
     }
 
-    public static Component colorizeComponent(String text) {
-        if (text == null) return Component.empty();
+    public static MutableComponent colorizeComponent(String text) {
+        if (text == null) return Component.empty().copy();
         return Component.literal(text.replace('&', '\u00a7'));
     }
 }

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -269,19 +269,16 @@ public class CommandRegistration {
                                 if (result.lines.isEmpty()) {
                                     source.sendSystemMessage(MessageUtil.colorizeComponent("&7(Empty)"));
                                 } else {
-                                    if (source.isPlayer()) {
-                                        for (String line : result.lines) {
-                                            String formatted = org.ssoggy.ssoggysouls.command.action.AdminLogAction.formatLogLine(line);
-                                            source.sendSystemMessage(MessageUtil.colorizeComponent(formatted).withStyle(s ->
+                                    for (String line : result.lines) {
+                                        String formatted = org.ssoggy.ssoggysouls.command.action.AdminLogAction.formatLogLine(line);
+                                        net.minecraft.network.chat.MutableComponent component = MessageUtil.colorizeComponent(formatted);
+                                        if (source.isPlayer()) {
+                                            component = component.withStyle(s ->
                                                  s.withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.COPY_TO_CLIPBOARD, line))
                                                  .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, Component.literal("Click to copy log entry").withStyle(net.minecraft.ChatFormatting.GRAY)))
-                                            ));
+                                            );
                                         }
-                                    } else {
-                                        for (String line : result.lines) {
-                                            String formatted = org.ssoggy.ssoggysouls.command.action.AdminLogAction.formatLogLine(line);
-                                            source.sendSystemMessage(MessageUtil.colorizeComponent(formatted));
-                                        }
+                                        source.sendSystemMessage(component);
                                     }
                                 }
                                 source.sendSystemMessage(MessageUtil.colorizeComponent("&6&l══════════════════════"));

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -265,20 +265,26 @@ public class CommandRegistration {
                                 source.sendFailure(MessageUtil.get("admin-log-read-error"));
                             }
                             case SUCCESS -> {
-                                source.sendSystemMessage(Component.literal("--- Recent Admin Logs ---").withStyle(net.minecraft.ChatFormatting.RED, net.minecraft.ChatFormatting.BOLD));
-                                if (source.isPlayer()) {
-                                    for (String line : result.lines) {
-                                        source.sendSystemMessage(Component.literal(line).withStyle(s ->
-                                            s.withColor(net.minecraft.ChatFormatting.GRAY)
-                                             .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.COPY_TO_CLIPBOARD, line))
-                                             .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, Component.literal("Click to copy log entry").withStyle(net.minecraft.ChatFormatting.GRAY)))
-                                        ));
-                                    }
+                                source.sendSystemMessage(MessageUtil.colorizeComponent("&6&l══ Admin Action Log ══"));
+                                if (result.lines.isEmpty()) {
+                                    source.sendSystemMessage(MessageUtil.colorizeComponent("&7(Empty)"));
                                 } else {
-                                    for (String line : result.lines) {
-                                        source.sendSystemMessage(Component.literal(line).withStyle(net.minecraft.ChatFormatting.GRAY));
+                                    if (source.isPlayer()) {
+                                        for (String line : result.lines) {
+                                            String formatted = org.ssoggy.ssoggysouls.command.action.AdminLogAction.formatLogLine(line);
+                                            source.sendSystemMessage(MessageUtil.colorizeComponent(formatted).withStyle(s ->
+                                                 s.withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.COPY_TO_CLIPBOARD, line))
+                                                 .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, Component.literal("Click to copy log entry").withStyle(net.minecraft.ChatFormatting.GRAY)))
+                                            ));
+                                        }
+                                    } else {
+                                        for (String line : result.lines) {
+                                            String formatted = org.ssoggy.ssoggysouls.command.action.AdminLogAction.formatLogLine(line);
+                                            source.sendSystemMessage(MessageUtil.colorizeComponent(formatted));
+                                        }
                                     }
                                 }
+                                source.sendSystemMessage(MessageUtil.colorizeComponent("&6&l══════════════════════"));
                             }
                         }
                     });

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/util/MessageUtil.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/util/MessageUtil.java
@@ -1,6 +1,7 @@
 package org.ssoggy.ssoggysouls.util;
 
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
 
 /**
  * Forge-specific MessageUtil.
@@ -24,16 +25,16 @@ public final class MessageUtil extends MessageHelper {
         return getRaw(key, replacements);
     }
 
-    public static Component get(String key, Object... replacements) {
+    public static MutableComponent get(String key, Object... replacements) {
         return colorizeComponent(prefix + getRaw(key, replacements));
     }
 
-    public static Component getNoPrefix(String key, Object... replacements) {
+    public static MutableComponent getNoPrefix(String key, Object... replacements) {
         return colorizeComponent(getRaw(key, replacements));
     }
 
-    public static Component colorizeComponent(String text) {
-        if (text == null) return Component.empty();
+    public static MutableComponent colorizeComponent(String text) {
+        if (text == null) return Component.empty().copy();
         return Component.literal(text.replace('&', '\u00a7'));
     }
 }


### PR DESCRIPTION
- Extracted formatLogLine logic into common AdminLogAction
- Updated Forge and NeoForge MessageUtil to return MutableComponent
- Ported interactive click-to-copy chat component logic from Paper to Fabric, Forge, and NeoForge adminlog commands
- Satisfied parity for interactive UI logs across loaders

---
*PR created automatically by Jules for task [4372985047499427292](https://jules.google.com/task/4372985047499427292) started by @SSoggyTacoMan*