### PR TITLE
feat(paper): 🎨 Palette: Improve interactive configuration errors

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -65,3 +65,6 @@
 ## 2026-07-10 - [Interactive CLI Name Linking]
 **Learning:** Players often want to take follow-up actions (like checking status) on users listed in chat output (like obituaries). By making usernames clickable with a suggest_command, we reduce the friction of typing out another command manually.
 **Action:** When displaying lists of players or events involving players in chat, wrap the usernames in a clickable component that suggests a logical follow-up command (e.g., /pstatus).
+## 2026-07-29 - [Interactive CLI Number Parsing Errors with RPCommandOutput]
+**Learning:** In the `RPConfigCommand` class, legacy error messages for structural configuration errors (like 'Use add, remove, or reset.' and 'Invalid BlockMaterial entered') were static. By appending an interactive Kyori Adventure MiniMessage clickable recovery path using `buildErrorComponent`, players can now click errors to have the command auto-filled in their chat bar, preventing them from needing to manually correct and retype the command completely.
+**Action:** When replacing static error messages with generic clickable components, explicitly preserve any specific instructional context by concatenating it with the interactive component, rather than completely overwriting it.

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -111,10 +111,10 @@ public class CommandRegistration {
         dispatcher.register(Commands.literal("revive")
             .requires(source -> source.hasPermission(2))
             .executes(context -> {
-                context.getSource().sendFailure(MessageUtil.get("usage-revive")
+                context.getSource().sendFailure(MessageUtil.get("usage-revive").copy()
                     .withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
                         .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/revive "))
-                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").withStyle(net.minecraft.ChatFormatting.GRAY)))));
+                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
                 return 0;
             })
             .then(Commands.argument(PLAYER, StringArgumentType.word())
@@ -182,10 +182,10 @@ public class CommandRegistration {
         dispatcher.register(Commands.literal("psetlives")
             .requires(source -> source.hasPermission(2))
             .executes(context -> {
-                context.getSource().sendFailure(MessageUtil.get("usage-psetlives")
+                context.getSource().sendFailure(MessageUtil.get("usage-psetlives").copy()
                     .withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
                         .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/psetlives "))
-                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").withStyle(net.minecraft.ChatFormatting.GRAY)))));
+                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
                 return 0;
             })
             .then(Commands.argument(PLAYER, StringArgumentType.word())
@@ -193,10 +193,10 @@ public class CommandRegistration {
                         context.getSource().getServer().getPlayerNames(), builder))
                 .executes(context -> {
                     String targetName = StringArgumentType.getString(context, PLAYER);
-                    context.getSource().sendFailure(MessageUtil.get("usage-psetlives-player", PLAYER, targetName)
+                    context.getSource().sendFailure(MessageUtil.get("usage-psetlives-player", PLAYER, targetName).copy()
                         .withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
                             .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/psetlives " + targetName + " "))
-                            .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").withStyle(net.minecraft.ChatFormatting.GRAY)))));
+                            .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
                     return 0;
                 })
                 .then(Commands.argument(LIVES, IntegerArgumentType.integer(0))

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -110,10 +110,10 @@ public class CommandRegistration {
         dispatcher.register(Commands.literal("revive")
             .requires(source -> source.hasPermission(2))
             .executes(context -> {
-                context.getSource().sendFailure(MessageUtil.get("usage-revive")
+                context.getSource().sendFailure(MessageUtil.get("usage-revive").copy()
                     .withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
                         .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/revive "))
-                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").withStyle(net.minecraft.ChatFormatting.GRAY)))));
+                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
                 return 0;
             })
             .then(Commands.argument(PLAYER, StringArgumentType.word())
@@ -181,10 +181,10 @@ public class CommandRegistration {
         dispatcher.register(Commands.literal("psetlives")
             .requires(source -> source.hasPermission(2))
             .executes(context -> {
-                context.getSource().sendFailure(MessageUtil.get("usage-psetlives")
+                context.getSource().sendFailure(MessageUtil.get("usage-psetlives").copy()
                     .withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
                         .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/psetlives "))
-                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").withStyle(net.minecraft.ChatFormatting.GRAY)))));
+                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
                 return 0;
             })
             .then(Commands.argument(PLAYER, StringArgumentType.word())
@@ -192,10 +192,10 @@ public class CommandRegistration {
                         context.getSource().getServer().getPlayerNames(), builder))
                 .executes(context -> {
                     String targetName = StringArgumentType.getString(context, PLAYER);
-                    context.getSource().sendFailure(MessageUtil.get("usage-psetlives-player", PLAYER, targetName)
+                    context.getSource().sendFailure(MessageUtil.get("usage-psetlives-player", PLAYER, targetName).copy()
                         .withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
                             .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/psetlives " + targetName + " "))
-                            .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").withStyle(net.minecraft.ChatFormatting.GRAY)))));
+                            .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
                     return 0;
                 })
                 .then(Commands.argument(LIVES, IntegerArgumentType.integer(0))

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/RPConfigCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/RPConfigCommand.java
@@ -121,7 +121,7 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
         result.message = "Set " + where + " to " + whoBool;
     }
 
-    private void executeStructureCMD(String who, String what, String where, RPCommandOutput result) {
+    private void executeStructureCMD(String who, String what, String where, RPCommandOutput result, String label) {
         Set<Material> whoSet;
         Material whoMat;
         String whoName;
@@ -133,7 +133,7 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
         }
         if (action == null) {
             result.success = COMMANDOUTPUTENUM.FALSE;
-            result.message = "Use add, remove, or reset.";
+            result.message = "Use add, remove, or reset. " + buildErrorComponent("/" + label + " structure " + where + " ", what);
             return;
         }
 
@@ -143,7 +143,7 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
                     whoMat = Material.getMaterial(who);
                     if (whoMat == null) {
                         result.success = COMMANDOUTPUTENUM.FALSE;
-                        result.message = "Invalid BlockMaterial entered";
+                        result.message = "Invalid BlockMaterial entered. " + buildErrorComponent("/" + label + " structure " + where + " " + what + " ", who);
                         break;
                     }
 
@@ -165,7 +165,7 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
                     whoMat = Material.getMaterial(who);
                     if (whoMat == null) {
                         result.success = COMMANDOUTPUTENUM.FALSE;
-                        result.message = "Invalid BlockMaterial entered";
+                        result.message = "Invalid BlockMaterial entered. " + buildErrorComponent("/" + label + " structure " + where + " " + what + " ", who);
                         return;
                     }
 
@@ -201,7 +201,7 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
             result.message = "Please use <click:suggest_command:'/revivalconfig '><hover:show_text:'<gray>Click to auto-fill this command</gray>'><gray>/revivalconfig \\<structure|gamerule|timer|reload\\></gray></hover></click>";
         } else {
             switch (option) {
-                case OPTIONCONFIGENUM.STRUCTURE -> handleStructure(args, result);
+                case OPTIONCONFIGENUM.STRUCTURE -> handleStructure(args, result, label);
                 case OPTIONCONFIGENUM.GAMERULE -> handleGamerule(args, result);
                 case OPTIONCONFIGENUM.TIMER -> handleTimer(args, result, label);
                 case OPTIONCONFIGENUM.RELOAD -> executeReloadCMD(result);
@@ -224,7 +224,7 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
         return true;
     }
 
-    private void handleStructure(String[] args, RPCommandOutput result) {
+    private void handleStructure(String[] args, RPCommandOutput result, String label) {
         switch (args.length) {
             case 0, 1:
                 result.success = COMMANDOUTPUTENUM.FALSE;
@@ -251,10 +251,10 @@ public class RPConfigCommand implements CommandExecutor, TabCompleter {
                     break;
                 }
                 // reset action has exactly 3 args, so no material argument is available
-                executeStructureCMD("", args[2], args[1], result);
+                executeStructureCMD("", args[2], args[1], result, label);
                 break;
             default:
-                executeStructureCMD(args.length > 3 ? args[3].toUpperCase() : "", args[2], args[1], result); // All params are successfully entered
+                executeStructureCMD(args.length > 3 ? args[3].toUpperCase() : "", args[2], args[1], result, label); // All params are successfully entered
                 break;
         }
     }


### PR DESCRIPTION
💡 **What:** Replaced static error messages for structural configuration argument errors with interactive, clickable MiniMessage suggestions via `buildErrorComponent`.

🎯 **Why:** Previously, if a player made a typo entering a structure configuration command (like an invalid material or missing action), they were shown a static "Invalid BlockMaterial entered" or "Use add, remove, or reset." message. This forced them to manually retype the entire complex command string (`/revivalconfig structure ...`). By making the errors clickable with a pre-filled suggestion, we significantly reduce friction and typing effort for server administrators configuring the plugin.

♿ **Accessibility/UX:** Greatly improves quality of life by reducing redundant typing for configuration command typos. Preserves the original instructional context (e.g. "Use add, remove, or reset") while appending the actionable auto-fill suggestion, making the error clear while providing an immediate recovery path.

---
*PR created automatically by Jules for task [9340537558753984423](https://jules.google.com/task/9340537558753984423) started by @SSoggyTacoMan*