### PR TITLE
🎨 Palette: Make /trust info usernames clickable

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -65,3 +65,6 @@
 ## 2026-07-10 - [Interactive CLI Name Linking]
 **Learning:** Players often want to take follow-up actions (like checking status) on users listed in chat output (like obituaries). By making usernames clickable with a suggest_command, we reduce the friction of typing out another command manually.
 **Action:** When displaying lists of players or events involving players in chat, wrap the usernames in a clickable component that suggests a logical follow-up command (e.g., /pstatus).
+## 2026-07-21 - [Interactive CLI Trust List Actions]
+**Learning:** When users view trust lists (like via `/trust info`), they frequently want to take follow-up actions or check the status of the trusted/blocked players. Displaying static names forces them to manually retype names into commands like `/pstatus`.
+**Action:** Wrap usernames in trust/social lists with interactive `<click:suggest_command:'/pstatus <name>'>` and `<hover>` components to reduce command friction.

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/SocialCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/hrm/dlc/commands/SocialCommand.java
@@ -211,10 +211,12 @@ public class SocialCommand implements CommandExecutor, TabCompleter {
         output.success = COMMANDOUTPUTENUM.RAW;
         output.message = "\n<green>--- Trust List ---</green>\n";
 
-        social.getRelationsToAll((k, v) -> k.equals(targetPlayerUUID)).forEach((k, v) ->
-            output.message += "- " + RPUtil.getUsernameFromCache(k) + ": " + v + "\n"
+        social.getRelationsToAll((k, v) -> k.equals(targetPlayerUUID)).forEach((k, v) -> {
+            String username = RPUtil.getUsernameFromCache(k);
+            String escapedUsername = net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().escapeTags(username);
+            output.message += "- <click:suggest_command:'/pstatus " + escapedUsername + "'><hover:show_text:'<gray>Click to view status</gray>'>" + escapedUsername + "</hover></click>: " + v + "\n";
             // Future: Make them glow locally when this command is ran
-        );
+        });
     }
 
 


### PR DESCRIPTION
💡 What: Added interactive Kyori MiniMessage components to usernames displayed in /trust info.
🎯 Why: Reduces friction by allowing players to click a username to auto-fill the /pstatus command, rather than typing it manually.
📸 Before/After: Before, it was static text. Now, the usernames are clickable and have a hover state.
♿ Accessibility: Improves usability by offering quick command actions and hover text context.

---
*PR created automatically by Jules for task [16134009594958666749](https://jules.google.com/task/16134009594958666749) started by @SSoggyTacoMan*