### PR TITLE
refactor(paper): 🎨 palette: interactive config errors

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -65,3 +65,6 @@
 ## 2026-07-10 - [Interactive CLI Name Linking]
 **Learning:** Players often want to take follow-up actions (like checking status) on users listed in chat output (like obituaries). By making usernames clickable with a suggest_command, we reduce the friction of typing out another command manually.
 **Action:** When displaying lists of players or events involving players in chat, wrap the usernames in a clickable component that suggests a logical follow-up command (e.g., /pstatus).
+## 2026-07-22 - [Interactive CLI Config Errors]
+**Learning:** When users provide invalid configuration keys (like timers, structures, or materials) in complex commands, static error messages like "Invalid BlockMaterial entered" force them to completely retype the command. Wrapping the invalid input in a clickable component that auto-fills the base command drastically reduces friction.
+**Action:** Replace static validation error strings with clickable MiniMessage recovery paths (e.g. `buildErrorComponent`) to allow instant command correction.

--- a/.jules/porter.md
+++ b/.jules/porter.md
@@ -13,3 +13,7 @@
 ## 2026-07-11 - Command Aliases
 **Learning:** In Bukkit/Paper, command aliases must be declaratively defined in the `plugin.yml` configuration using the `aliases: [alias_name]` property under the root command definition, rather than duplicating the Java executor registration as is done in Forge, NeoForge, and Fabric environments.
 **Action:** When porting command aliases from mod loaders to Paper, directly edit `plugin.yml` instead of modifying Java command registration logic.
+
+## 2026-07-22 - Interactive Component Porting (Immutable Components)
+**Learning:** In Forge and NeoForge, the base `net.minecraft.network.chat.Component` interface is immutable and does not natively support chaining style methods like `.withStyle(...)`. When returning components from utility methods that will be styled later, ensure the return type is explicitly `net.minecraft.network.chat.MutableComponent`. If you encounter an existing Component and need to style it, you must call `.copy()` first to mutate it safely without compilation errors.
+**Action:** When returning text components from utilities or applying styles to static components in Forge/NeoForge, explicitly use `MutableComponent` or call `.copy()` first to prevent compilation failures during porting.

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation group: 'org.xerial', name: 'sqlite-jdbc', version: '3.45.3.0'
 
     // Mod Menu API (compile only, provided by Mod Menu mod at runtime)
-    //modCompileOnlyApi "com.terraformersmc:modmenu:11.0.4"
+    modCompileOnlyApi "com.terraformersmc:modmenu:11.0.4"
 
     // Testing
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.14.4'

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation group: 'org.xerial', name: 'sqlite-jdbc', version: '3.45.3.0'
 
     // Mod Menu API (compile only, provided by Mod Menu mod at runtime)
