### PR TITLE
🛡️ Sentinel: [HIGH] Fix legacy color code injection in Admin Log

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,7 @@
 **Vulnerability:** In `LeaveLimboCommand.java`, `RPConfig.java`, and `UpdateChecker.java`, exception messages (`e.getMessage()`) were directly appended to error logs using `logger.severe()` or `logger.warning()`.
 **Learning:** Appending `e.getMessage()` manually instead of passing the entire Exception object can leak sensitive information to the logs without providing a full stack trace, reducing debuggability and posing a potential security risk.
 **Prevention:** Always use `logger.log(Level.SEVERE, "context message", exception)` or equivalent to properly log the context message and the full stack trace securely.
+## 2026-05-16 - [Fix legacy color code injection in Admin Log]
+**Vulnerability:** Unsanitized user inputs in AdminLogger could include the `&` character which gets deserialized using `LegacyComponentSerializer.legacyAmpersand().deserialize()`.
+**Learning:** This exposes the application to legacy color code injection and chat formatting spoofing.
+**Prevention:** Sanitize the `&` character (e.g., replace with full-width `＆`) before writing to disk.

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/util/AdminLogger.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/util/AdminLogger.java
@@ -21,7 +21,7 @@ public class AdminLogger {
 
     private static String sanitize(String input) {
         if (input == null) return "null";
-        return input.replace('\n', '_').replace('\r', '_');
+        return input.replace('\n', '_').replace('\r', '_').replace('&', '＆');
     }
 
     public static void log(String sender, String action) {

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/util/AdminLogger.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/util/AdminLogger.java
@@ -21,7 +21,7 @@ public class AdminLogger {
 
     private static String sanitize(String input) {
         if (input == null) return "null";
-        return input.replace('\n', '_').replace('\r', '_');
+        return input.replace('\n', '_').replace('\r', '_').replace('&', '＆');
     }
 
     public static void log(String sender, String action) {

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/util/AdminLogger.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/util/AdminLogger.java
@@ -21,7 +21,7 @@ public class AdminLogger {
 
     private static String sanitize(String input) {
         if (input == null) return "null";
-        return input.replace('\n', '_').replace('\r', '_');
+        return input.replace('\n', '_').replace('\r', '_').replace('&', '＆');
     }
 
     public static void log(String sender, String action) {

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/util/AdminLogger.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/util/AdminLogger.java
@@ -20,7 +20,7 @@ public class AdminLogger {
 
     private static String sanitize(String input) {
         if (input == null) return "null";
-        return input.replace('\n', '_').replace('\r', '_');
+        return input.replace('\n', '_').replace('\r', '_').replace('&', '＆');
     }
 
     public static void log(SSoggySouls plugin, String sender, String action) {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: User input in AdminLogger.java was not sanitizing the `&` character. When read by `AdminLogCommand.java`, the `&` character is deserialized using `LegacyComponentSerializer.legacyAmpersand().deserialize()`. 
🎯 Impact: This allows malicious users to inject legacy color codes or format chat messages spoofing.
🔧 Fix: Sanitized the `&` character in AdminLogger.java across all loaders by replacing it with full-width `＆`.
✅ Verification: Ensure the fix is present across all modules. Run tests and verify they pass.

---
*PR created automatically by Jules for task [8415167629526002130](https://jules.google.com/task/8415167629526002130) started by @SSoggyTacoMan*