### PR TITLE
feat(paper): make names in trust list interactive

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -65,3 +65,7 @@
 ## 2026-07-10 - [Interactive CLI Name Linking]
 **Learning:** Players often want to take follow-up actions (like checking status) on users listed in chat output (like obituaries). By making usernames clickable with a suggest_command, we reduce the friction of typing out another command manually.
 **Action:** When displaying lists of players or events involving players in chat, wrap the usernames in a clickable component that suggests a logical follow-up command (e.g., /pstatus).
+
+## 2026-07-15 - [Interactive CLI Trust List]
+**Learning:** Users viewing their trust list often want to manage it immediately. By wrapping the names in a clickable component that suggests /trust revoke <name>, we streamline the workflow and reduce command typing friction.
+**Action:** When displaying lists of relationships (like /trust info), make the names interactive to auto-fill the most common management command (e.g. revoke).

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/SocialCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/SocialCommand.java
@@ -211,10 +211,11 @@ public class SocialCommand implements CommandExecutor, TabCompleter {
         output.success = COMMANDOUTPUTENUM.RAW;
         output.message = "\n<green>--- Trust List ---</green>\n";
 
-        social.getRelationsToAll((k, v) -> k.equals(targetPlayerUUID)).forEach((k, v) ->
-            output.message += "- " + RPUtil.getUsernameFromCache(k) + ": " + v + "\n"
-            // Future: Make them glow locally when this command is ran
-        );
+                social.getRelationsToAll((k, v) -> k.equals(targetPlayerUUID)).forEach((k, v) -> {
+            String username = RPUtil.getUsernameFromCache(k);
+            String escapedUsername = username != null ? net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().escapeTags(username) : "Unknown";
+            output.message += "- <click:suggest_command:'/trust revoke " + escapedUsername + "'><hover:show_text:'<gray>Click to revoke trust for " + escapedUsername + "</gray>'>" + escapedUsername + "</hover></click>: " + v + "\n";
+        });
     }
 
 


### PR DESCRIPTION
Made the usernames in the `/trust info` list interactive. Clicking a username now suggests the `/trust revoke <username>` command. This reduces the friction of managing trust lists. Escaped usernames to ensure safety. Also logged this new learning in the Palette journal.

---
*PR created automatically by Jules for task [12929131188927405107](https://jules.google.com/task/12929131188927405107) started by @SSoggyTacoMan*