### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
@@ -99,8 +99,15 @@ public class LimboServerListener {
     }
 
     private static boolean isWhitelistedCommand(String message) {
-        String[] tokens = message.trim().split("\\s+");
-        String command = tokens.length > 0 ? tokens[0].toLowerCase(Locale.ROOT) : "";
+        String clean = message.trim();
+        int spaceIdx = -1;
+        for (int i = 0; i < clean.length(); i++) {
+            if (Character.isWhitespace(clean.charAt(i))) {
+                spaceIdx = i;
+                break;
+            }
+        }
+        String command = (spaceIdx == -1 ? clean : clean.substring(0, spaceIdx)).toLowerCase(Locale.ROOT);
         return WHITELISTED_COMMANDS.contains(command) || WHITELISTED_COMMANDS.contains("/" + command);
     }
 

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
@@ -34,9 +34,15 @@ public class LimboServerListener {
     }
 
     private static boolean isWhitelistedCommand(String fullCommand) {
-        String clean = fullCommand.trim().toLowerCase(java.util.Locale.ROOT);
-        String[] tokens = clean.split("\\s+");
-        String command = tokens.length > 0 ? tokens[0] : "";
+        String clean = fullCommand.trim();
+        int spaceIdx = -1;
+        for (int i = 0; i < clean.length(); i++) {
+            if (Character.isWhitespace(clean.charAt(i))) {
+                spaceIdx = i;
+                break;
+            }
+        }
+        String command = (spaceIdx == -1 ? clean : clean.substring(0, spaceIdx)).toLowerCase(java.util.Locale.ROOT);
         return WHITELISTED_COMMANDS.contains(command) || WHITELISTED_COMMANDS.contains("/" + command);
     }
 

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
@@ -34,9 +34,15 @@ public class LimboServerListener {
     }
 
     private static boolean isWhitelistedCommand(String fullCommand) {
-        String clean = fullCommand.trim().toLowerCase(java.util.Locale.ROOT);
-        String[] tokens = clean.split("\\s+");
-        String command = tokens.length > 0 ? tokens[0] : "";
+        String clean = fullCommand.trim();
+        int spaceIdx = -1;
+        for (int i = 0; i < clean.length(); i++) {
+            if (Character.isWhitespace(clean.charAt(i))) {
+                spaceIdx = i;
+                break;
+            }
+        }
+        String command = (spaceIdx == -1 ? clean : clean.substring(0, spaceIdx)).toLowerCase(java.util.Locale.ROOT);
         return WHITELISTED_COMMANDS.contains(command) || WHITELISTED_COMMANDS.contains("/" + command);
     }
 

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
@@ -140,8 +140,15 @@ public class LimboServerListener implements Listener {
         if (player.hasPermission(PERM_BYPASS) || player.hasPermission("ssoggysouls.admin")) return;
 
         String rawMessage = event.getMessage();
-        int spaceIdx = rawMessage.indexOf(' ');
-        String command = (spaceIdx == -1 ? rawMessage : rawMessage.substring(0, spaceIdx)).toLowerCase(java.util.Locale.ROOT);
+        String clean = rawMessage.trim();
+        int spaceIdx = -1;
+        for (int i = 0; i < clean.length(); i++) {
+            if (Character.isWhitespace(clean.charAt(i))) {
+                spaceIdx = i;
+                break;
+            }
+        }
+        String command = (spaceIdx == -1 ? clean : clean.substring(0, spaceIdx)).toLowerCase(java.util.Locale.ROOT);
 
         if (isWhitelistedCommand(command)) {
             return;


### PR DESCRIPTION
💡 What: Replaced string .split("\\s+") and indexOf(' ') with manual Character.isWhitespace() iteration and substring() in LimboServerListener across Fabric, Forge, NeoForge, and Paper.
🎯 Why: Using .split("\\s+") inside high-frequency listeners unnecessarily allocates string arrays and uses regex parsing to extract just the first command word.
📊 Impact: Reduces unnecessary object allocations during chat/command events.
🔬 Measurement: Code analysis shows memory allocations are bypassed on all non-whitelisted Limbo chat event occurrences.

---
*PR created automatically by Jules for task [13337039576411883629](https://jules.google.com/task/13337039576411883629) started by @SSoggyTacoMan*