### PR TITLE
📦 Porter: [Limbo Command Optimization] ported to [Fabric, Forge, NeoForge]

### DIFF
--- a/common/src/main/java/org/ssoggy/ssoggysouls/util/CommandParserUtil.java
+++ b/common/src/main/java/org/ssoggy/ssoggysouls/util/CommandParserUtil.java
@@ -1,0 +1,17 @@
+package org.ssoggy.ssoggysouls.util;
+
+public final class CommandParserUtil {
+    private CommandParserUtil() {}
+
+    public static String getBaseCommand(String fullCommand) {
+        String trimmed = fullCommand.trim();
+        int spaceIdx = -1;
+        for (int i = 0; i < trimmed.length(); i++) {
+            if (Character.isWhitespace(trimmed.charAt(i))) {
+                spaceIdx = i;
+                break;
+            }
+        }
+        return (spaceIdx == -1 ? trimmed : trimmed.substring(0, spaceIdx)).toLowerCase(java.util.Locale.ROOT);
+    }
+}

--- a/common/src/test/java/org/ssoggy/ssoggysouls/util/CommandParserUtilTest.java
+++ b/common/src/test/java/org/ssoggy/ssoggysouls/util/CommandParserUtilTest.java
@@ -1,0 +1,40 @@
+package org.ssoggy.ssoggysouls.util;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CommandParserUtilTest {
+
+    @Test
+    void testGetBaseCommand_NoSpaces() {
+        assertEquals("help", CommandParserUtil.getBaseCommand("help"));
+    }
+
+    @Test
+    void testGetBaseCommand_WithSpaces() {
+        assertEquals("msg", CommandParserUtil.getBaseCommand("msg Notch hello"));
+    }
+
+    @Test
+    void testGetBaseCommand_Uppercase() {
+        assertEquals("list", CommandParserUtil.getBaseCommand("LIST"));
+        assertEquals("reply", CommandParserUtil.getBaseCommand("Reply testing"));
+    }
+
+    @Test
+    void testGetBaseCommand_LeadingSpaces() {
+        assertEquals("tell", CommandParserUtil.getBaseCommand("   tell Notch hello"));
+    }
+
+    @Test
+    void testGetBaseCommand_Empty() {
+        assertEquals("", CommandParserUtil.getBaseCommand(""));
+        assertEquals("", CommandParserUtil.getBaseCommand("   "));
+    }
+
+    @Test
+    void testGetBaseCommand_Slash() {
+        assertEquals("/help", CommandParserUtil.getBaseCommand("/help me"));
+        assertEquals("/list", CommandParserUtil.getBaseCommand("/LIST "));
+    }
+}

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
@@ -120,8 +120,7 @@ public class LimboServerListener {
 
         // Allow travel to the Limbo dimension (prevents blocking the initial death teleport)
         ConfigManager.ModConfig cfg = ConfigManager.getConfig();
-        String spawnWorld = cfg.getLimboSpawnWorld();
-        Identifier worldId = spawnWorld != null ? Identifier.tryParse(spawnWorld) : null;
+        Identifier worldId = Identifier.tryParse(cfg.getLimboSpawnWorld());
         if (worldId != null && destination.getRegistryKey().getValue().equals(worldId)) {
             return false;
         }
@@ -144,8 +143,7 @@ public class LimboServerListener {
                 player.sendMessage(MessageUtil.get(LIMBO_CANNOT_LEAVE_MESSAGE), false);
 
         ConfigManager.ModConfig cfg = ConfigManager.getConfig();
-        String spawnWorld = cfg.getLimboSpawnWorld();
-        Identifier worldId = spawnWorld != null ? Identifier.tryParse(spawnWorld) : null;
+        Identifier worldId = Identifier.tryParse(cfg.getLimboSpawnWorld());
         if (worldId != null) {
             ServerWorld world = player.getServer().getWorld(RegistryKey.of(RegistryKeys.WORLD, worldId));
             if (world != null) {

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
@@ -99,8 +99,15 @@ public class LimboServerListener {
     }
 
     private static boolean isWhitelistedCommand(String message) {
-        String[] tokens = message.trim().split("\\s+");
-        String command = tokens.length > 0 ? tokens[0].toLowerCase(Locale.ROOT) : "";
+        String trimmed = message.trim();
+        int spaceIdx = -1;
+        for (int i = 0; i < trimmed.length(); i++) {
+            if (Character.isWhitespace(trimmed.charAt(i))) {
+                spaceIdx = i;
+                break;
+            }
+        }
+        String command = (spaceIdx == -1 ? trimmed : trimmed.substring(0, spaceIdx)).toLowerCase(java.util.Locale.ROOT);
         return WHITELISTED_COMMANDS.contains(command) || WHITELISTED_COMMANDS.contains("/" + command);
     }
 

--- a/fabric/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
+++ b/fabric/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
@@ -99,15 +99,7 @@ public class LimboServerListener {
     }
 
     private static boolean isWhitelistedCommand(String message) {
-        String trimmed = message.trim();
-        int spaceIdx = -1;
-        for (int i = 0; i < trimmed.length(); i++) {
-            if (Character.isWhitespace(trimmed.charAt(i))) {
-                spaceIdx = i;
-                break;
-            }
-        }
-        String command = (spaceIdx == -1 ? trimmed : trimmed.substring(0, spaceIdx)).toLowerCase(java.util.Locale.ROOT);
+        String command = org.ssoggy.ssoggysouls.util.CommandParserUtil.getBaseCommand(message);
         return WHITELISTED_COMMANDS.contains(command) || WHITELISTED_COMMANDS.contains("/" + command);
     }
 
@@ -128,7 +120,8 @@ public class LimboServerListener {
 
         // Allow travel to the Limbo dimension (prevents blocking the initial death teleport)
         ConfigManager.ModConfig cfg = ConfigManager.getConfig();
-        Identifier worldId = Identifier.tryParse(cfg.getLimboSpawnWorld());
+        String spawnWorld = cfg.getLimboSpawnWorld();
+        Identifier worldId = spawnWorld != null ? Identifier.tryParse(spawnWorld) : null;
         if (worldId != null && destination.getRegistryKey().getValue().equals(worldId)) {
             return false;
         }
@@ -151,7 +144,8 @@ public class LimboServerListener {
                 player.sendMessage(MessageUtil.get(LIMBO_CANNOT_LEAVE_MESSAGE), false);
 
         ConfigManager.ModConfig cfg = ConfigManager.getConfig();
-        Identifier worldId = Identifier.tryParse(cfg.getLimboSpawnWorld());
+        String spawnWorld = cfg.getLimboSpawnWorld();
+        Identifier worldId = spawnWorld != null ? Identifier.tryParse(spawnWorld) : null;
         if (worldId != null) {
             ServerWorld world = player.getServer().getWorld(RegistryKey.of(RegistryKeys.WORLD, worldId));
             if (world != null) {

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -44,13 +44,6 @@ public class CommandRegistration {
 
     @SubscribeEvent
 
-    private static net.minecraft.network.chat.MutableComponent createAutofillMessage(String command) {
-        String base = command.contains(" ") ? command.split(" ")[0] : command;
-        return MessageUtil.get("usage-" + base).copy().withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
-            .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/" + command))
-            .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY))));
-    }
-
     public static void onRegisterCommands(RegisterCommandsEvent event) {
         if (db == null) {
             SSoggySoulsMod.LOGGER.error("Cannot register commands: DatabaseManager is null");
@@ -119,7 +112,10 @@ public class CommandRegistration {
         dispatcher.register(Commands.literal("revive")
             .requires(source -> source.hasPermission(2))
             .executes(context -> {
-                context.getSource().sendFailure(createAutofillMessage("revive "));
+                context.getSource().sendFailure(MessageUtil.get("usage-revive")
+                    .copy().withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
+                        .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/revive "))
+                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
                 return 0;
             })
             .then(Commands.argument(PLAYER, StringArgumentType.word())

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -43,7 +43,6 @@ public class CommandRegistration {
     }
 
     @SubscribeEvent
-
     public static void onRegisterCommands(RegisterCommandsEvent event) {
         if (db == null) {
             SSoggySoulsMod.LOGGER.error("Cannot register commands: DatabaseManager is null");
@@ -112,10 +111,11 @@ public class CommandRegistration {
         dispatcher.register(Commands.literal("revive")
             .requires(source -> source.hasPermission(2))
             .executes(context -> {
-                context.getSource().sendFailure(MessageUtil.get("usage-revive")
-                    .copy().withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
+                net.minecraft.network.chat.MutableComponent msg = MessageUtil.get("usage-revive").copy();
+                msg.withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
                         .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/revive "))
-                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
+                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY))));
+                context.getSource().sendFailure(msg);
                 return 0;
             })
             .then(Commands.argument(PLAYER, StringArgumentType.word())
@@ -183,10 +183,11 @@ public class CommandRegistration {
         dispatcher.register(Commands.literal("psetlives")
             .requires(source -> source.hasPermission(2))
             .executes(context -> {
-                context.getSource().sendFailure(MessageUtil.get("usage-psetlives")
-                    .copy().withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
+                net.minecraft.network.chat.MutableComponent msg = MessageUtil.get("usage-psetlives").copy();
+                msg.withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
                         .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/psetlives "))
-                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
+                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY))));
+                context.getSource().sendFailure(msg);
                 return 0;
             })
             .then(Commands.argument(PLAYER, StringArgumentType.word())
@@ -194,10 +195,11 @@ public class CommandRegistration {
                         context.getSource().getServer().getPlayerNames(), builder))
                 .executes(context -> {
                     String targetName = StringArgumentType.getString(context, PLAYER);
-                    context.getSource().sendFailure(MessageUtil.get("usage-psetlives-player", PLAYER, targetName)
-                        .copy().withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
+                    net.minecraft.network.chat.MutableComponent msg = MessageUtil.get("usage-psetlives-player", PLAYER, targetName).copy();
+                    msg.withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
                             .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/psetlives " + targetName + " "))
-                            .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
+                            .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY))));
+                    context.getSource().sendFailure(msg);
                     return 0;
                 })
                 .then(Commands.argument(LIVES, IntegerArgumentType.integer(0))
@@ -267,18 +269,18 @@ public class CommandRegistration {
                                 source.sendFailure(MessageUtil.get("admin-log-read-error"));
                             }
                             case SUCCESS -> {
-                                source.sendSystemMessage(Component.literal("--- Recent Admin Logs ---").copy().withStyle(net.minecraft.ChatFormatting.RED, net.minecraft.ChatFormatting.BOLD));
+                                source.sendSystemMessage(Component.literal("--- Recent Admin Logs ---").withStyle(net.minecraft.ChatFormatting.RED, net.minecraft.ChatFormatting.BOLD));
                                 if (source.isPlayer()) {
                                     for (String line : result.lines) {
-                                        source.sendSystemMessage(Component.literal(line).copy().withStyle(s ->
+                                        source.sendSystemMessage(Component.literal(line).withStyle(s ->
                                             s.withColor(net.minecraft.ChatFormatting.GRAY)
                                              .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.COPY_TO_CLIPBOARD, line))
-                                             .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, Component.literal("Click to copy log entry").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))
+                                             .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, Component.literal("Click to copy log entry").withStyle(net.minecraft.ChatFormatting.GRAY)))
                                         ));
                                     }
                                 } else {
                                     for (String line : result.lines) {
-                                        source.sendSystemMessage(Component.literal(line).copy().withStyle(net.minecraft.ChatFormatting.GRAY));
+                                        source.sendSystemMessage(Component.literal(line).withStyle(net.minecraft.ChatFormatting.GRAY));
                                     }
                                 }
                             }

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -112,9 +112,9 @@ public class CommandRegistration {
             .requires(source -> source.hasPermission(2))
             .executes(context -> {
                 context.getSource().sendFailure(MessageUtil.get("usage-revive")
-                    .withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
+                    .copy().withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
                         .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/revive "))
-                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").withStyle(net.minecraft.ChatFormatting.GRAY)))));
+                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
                 return 0;
             })
             .then(Commands.argument(PLAYER, StringArgumentType.word())
@@ -183,9 +183,9 @@ public class CommandRegistration {
             .requires(source -> source.hasPermission(2))
             .executes(context -> {
                 context.getSource().sendFailure(MessageUtil.get("usage-psetlives")
-                    .withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
+                    .copy().withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
                         .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/psetlives "))
-                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").withStyle(net.minecraft.ChatFormatting.GRAY)))));
+                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
                 return 0;
             })
             .then(Commands.argument(PLAYER, StringArgumentType.word())
@@ -194,9 +194,9 @@ public class CommandRegistration {
                 .executes(context -> {
                     String targetName = StringArgumentType.getString(context, PLAYER);
                     context.getSource().sendFailure(MessageUtil.get("usage-psetlives-player", PLAYER, targetName)
-                        .withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
+                        .copy().withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
                             .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/psetlives " + targetName + " "))
-                            .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").withStyle(net.minecraft.ChatFormatting.GRAY)))));
+                            .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
                     return 0;
                 })
                 .then(Commands.argument(LIVES, IntegerArgumentType.integer(0))
@@ -266,18 +266,18 @@ public class CommandRegistration {
                                 source.sendFailure(MessageUtil.get("admin-log-read-error"));
                             }
                             case SUCCESS -> {
-                                source.sendSystemMessage(Component.literal("--- Recent Admin Logs ---").withStyle(net.minecraft.ChatFormatting.RED, net.minecraft.ChatFormatting.BOLD));
+                                source.sendSystemMessage(Component.literal("--- Recent Admin Logs ---").copy().withStyle(net.minecraft.ChatFormatting.RED, net.minecraft.ChatFormatting.BOLD));
                                 if (source.isPlayer()) {
                                     for (String line : result.lines) {
-                                        source.sendSystemMessage(Component.literal(line).withStyle(s ->
+                                        source.sendSystemMessage(Component.literal(line).copy().withStyle(s ->
                                             s.withColor(net.minecraft.ChatFormatting.GRAY)
                                              .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.COPY_TO_CLIPBOARD, line))
-                                             .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, Component.literal("Click to copy log entry").withStyle(net.minecraft.ChatFormatting.GRAY)))
+                                             .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, Component.literal("Click to copy log entry").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))
                                         ));
                                     }
                                 } else {
                                     for (String line : result.lines) {
-                                        source.sendSystemMessage(Component.literal(line).withStyle(net.minecraft.ChatFormatting.GRAY));
+                                        source.sendSystemMessage(Component.literal(line).copy().withStyle(net.minecraft.ChatFormatting.GRAY));
                                     }
                                 }
                             }

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -43,6 +43,14 @@ public class CommandRegistration {
     }
 
     @SubscribeEvent
+
+    private static net.minecraft.network.chat.MutableComponent createAutofillMessage(String command) {
+        String base = command.contains(" ") ? command.split(" ")[0] : command;
+        return MessageUtil.get("usage-" + base).copy().withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
+            .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/" + command))
+            .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY))));
+    }
+
     public static void onRegisterCommands(RegisterCommandsEvent event) {
         if (db == null) {
             SSoggySoulsMod.LOGGER.error("Cannot register commands: DatabaseManager is null");
@@ -111,10 +119,7 @@ public class CommandRegistration {
         dispatcher.register(Commands.literal("revive")
             .requires(source -> source.hasPermission(2))
             .executes(context -> {
-                context.getSource().sendFailure(MessageUtil.get("usage-revive")
-                    .copy().withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
-                        .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/revive "))
-                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
+                context.getSource().sendFailure(createAutofillMessage("revive "));
                 return 0;
             })
             .then(Commands.argument(PLAYER, StringArgumentType.word())

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
@@ -34,9 +34,15 @@ public class LimboServerListener {
     }
 
     private static boolean isWhitelistedCommand(String fullCommand) {
-        String clean = fullCommand.trim().toLowerCase(java.util.Locale.ROOT);
-        String[] tokens = clean.split("\\s+");
-        String command = tokens.length > 0 ? tokens[0] : "";
+        String trimmed = fullCommand.trim();
+        int spaceIdx = -1;
+        for (int i = 0; i < trimmed.length(); i++) {
+            if (Character.isWhitespace(trimmed.charAt(i))) {
+                spaceIdx = i;
+                break;
+            }
+        }
+        String command = (spaceIdx == -1 ? trimmed : trimmed.substring(0, spaceIdx)).toLowerCase(java.util.Locale.ROOT);
         return WHITELISTED_COMMANDS.contains(command) || WHITELISTED_COMMANDS.contains("/" + command);
     }
 

--- a/forge/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
+++ b/forge/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
@@ -34,15 +34,7 @@ public class LimboServerListener {
     }
 
     private static boolean isWhitelistedCommand(String fullCommand) {
-        String trimmed = fullCommand.trim();
-        int spaceIdx = -1;
-        for (int i = 0; i < trimmed.length(); i++) {
-            if (Character.isWhitespace(trimmed.charAt(i))) {
-                spaceIdx = i;
-                break;
-            }
-        }
-        String command = (spaceIdx == -1 ? trimmed : trimmed.substring(0, spaceIdx)).toLowerCase(java.util.Locale.ROOT);
+        String command = org.ssoggy.ssoggysouls.util.CommandParserUtil.getBaseCommand(fullCommand);
         return WHITELISTED_COMMANDS.contains(command) || WHITELISTED_COMMANDS.contains("/" + command);
     }
 

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -42,6 +42,14 @@ public class CommandRegistration {
     }
 
     @SubscribeEvent
+
+    private static net.minecraft.network.chat.MutableComponent createAutofillMessage(String command) {
+        String base = command.contains(" ") ? command.split(" ")[0] : command;
+        return MessageUtil.get("usage-" + base).copy().withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
+            .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/" + command))
+            .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY))));
+    }
+
     public static void onRegisterCommands(RegisterCommandsEvent event) {
         if (db == null) {
             SSoggySoulsMod.LOGGER.error("Cannot register commands: DatabaseManager is null");
@@ -110,10 +118,7 @@ public class CommandRegistration {
         dispatcher.register(Commands.literal("revive")
             .requires(source -> source.hasPermission(2))
             .executes(context -> {
-                context.getSource().sendFailure(MessageUtil.get("usage-revive")
-                    .copy().withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
-                        .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/revive "))
-                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
+                context.getSource().sendFailure(createAutofillMessage("revive "));
                 return 0;
             })
             .then(Commands.argument(PLAYER, StringArgumentType.word())

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -42,7 +42,6 @@ public class CommandRegistration {
     }
 
     @SubscribeEvent
-
     public static void onRegisterCommands(RegisterCommandsEvent event) {
         if (db == null) {
             SSoggySoulsMod.LOGGER.error("Cannot register commands: DatabaseManager is null");
@@ -111,8 +110,8 @@ public class CommandRegistration {
         dispatcher.register(Commands.literal("revive")
             .requires(source -> source.hasPermission(2))
             .executes(context -> {
-                context.getSource().sendFailure(MessageUtil.get("usage-revive")
-                    .copy().withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
+                context.getSource().sendFailure(MessageUtil.get("usage-revive").copy()
+                    .withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
                         .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/revive "))
                         .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
                 return 0;
@@ -182,8 +181,8 @@ public class CommandRegistration {
         dispatcher.register(Commands.literal("psetlives")
             .requires(source -> source.hasPermission(2))
             .executes(context -> {
-                context.getSource().sendFailure(MessageUtil.get("usage-psetlives")
-                    .copy().withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
+                context.getSource().sendFailure(MessageUtil.get("usage-psetlives").copy()
+                    .withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
                         .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/psetlives "))
                         .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
                 return 0;
@@ -193,8 +192,8 @@ public class CommandRegistration {
                         context.getSource().getServer().getPlayerNames(), builder))
                 .executes(context -> {
                     String targetName = StringArgumentType.getString(context, PLAYER);
-                    context.getSource().sendFailure(MessageUtil.get("usage-psetlives-player", PLAYER, targetName)
-                        .copy().withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
+                    context.getSource().sendFailure(MessageUtil.get("usage-psetlives-player", PLAYER, targetName).copy()
+                        .withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
                             .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/psetlives " + targetName + " "))
                             .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
                     return 0;
@@ -266,18 +265,18 @@ public class CommandRegistration {
                                 source.sendFailure(MessageUtil.get("admin-log-read-error"));
                             }
                             case SUCCESS -> {
-                                source.sendSystemMessage(Component.literal("--- Recent Admin Logs ---").copy().withStyle(net.minecraft.ChatFormatting.RED, net.minecraft.ChatFormatting.BOLD));
+                                source.sendSystemMessage(Component.literal("--- Recent Admin Logs ---").withStyle(net.minecraft.ChatFormatting.RED, net.minecraft.ChatFormatting.BOLD));
                                 if (source.isPlayer()) {
                                     for (String line : result.lines) {
-                                        source.sendSystemMessage(Component.literal(line).copy().withStyle(s ->
+                                        source.sendSystemMessage(Component.literal(line).withStyle(s ->
                                             s.withColor(net.minecraft.ChatFormatting.GRAY)
                                              .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.COPY_TO_CLIPBOARD, line))
-                                             .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, Component.literal("Click to copy log entry").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))
+                                             .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, Component.literal("Click to copy log entry").withStyle(net.minecraft.ChatFormatting.GRAY)))
                                         ));
                                     }
                                 } else {
                                     for (String line : result.lines) {
-                                        source.sendSystemMessage(Component.literal(line).copy().withStyle(net.minecraft.ChatFormatting.GRAY));
+                                        source.sendSystemMessage(Component.literal(line).withStyle(net.minecraft.ChatFormatting.GRAY));
                                     }
                                 }
                             }

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -43,13 +43,6 @@ public class CommandRegistration {
 
     @SubscribeEvent
 
-    private static net.minecraft.network.chat.MutableComponent createAutofillMessage(String command) {
-        String base = command.contains(" ") ? command.split(" ")[0] : command;
-        return MessageUtil.get("usage-" + base).copy().withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
-            .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/" + command))
-            .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY))));
-    }
-
     public static void onRegisterCommands(RegisterCommandsEvent event) {
         if (db == null) {
             SSoggySoulsMod.LOGGER.error("Cannot register commands: DatabaseManager is null");
@@ -118,7 +111,10 @@ public class CommandRegistration {
         dispatcher.register(Commands.literal("revive")
             .requires(source -> source.hasPermission(2))
             .executes(context -> {
-                context.getSource().sendFailure(createAutofillMessage("revive "));
+                context.getSource().sendFailure(MessageUtil.get("usage-revive")
+                    .copy().withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
+                        .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/revive "))
+                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
                 return 0;
             })
             .then(Commands.argument(PLAYER, StringArgumentType.word())

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/command/CommandRegistration.java
@@ -111,9 +111,9 @@ public class CommandRegistration {
             .requires(source -> source.hasPermission(2))
             .executes(context -> {
                 context.getSource().sendFailure(MessageUtil.get("usage-revive")
-                    .withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
+                    .copy().withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
                         .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/revive "))
-                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").withStyle(net.minecraft.ChatFormatting.GRAY)))));
+                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
                 return 0;
             })
             .then(Commands.argument(PLAYER, StringArgumentType.word())
@@ -182,9 +182,9 @@ public class CommandRegistration {
             .requires(source -> source.hasPermission(2))
             .executes(context -> {
                 context.getSource().sendFailure(MessageUtil.get("usage-psetlives")
-                    .withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
+                    .copy().withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
                         .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/psetlives "))
-                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").withStyle(net.minecraft.ChatFormatting.GRAY)))));
+                        .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
                 return 0;
             })
             .then(Commands.argument(PLAYER, StringArgumentType.word())
@@ -193,9 +193,9 @@ public class CommandRegistration {
                 .executes(context -> {
                     String targetName = StringArgumentType.getString(context, PLAYER);
                     context.getSource().sendFailure(MessageUtil.get("usage-psetlives-player", PLAYER, targetName)
-                        .withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
+                        .copy().withStyle(s -> s.withColor(net.minecraft.ChatFormatting.RED)
                             .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.SUGGEST_COMMAND, "/psetlives " + targetName + " "))
-                            .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").withStyle(net.minecraft.ChatFormatting.GRAY)))));
+                            .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, MessageUtil.get("click-to-autofill").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))));
                     return 0;
                 })
                 .then(Commands.argument(LIVES, IntegerArgumentType.integer(0))
@@ -265,18 +265,18 @@ public class CommandRegistration {
                                 source.sendFailure(MessageUtil.get("admin-log-read-error"));
                             }
                             case SUCCESS -> {
-                                source.sendSystemMessage(Component.literal("--- Recent Admin Logs ---").withStyle(net.minecraft.ChatFormatting.RED, net.minecraft.ChatFormatting.BOLD));
+                                source.sendSystemMessage(Component.literal("--- Recent Admin Logs ---").copy().withStyle(net.minecraft.ChatFormatting.RED, net.minecraft.ChatFormatting.BOLD));
                                 if (source.isPlayer()) {
                                     for (String line : result.lines) {
-                                        source.sendSystemMessage(Component.literal(line).withStyle(s ->
+                                        source.sendSystemMessage(Component.literal(line).copy().withStyle(s ->
                                             s.withColor(net.minecraft.ChatFormatting.GRAY)
                                              .withClickEvent(new net.minecraft.network.chat.ClickEvent(net.minecraft.network.chat.ClickEvent.Action.COPY_TO_CLIPBOARD, line))
-                                             .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, Component.literal("Click to copy log entry").withStyle(net.minecraft.ChatFormatting.GRAY)))
+                                             .withHoverEvent(new net.minecraft.network.chat.HoverEvent(net.minecraft.network.chat.HoverEvent.Action.SHOW_TEXT, Component.literal("Click to copy log entry").copy().withStyle(net.minecraft.ChatFormatting.GRAY)))
                                         ));
                                     }
                                 } else {
                                     for (String line : result.lines) {
-                                        source.sendSystemMessage(Component.literal(line).withStyle(net.minecraft.ChatFormatting.GRAY));
+                                        source.sendSystemMessage(Component.literal(line).copy().withStyle(net.minecraft.ChatFormatting.GRAY));
                                     }
                                 }
                             }

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
@@ -34,15 +34,7 @@ public class LimboServerListener {
     }
 
     private static boolean isWhitelistedCommand(String fullCommand) {
-        String trimmed = fullCommand.trim();
-        int spaceIdx = -1;
-        for (int i = 0; i < trimmed.length(); i++) {
-            if (Character.isWhitespace(trimmed.charAt(i))) {
-                spaceIdx = i;
-                break;
-            }
-        }
-        String command = (spaceIdx == -1 ? trimmed : trimmed.substring(0, spaceIdx)).toLowerCase(java.util.Locale.ROOT);
+        String command = org.ssoggy.ssoggysouls.util.CommandParserUtil.getBaseCommand(fullCommand);
         return WHITELISTED_COMMANDS.contains(command) || WHITELISTED_COMMANDS.contains("/" + command);
     }
 
@@ -97,7 +89,8 @@ public class LimboServerListener {
         if (event.getEntity() instanceof ServerPlayer player) {
             // Allow travel to the Limbo dimension (prevents blocking the initial death teleport)
             ConfigManager.ModConfig cfg = ConfigManager.getConfig();
-            ResourceLocation limboId = ResourceLocation.tryParse(cfg.getLimboSpawnWorld());
+            String spawnWorld = cfg.getLimboSpawnWorld();
+            ResourceLocation limboId = spawnWorld != null ? ResourceLocation.tryParse(spawnWorld) : null;
             if (limboId != null && event.getDimension().location().equals(limboId)) return;
 
             // Check for bypass permission (parity with Fabric)
@@ -120,10 +113,13 @@ public class LimboServerListener {
         player.getFoodData().setSaturation(20f);
 
         ConfigManager.ModConfig cfg = ConfigManager.getConfig();
-        ResourceLocation worldId = ResourceLocation.parse(cfg.getLimboSpawnWorld());
-        ServerLevel world = player.server.getLevel(ResourceKey.create(Registries.DIMENSION, worldId));
-        if (world != null) {
-            player.teleportTo(world, cfg.getLimboSpawnX(), cfg.getLimboSpawnY(), cfg.getLimboSpawnZ(), cfg.getLimboSpawnYaw(), cfg.getLimboSpawnPitch());
+        String spawnWorld = cfg.getLimboSpawnWorld();
+        ResourceLocation worldId = spawnWorld != null ? ResourceLocation.parse(spawnWorld) : null;
+        if (worldId != null) {
+            ServerLevel world = player.server.getLevel(ResourceKey.create(Registries.DIMENSION, worldId));
+            if (world != null) {
+                player.teleportTo(world, cfg.getLimboSpawnX(), cfg.getLimboSpawnY(), cfg.getLimboSpawnZ(), cfg.getLimboSpawnYaw(), cfg.getLimboSpawnPitch());
+            }
         }
 
         player.sendSystemMessage(MessageUtil.get("limbo-welcome-dead"));

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
@@ -89,8 +89,7 @@ public class LimboServerListener {
         if (event.getEntity() instanceof ServerPlayer player) {
             // Allow travel to the Limbo dimension (prevents blocking the initial death teleport)
             ConfigManager.ModConfig cfg = ConfigManager.getConfig();
-            String spawnWorld = cfg.getLimboSpawnWorld();
-            ResourceLocation limboId = spawnWorld != null ? ResourceLocation.tryParse(spawnWorld) : null;
+            ResourceLocation limboId = ResourceLocation.tryParse(cfg.getLimboSpawnWorld());
             if (limboId != null && event.getDimension().location().equals(limboId)) return;
 
             // Check for bypass permission (parity with Fabric)
@@ -113,13 +112,10 @@ public class LimboServerListener {
         player.getFoodData().setSaturation(20f);
 
         ConfigManager.ModConfig cfg = ConfigManager.getConfig();
-        String spawnWorld = cfg.getLimboSpawnWorld();
-        ResourceLocation worldId = spawnWorld != null ? ResourceLocation.parse(spawnWorld) : null;
-        if (worldId != null) {
-            ServerLevel world = player.server.getLevel(ResourceKey.create(Registries.DIMENSION, worldId));
-            if (world != null) {
-                player.teleportTo(world, cfg.getLimboSpawnX(), cfg.getLimboSpawnY(), cfg.getLimboSpawnZ(), cfg.getLimboSpawnYaw(), cfg.getLimboSpawnPitch());
-            }
+        ResourceLocation worldId = ResourceLocation.parse(cfg.getLimboSpawnWorld());
+        ServerLevel world = player.server.getLevel(ResourceKey.create(Registries.DIMENSION, worldId));
+        if (world != null) {
+            player.teleportTo(world, cfg.getLimboSpawnX(), cfg.getLimboSpawnY(), cfg.getLimboSpawnZ(), cfg.getLimboSpawnYaw(), cfg.getLimboSpawnPitch());
         }
 
         player.sendSystemMessage(MessageUtil.get("limbo-welcome-dead"));

--- a/neoforge/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
+++ b/neoforge/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
@@ -34,9 +34,15 @@ public class LimboServerListener {
     }
 
     private static boolean isWhitelistedCommand(String fullCommand) {
-        String clean = fullCommand.trim().toLowerCase(java.util.Locale.ROOT);
-        String[] tokens = clean.split("\\s+");
-        String command = tokens.length > 0 ? tokens[0] : "";
+        String trimmed = fullCommand.trim();
+        int spaceIdx = -1;
+        for (int i = 0; i < trimmed.length(); i++) {
+            if (Character.isWhitespace(trimmed.charAt(i))) {
+                spaceIdx = i;
+                break;
+            }
+        }
+        String command = (spaceIdx == -1 ? trimmed : trimmed.substring(0, spaceIdx)).toLowerCase(java.util.Locale.ROOT);
         return WHITELISTED_COMMANDS.contains(command) || WHITELISTED_COMMANDS.contains("/" + command);
     }
 

--- a/paper/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
+++ b/paper/src/main/java/org/ssoggy/ssoggysouls/listener/LimboServerListener.java
@@ -140,8 +140,7 @@ public class LimboServerListener implements Listener {
         if (player.hasPermission(PERM_BYPASS) || player.hasPermission("ssoggysouls.admin")) return;
 
         String rawMessage = event.getMessage();
-        int spaceIdx = rawMessage.indexOf(' ');
-        String command = (spaceIdx == -1 ? rawMessage : rawMessage.substring(0, spaceIdx)).toLowerCase(java.util.Locale.ROOT);
+        String command = org.ssoggy.ssoggysouls.util.CommandParserUtil.getBaseCommand(rawMessage);
 
         if (isWhitelistedCommand(command)) {
             return;


### PR DESCRIPTION
💡 What: Optimize `isWhitelistedCommand` parsing to avoid allocating a string array and unnecessarily lowercasing the entire message string.
🔗 Origin: a345b5aabf93523104168fd19c6762503e16dc0a
🛠️ Translation: Replaced `.split("\\s+")` with a manual `for` loop using `Character.isWhitespace()` to find the delimiter and `.substring()` to isolate the command before lowercasing, matching the Paper PR.
🔬 Verification: Ran all tests across Fabric, Forge, and NeoForge loaders successfully.

---
*PR created automatically by Jules for task [1182956620112466034](https://jules.google.com/task/1182956620112466034) started by @SSoggyTacoMan*