### PR TITLE
🎨 Palette: Interactive Player Name in Admin Info

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -65,3 +65,6 @@
 ## 2026-07-10 - [Interactive CLI Name Linking]
 **Learning:** Players often want to take follow-up actions (like checking status) on users listed in chat output (like obituaries). By making usernames clickable with a suggest_command, we reduce the friction of typing out another command manually.
 **Action:** When displaying lists of players or events involving players in chat, wrap the usernames in a clickable component that suggests a logical follow-up command (e.g., /pstatus).
+## 2026-07-28 - [Interactive CLI Name Linking in Admin Info]
+**Learning:** When displaying detailed administrative information (like player profiles in `/psadmin info`), displaying the player's name as plain text misses an opportunity for intuitive navigation.
+**Action:** Enhance plain text player names in info displays with Kyori Adventure components that include a `suggestCommand` (e.g., `/pstatus <name>`) and a hover prompt ("Click to check status"), allowing admins to seamlessly transition between related commands without retyping names.

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminCommand.java
@@ -584,9 +584,15 @@ public class AdminCommand implements CommandExecutor, TabCompleter {
 
     private void sendInfoHeader(CommandSender sender, PlayerData data) {
         sender.sendMessage(MessageUtil.colorize("&6&l══ Player Info ══"));
-        sender.sendMessage(MessageUtil.colorize("&7Player: &f" + data.getUsername()));
 
         if (sender instanceof Player player) {
+            String nameStr = data.getUsername();
+            net.kyori.adventure.text.Component nameComp = net.kyori.adventure.text.Component.text("Player: ", net.kyori.adventure.text.format.NamedTextColor.GRAY)
+                .append(net.kyori.adventure.text.Component.text(nameStr, net.kyori.adventure.text.format.NamedTextColor.WHITE))
+                .clickEvent(net.kyori.adventure.text.event.ClickEvent.suggestCommand("/pstatus " + nameStr))
+                .hoverEvent(net.kyori.adventure.text.event.HoverEvent.showText(net.kyori.adventure.text.Component.text("Click to check status", net.kyori.adventure.text.format.NamedTextColor.GRAY)));
+            player.sendMessage(nameComp);
+
             String uuidStr = data.getUuid().toString();
             net.kyori.adventure.text.Component uuidComponent = net.kyori.adventure.text.Component.text("UUID: ", net.kyori.adventure.text.format.NamedTextColor.GRAY)
                 .append(net.kyori.adventure.text.Component.text(uuidStr, net.kyori.adventure.text.format.NamedTextColor.WHITE))
@@ -594,6 +600,7 @@ public class AdminCommand implements CommandExecutor, TabCompleter {
                 .hoverEvent(net.kyori.adventure.text.event.HoverEvent.showText(net.kyori.adventure.text.Component.text("Click to copy UUID", net.kyori.adventure.text.format.NamedTextColor.GRAY)));
             player.sendMessage(uuidComponent);
         } else {
+            sender.sendMessage(MessageUtil.colorize("&7Player: &f" + data.getUsername()));
             sender.sendMessage(MessageUtil.colorize("&7UUID: &f" + data.getUuid()));
         }
 


### PR DESCRIPTION
Made the player name interactive in `/psadmin info`.

Clicking the player name now suggests the `/pstatus <player>` command and shows a hover text.
This matches the existing interactive UUID and improves usability for server admins.

No major logic or system changes were made.

---
*PR created automatically by Jules for task [18408605352233144980](https://jules.google.com/task/18408605352233144980) started by @SSoggyTacoMan*