### PR TITLE
🎨 Palette: Interactive Grace Confirmation Errors

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -65,3 +65,6 @@
 ## 2026-07-10 - [Interactive CLI Name Linking]
 **Learning:** Players often want to take follow-up actions (like checking status) on users listed in chat output (like obituaries). By making usernames clickable with a suggest_command, we reduce the friction of typing out another command manually.
 **Action:** When displaying lists of players or events involving players in chat, wrap the usernames in a clickable component that suggests a logical follow-up command (e.g., /pstatus).
+## 2026-08-05 - [Interactive CLI Grace Confirmation Recovery]
+**Learning:** When multi-step commands (like `/psadmin grace set` -> `/psadmin confirm`) time out or fail state checks, static error messages force users to manually restart the entire workflow from scratch, which is tedious and error-prone.
+**Action:** When catching state expiry or missing context errors in multi-step CLI workflows, use `CommandUtil.sendInteractiveUsage()` to provide a clickable suggestion that auto-fills the initial base command (like `/psadmin grace set `), creating a frictionless recovery loop.

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/util/MessageUtil.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/util/MessageUtil.java
@@ -24,15 +24,15 @@ public final class MessageUtil extends MessageHelper {
         return getRaw(key, replacements);
     }
 
-    public static Component get(String key, Object... replacements) {
+    public static net.minecraft.network.chat.MutableComponent get(String key, Object... replacements) {
         return colorizeComponent(prefix + getRaw(key, replacements));
     }
 
-    public static Component getNoPrefix(String key, Object... replacements) {
+    public static net.minecraft.network.chat.MutableComponent getNoPrefix(String key, Object... replacements) {
         return colorizeComponent(getRaw(key, replacements));
     }
 
-    public static Component colorizeComponent(String text) {
+    public static net.minecraft.network.chat.MutableComponent colorizeComponent(String text) {
         if (text == null) return Component.empty();
         return Component.literal(text.replace('&', '\u00a7'));
     }

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/util/MessageUtil.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/util/MessageUtil.java
@@ -24,15 +24,15 @@ public final class MessageUtil extends MessageHelper {
         return getRaw(key, replacements);
     }
 
-    public static Component get(String key, Object... replacements) {
+    public static net.minecraft.network.chat.MutableComponent get(String key, Object... replacements) {
         return colorizeComponent(prefix + getRaw(key, replacements));
     }
 
-    public static Component getNoPrefix(String key, Object... replacements) {
+    public static net.minecraft.network.chat.MutableComponent getNoPrefix(String key, Object... replacements) {
         return colorizeComponent(getRaw(key, replacements));
     }
 
-    public static Component colorizeComponent(String text) {
+    public static net.minecraft.network.chat.MutableComponent colorizeComponent(String text) {
         if (text == null) return Component.empty();
         return Component.literal(text.replace('&', '\u00a7'));
     }

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminCommand.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/command/AdminCommand.java
@@ -314,8 +314,9 @@ public class AdminCommand implements CommandExecutor, TabCompleter {
 
         PendingGrace pending = pendingGraceConfirmations.remove(getConfirmationKey(sender));
         if (pending == null) {
-            sender.sendMessage(MessageUtil.colorize(
-                    "&cNo pending grace confirmation found. Use /psadmin grace set first."));
+            CommandUtil.sendInteractiveUsage(sender,
+                    "&cNo pending grace confirmation found. Use /psadmin grace set first.",
+                    "/psadmin grace set ");
             return;
         }
 
@@ -323,8 +324,9 @@ public class AdminCommand implements CommandExecutor, TabCompleter {
         long confirmationAge = System.currentTimeMillis() - pending.createdAt();
         long twoMinutesMillis = 2 * 60 * 1000L;
         if (confirmationAge > twoMinutesMillis) {
-            sender.sendMessage(MessageUtil.colorize(
-                    "&cGrace confirmation expired. Please run /psadmin grace set again."));
+            CommandUtil.sendInteractiveUsage(sender,
+                    "&cGrace confirmation expired. Please run /psadmin grace set again.",
+                    "/psadmin grace set ");
             return;
         }
 


### PR DESCRIPTION
💡 What: Upgraded static grace confirmation expiry/not-found error messages to be interactive, allowing users to click them to auto-fill `/psadmin grace set `.
🎯 Why: When a confirmation expires or is missing, users previously had to manually re-type the entire `/psadmin grace set <player> <time>` command, which is tedious and error-prone. This creates a frictionless recovery path.
📸 Before/After: Before, error was plain text. After, clicking the error auto-fills the base command context.
♿ Accessibility: Reduces cognitive load and motor friction for server administrators by providing immediate, clickable recovery actions for workflow interruptions.

---
*PR created automatically by Jules for task [15442673470461656816](https://jules.google.com/task/15442673470461656816) started by @SSoggyTacoMan*