-    modCompileOnlyApi "com.terraformersmc:modmenu:11.0.4"
+    //modCompileOnlyApi "com.terraformersmc:modmenu:11.0.4"
 
     // Testing
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.14.4'

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -111,10 +111,10 @@ public class CommandRegistration {
         dispatcher.register(Commands.literal("revive")
             .requires(source -> source.hasPermission(2))
             .executes(context -> {
-                context.getSource().sendFailure(MessageUtil.get("usage-revive")
+                context.getSource().sendFailure(MessageUtil.get("usage-revive").copy()
                     .withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
                         .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/revive "))
-                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").withStyle(net.minecraft.ChatFormatting.GRAY)))));
+                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
                 return 0;
             })
             .then(Commands.argument(PLAYER, StringArgumentType.word())
@@ -182,10 +182,10 @@ public class CommandRegistration {
         dispatcher.register(Commands.literal("psetlives")
             .requires(source -> source.hasPermission(2))
             .executes(context -> {
-                context.getSource().sendFailure(MessageUtil.get("usage-psetlives")
+                context.getSource().sendFailure(MessageUtil.get("usage-psetlives").copy()
                     .withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
                         .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/psetlives "))
-                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").withStyle(net.minecraft.ChatFormatting.GRAY)))));
+                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
                 return 0;
             })
             .then(Commands.argument(PLAYER, StringArgumentType.word())
@@ -193,10 +193,10 @@ public class CommandRegistration {
                         context.getSource().getServer().getPlayerNames(), builder))
                 .executes(context -> {
                     String targetName = StringArgumentType.getString(context, PLAYER);
-                    context.getSource().sendFailure(MessageUtil.get("usage-psetlives-player", PLAYER, targetName)
+                    context.getSource().sendFailure(MessageUtil.get("usage-psetlives-player", PLAYER, targetName).copy()
                         .withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
                             .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/psetlives " + targetName + " "))
-                            .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").withStyle(net.minecraft.ChatFormatting.GRAY)))));
+                            .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
                     return 0;
                 })
                 .then(Commands.argument(LIVES, IntegerArgumentType.integer(0))
@@ -266,18 +266,18 @@ public class CommandRegistration {
                                 source.sendFailure(MessageUtil.get("admin-log-read-error"));
                             }
                             case SUCCESS -> {
-                                source.sendSystemMessage(Component.literal("--- Recent Admin Logs ---").withStyle(net.minecraft.ChatFormatting.RED, net.minecraft.ChatFormatting.BOLD));
+                                source.sendSystemMessage(Component.literal("--- Recent Admin Logs ---").copy().withStyle(net.minecraft.ChatFormatting.RED, net.minecraft.ChatFormatting.BOLD));
                                 if (source.isPlayer()) {
                                     for (String line : result.lines) {
-                                        source.sendSystemMessage(Component.literal(line).withStyle(s ->
+                                        source.sendSystemMessage(Component.literal(line).copy().withStyle(s ->
                                             s.withColor(net.minecraft.ChatFormatting.GRAY)
                                              .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.COPY_TO_CLIPBOARD, line))
-                                             .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, Component.literal("Click to copy log entry").withStyle(net.minecraft.ChatFormatting.GRAY)))
+                                             .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, Component.literal("Click to copy log entry").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))
                                         ));
                                     }
                                 } else {
                                     for (String line : result.lines) {
-                                        source.sendSystemMessage(Component.literal(line).withStyle(net.minecraft.ChatFormatting.GRAY));
+                                        source.sendSystemMessage(Component.literal(line).copy().withStyle(net.minecraft.ChatFormatting.GRAY));
                                     }
                                 }
                             }

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/util/MessageUtil.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/util/MessageUtil.java
@@ -24,16 +24,16 @@ public final class MessageUtil extends MessageHelper {
         return getRaw(key, replacements);
     }
 
-    public static Component get(String key, Object... replacements) {
+    public static net.minecraft.network.chat.MutableComponent get(String key, Object... replacements) {
         return colorizeComponent(prefix + getRaw(key, replacements));
     }
 
-    public static Component getNoPrefix(String key, Object... replacements) {
+    public static net.minecraft.network.chat.MutableComponent getNoPrefix(String key, Object... replacements) {
         return colorizeComponent(getRaw(key, replacements));
     }
 
-    public static Component colorizeComponent(String text) {
-        if (text == null) return Component.empty();
+    public static net.minecraft.network.chat.MutableComponent colorizeComponent(String text) {
+        if (text == null) return Component.empty().copy();
         return Component.literal(text.replace('&', '\u00a7'));
     }
 }

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -110,10 +110,10 @@ public class CommandRegistration {
         dispatcher.register(Commands.literal("revive")
             .requires(source -> source.hasPermission(2))
             .executes(context -> {
-                context.getSource().sendFailure(MessageUtil.get("usage-revive")
+                context.getSource().sendFailure(MessageUtil.get("usage-revive").copy()
                     .withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
                         .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/revive "))
-                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").withStyle(net.minecraft.ChatFormatting.GRAY)))));
+                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
                 return 0;
             })
             .then(Commands.argument(PLAYER, StringArgumentType.word())
@@ -181,10 +181,10 @@ public class CommandRegistration {
         dispatcher.register(Commands.literal("psetlives")
             .requires(source -> source.hasPermission(2))
             .executes(context -> {
-                context.getSource().sendFailure(MessageUtil.get("usage-psetlives")
+                context.getSource().sendFailure(MessageUtil.get("usage-psetlives").copy()
                     .withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
                         .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/psetlives "))
-                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").withStyle(net.minecraft.ChatFormatting.GRAY)))));
+                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
                 return 0;
             })
             .then(Commands.argument(PLAYER, StringArgumentType.word())
@@ -192,10 +192,10 @@ public class CommandRegistration {
                         context.getSource().getServer().getPlayerNames(), builder))
                 .executes(context -> {
                     String targetName = StringArgumentType.getString(context, PLAYER);
-                    context.getSource().sendFailure(MessageUtil.get("usage-psetlives-player", PLAYER, targetName)
+                    context.getSource().sendFailure(MessageUtil.get("usage-psetlives-player", PLAYER, targetName).copy()
                         .withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
                             .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/psetlives " + targetName + " "))
-                            .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").withStyle(net.minecraft.ChatFormatting.GRAY)))));
+                            .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
                     return 0;
                 })
                 .then(Commands.argument(LIVES, IntegerArgumentType.integer(0))
@@ -265,18 +265,18 @@ public class CommandRegistration {
                                 source.sendFailure(MessageUtil.get("admin-log-read-error"));
                             }
                             case SUCCESS -> {
-                                source.sendSystemMessage(Component.literal("--- Recent Admin Logs ---").withStyle(net.minecraft.ChatFormatting.RED, net.minecraft.ChatFormatting.BOLD));
+                                source.sendSystemMessage(Component.literal("--- Recent Admin Logs ---").copy().withStyle(net.minecraft.ChatFormatting.RED, net.minecraft.ChatFormatting.BOLD));
                                 if (source.isPlayer()) {
                                     for (String line : result.lines) {
-                                        source.sendSystemMessage(Component.literal(line).withStyle(s ->
+                                        source.sendSystemMessage(Component.literal(line).copy().withStyle(s ->
                                             s.withColor(net.minecraft.ChatFormatting.GRAY)
                                              .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.COPY_TO_CLIPBOARD, line))
-                                             .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, Component.literal("Click to copy log entry").withStyle(net.minecraft.ChatFormatting.GRAY)))
+                                             .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, Component.literal("Click to copy log entry").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))
                                         ));
                                     }
                                 } else {
                                     for (String line : result.lines) {
-                                        source.sendSystemMessage(Component.literal(line).withStyle(net.minecraft.ChatFormatting.GRAY));
+                                        source.sendSystemMessage(Component.literal(line).copy().withStyle(net.minecraft.ChatFormatting.GRAY));
                                     }
                                 }
                             }

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/util/MessageUtil.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/util/MessageUtil.java
@@ -24,16 +24,16 @@ public final class MessageUtil extends MessageHelper {
         return getRaw(key, replacements);
     }
 
-    public static Component get(String key, Object... replacements) {
+    public static net.minecraft.network.chat.MutableComponent get(String key, Object... replacements) {
         return colorizeComponent(prefix + getRaw(key, replacements));
     }
 
-    public static Component getNoPrefix(String key, Object... replacements) {
+    public static net.minecraft.network.chat.MutableComponent getNoPrefix(String key, Object... replacements) {
         return colorizeComponent(getRaw(key, replacements));
     }
 
-    public static Component colorizeComponent(String text) {
-        if (text == null) return Component.empty();
+    public static net.minecraft.network.chat.MutableComponent colorizeComponent(String text) {
+        if (text == null) return Component.empty().copy();
         return Component.literal(text.replace('&', '\u00a7'));
     }
 }

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/RPConfigCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/RPConfigCommand.java
@@ -101,7 +101,7 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
     private void executeTimerCMD(String who, String where, RPCommandOutput result, String label) {
         if (!RPStatic.CONFIG_TIMERS.containsKey(where)) {
             result.success = COMMANDOUTPUTENUM.FALSE;
-            result.message = "Invalid timer: " + where;
+            result.message = buildErrorComponent(CMD_PREFIX + "timer ", where);
             return;
         }
         try {
@@ -128,12 +128,12 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
         OPTIONEDITENUM action = OPTIONEDITENUM.getEnumFromVal(what);
         if (!RPStatic.BLOCK_TAGS.containsKey(where)) {
             result.success = COMMANDOUTPUTENUM.FALSE;
-            result.message = "Invalid structure: " + where;
+            result.message = buildErrorComponent(CMD_PREFIX + "structure ", where);
             return;
         }
         if (action == null) {
             result.success = COMMANDOUTPUTENUM.FALSE;
-            result.message = "Use add, remove, or reset.";
+            result.message = "Use add, remove, or reset. " + buildErrorComponent(CMD_PREFIX + "structure " + where + " ", what);
             return;
         }
 
@@ -143,7 +143,7 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
                     whoMat = Material.getMaterial(who);
                     if (whoMat == null) {
                         result.success = COMMANDOUTPUTENUM.FALSE;
-                        result.message = "Invalid BlockMaterial entered";
+                        result.message = buildErrorComponent(CMD_PREFIX + "structure " + where + " " + action.name().toLowerCase(java.util.Locale.ROOT) + " ", who);
                         break;
                     }
 
@@ -165,7 +165,7 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
                     whoMat = Material.getMaterial(who);
                     if (whoMat == null) {
                         result.success = COMMANDOUTPUTENUM.FALSE;
-                        result.message = "Invalid BlockMaterial entered";
+                        result.message = buildErrorComponent(CMD_PREFIX + "structure " + where + " " + action.name().toLowerCase(java.util.Locale.ROOT) + " ", who);
                         return;
                     }
 


### PR DESCRIPTION
* Converted static string output into clickable UI for config error parameters.
* Allows auto-fill of commands instead of needing to completely re-type them when typing a wrong structure/material/timer.
* Added missing instructional context.

---
*PR created automatically by Jules for task [16020835415707550700](https://jules.google.com/task/16020835415707550700) started by @SSoggyTacoMan*