### PR TITLE
🛡️ Sentinel: [HIGH] Fix legacy color code injection in admin logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** In `LeaveLimboCommand.java`, `RPConfig.java`, and `UpdateChecker.java`, exception messages (`e.getMessage()`) were directly appended to error logs using `logger.severe()` or `logger.warning()`.
 **Learning:** Appending `e.getMessage()` manually instead of passing the entire Exception object can leak sensitive information to the logs without providing a full stack trace, reducing debuggability and posing a potential security risk.
 **Prevention:** Always use `logger.log(Level.SEVERE, "context message", exception)` or equivalent to properly log the context message and the full stack trace securely.
+
+## 2024-08-13 - Legacy Color Code Injection in Admin Logs
+**Vulnerability:** User input logged in `AdminLogger.java` (like usernames) was not sanitized for `&` characters. When viewed via `AdminLogCommand`, this input was processed by `LegacyComponentSerializer.legacyAmpersand()`, allowing chat formatting spoofing.
+**Learning:** When data stored in plain text logs is later deserialized into interactive/formatted chat components, all special characters used by the deserializer (like `&`) must be sanitized *before* writing to disk.
+**Prevention:** Always explicitly sanitize the `&` character (e.g., replace with full-width `＆`) before writing to disk any user input that will later be parsed by Kyori's `LegacyComponentSerializer`.

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/util/AdminLogger.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/util/AdminLogger.java
@@ -21,7 +21,7 @@ public class AdminLogger {
 
     private static String sanitize(String input) {
         if (input == null) return "null";
-        return input.replace('\n', '_').replace('\r', '_');
+        return input.replace('\n', '_').replace('\r', '_').replace('&', '＆');
     }
 
     public static void log(String sender, String action) {

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -7,6 +7,7 @@ import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.SharedSuggestionProvider;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.GameType;
 import net.minecraftforge.event.RegisterCommandsEvent;
@@ -112,9 +113,9 @@ public class CommandRegistration {
             .requires(source -> source.hasPermission(2))
             .executes(context -> {
                 context.getSource().sendFailure(MessageUtil.get("usage-revive")
-                    .withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
+                    .copy().withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
                         .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/revive "))
-                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").withStyle(net.minecraft.ChatFormatting.GRAY)))));
+                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
                 return 0;
             })
             .then(Commands.argument(PLAYER, StringArgumentType.word())
@@ -183,9 +184,9 @@ public class CommandRegistration {
             .requires(source -> source.hasPermission(2))
             .executes(context -> {
                 context.getSource().sendFailure(MessageUtil.get("usage-psetlives")
-                    .withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
+                    .copy().withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
                         .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/psetlives "))
-                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").withStyle(net.minecraft.ChatFormatting.GRAY)))));
+                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
                 return 0;
             })
             .then(Commands.argument(PLAYER, StringArgumentType.word())
@@ -194,9 +195,9 @@ public class CommandRegistration {
                 .executes(context -> {
                     String targetName = StringArgumentType.getString(context, PLAYER);
                     context.getSource().sendFailure(MessageUtil.get("usage-psetlives-player", PLAYER, targetName)
-                        .withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
+                        .copy().withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
                             .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/psetlives " + targetName + " "))
-                            .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").withStyle(net.minecraft.ChatFormatting.GRAY)))));
+                            .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
                     return 0;
                 })
                 .then(Commands.argument(LIVES, IntegerArgumentType.integer(0))

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/util/AdminLogger.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/util/AdminLogger.java
@@ -21,7 +21,7 @@ public class AdminLogger {
 
     private static String sanitize(String input) {
         if (input == null) return "null";
-        return input.replace('\n', '_').replace('\r', '_');
+        return input.replace('\n', '_').replace('\r', '_').replace('&', '＆');
     }
 
     public static void log(String sender, String action) {

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -7,6 +7,7 @@ import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.SharedSuggestionProvider;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.GameType;
 import net.neoforged.neoforge.event.RegisterCommandsEvent;
@@ -111,9 +112,9 @@ public class CommandRegistration {
             .requires(source -> source.hasPermission(2))
             .executes(context -> {
                 context.getSource().sendFailure(MessageUtil.get("usage-revive")
-                    .withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
+                    .copy().withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
                         .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/revive "))
-                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").withStyle(net.minecraft.ChatFormatting.GRAY)))));
+                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
                 return 0;
             })
             .then(Commands.argument(PLAYER, StringArgumentType.word())
@@ -182,9 +183,9 @@ public class CommandRegistration {
             .requires(source -> source.hasPermission(2))
             .executes(context -> {
                 context.getSource().sendFailure(MessageUtil.get("usage-psetlives")
-                    .withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
+                    .copy().withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
                         .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/psetlives "))
-                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").withStyle(net.minecraft.ChatFormatting.GRAY)))));
+                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
                 return 0;
             })
             .then(Commands.argument(PLAYER, StringArgumentType.word())
@@ -193,9 +194,9 @@ public class CommandRegistration {
                 .executes(context -> {
                     String targetName = StringArgumentType.getString(context, PLAYER);
                     context.getSource().sendFailure(MessageUtil.get("usage-psetlives-player", PLAYER, targetName)
-                        .withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
+                        .copy().withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
                             .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/psetlives " + targetName + " "))
-                            .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").withStyle(net.minecraft.ChatFormatting.GRAY)))));
+                            .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
                     return 0;
                 })
                 .then(Commands.argument(LIVES, IntegerArgumentType.integer(0))

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/util/AdminLogger.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/util/AdminLogger.java
@@ -21,7 +21,7 @@ public class AdminLogger {
 
     private static String sanitize(String input) {
         if (input == null) return "null";
-        return input.replace('\n', '_').replace('\r', '_');
+        return input.replace('\n', '_').replace('\r', '_').replace('&', '＆');
     }
 
     public static void log(String sender, String action) {

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/util/AdminLogger.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/util/AdminLogger.java
@@ -20,7 +20,7 @@ public class AdminLogger {
 
     private static String sanitize(String input) {
         if (input == null) return "null";
-        return input.replace('\n', '_').replace('\r', '_');
+        return input.replace('\n', '_').replace('\r', '_').replace('&', '＆');
     }
 
     public static void log(SSoggySouls plugin, String sender, String action) {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: User input (like usernames) in admin logs was not sanitized for '&', allowing malicious users to inject legacy color codes when the logs were viewed via the admin command, as the logs are parsed using Kyori's LegacyComponentSerializer.
🎯 Impact: Attackers could spoof chat formatting, potentially disguising admin actions or injecting inappropriate formatting.
🔧 Fix: Explicitly replaced '&' with the full-width '＆' in the AdminLogger sanitize method across all platforms to neutralize the formatting codes before they are written to disk.
✅ Verification: Run the admin log tests and manually attempt to trigger an admin action with a username containing '&c' - it should display as the literal character rather than applying red color formatting.

---
*PR created automatically by Jules for task [3559426172113365839](https://jules.google.com/task/3559426172113365839) started by @SSoggyTacoMan*